### PR TITLE
Add fake AWS keys to legacy-scripting-runner test command

### DIFF
--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "lint": "node_modules/.bin/eslint .",
-    "test": "export CLIENT_ID=1234 CLIENT_SECRET=asdf && mocha --recursive -t 10000",
+    "test": "CLIENT_ID=1234 CLIENT_SECRET=asdf AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake mocha --recursive -t 10000",
     "posttest": "yarn lint",
     "preversion": "git pull",
     "postversion": "git push && git push --tags",


### PR DESCRIPTION
Adds fake AWS keys in the test command so we don't have to add them in Travis.