### PR TITLE
bundle.request.data should be null for GET requests

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -108,15 +108,12 @@ const addHookData = (event, bundle, convertedBundle) => {
       );
     }
     if (!convertedBundle.request.content) {
-      convertedBundle.request.content = convertedBundle.request.data;
+      convertedBundle.request.content = convertedBundle.request.data || '';
     }
   } else if (event.name.startsWith('trigger.hook.subscribe')) {
     convertedBundle.target_url = bundle.targetUrl;
     convertedBundle.event = bundle._legacyEvent;
   } else if (event.name.startsWith('trigger.hook.unsubscribe')) {
-    if (event.name.endsWith('.pre')) {
-      convertedBundle.request.method = 'DELETE';
-    }
     convertedBundle.target_url = bundle.targetUrl;
     convertedBundle.subscribe_data = bundle.subscribeData;
     convertedBundle.event = bundle._legacyEvent;
@@ -131,7 +128,7 @@ const addRequestData = async (event, z, bundle, convertedBundle) => {
   _.extend(convertedBundle.request.params, params);
 
   const body = _.get(bundle, 'request.body');
-  if (body) {
+  if (!_.isEmpty(body)) {
     let data = body,
       files;
 
@@ -186,14 +183,20 @@ const addResponse = (event, bundle, convertedBundle) => {
 
 // Convert bundle from CLI to WB based on which event to run
 const bundleConverter = async (bundle, event, z) => {
-  let defaultMethod = 'GET';
-
-  if (
-    event.name.startsWith('create') ||
-    event.name.startsWith('auth.oauth2') ||
-    event.name.startsWith('trigger.hook.subscribe')
-  ) {
-    defaultMethod = 'POST';
+  let requestMethod = _.get(bundle, 'request.method');
+  if (!requestMethod) {
+    if (
+      event.name.startsWith('create') ||
+      event.name.startsWith('auth.oauth2') ||
+      event.name.startsWith('trigger.hook.subscribe')
+    ) {
+      requestMethod = 'POST';
+    } else if (event.name === 'trigger.hook.unsubscribe.pre') {
+      requestMethod = 'DELETE';
+    }
+  }
+  if (!requestMethod) {
+    requestMethod = 'GET';
   }
 
   // Attach to bundle so we can reuse it
@@ -205,7 +208,7 @@ const bundleConverter = async (bundle, event, z) => {
 
   const convertedBundle = {
     request: {
-      method: _.get(bundle, 'request.method') || defaultMethod,
+      method: requestMethod,
       url: _.get(bundle, '_legacyUrl', '') || _.get(bundle, 'request.url', ''),
       headers: {
         'Content-Type': 'application/json'
@@ -216,7 +219,7 @@ const bundleConverter = async (bundle, event, z) => {
         meta.prefill // Confused? See test "KEY_pre_poll, dynamic dropdown"
           ? {}
           : _.get(bundle, 'inputData', {}),
-      data: ''
+      data: !requestMethod || requestMethod === 'GET' ? null : ''
     },
     auth_fields: _.get(bundle, 'authData', {}),
     meta,

--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -193,10 +193,9 @@ const bundleConverter = async (bundle, event, z) => {
       requestMethod = 'POST';
     } else if (event.name === 'trigger.hook.unsubscribe.pre') {
       requestMethod = 'DELETE';
+    } else {
+      requestMethod = 'GET';
     }
-  }
-  if (!requestMethod) {
-    requestMethod = 'GET';
   }
 
   // Attach to bundle so we can reuse it

--- a/packages/legacy-scripting-runner/test/bundle.js
+++ b/packages/legacy-scripting-runner/test/bundle.js
@@ -52,7 +52,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         apiKey: 'Zapier-API-Key'
@@ -109,7 +109,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         apiKey: 'Zapier-API-Key'
@@ -181,7 +181,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: '',
+        data: null,
         content: ''
       },
       cleaned_request: {
@@ -384,7 +384,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       meta: {
         frontend: false,
@@ -431,7 +431,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       meta: {
         frontend: false,
@@ -613,7 +613,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         apiKey: 'Zapier-API-Key'
@@ -669,7 +669,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         apiKey: 'Zapier-API-Key'
@@ -730,7 +730,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         apiKey: 'Zapier-API-Key'
@@ -799,7 +799,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         apiKey: 'Zapier-API-Key'
@@ -995,7 +995,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         user: 'qwerty',
@@ -1046,7 +1046,7 @@ describe('bundleConverter', () => {
         params: {
           user: 'Zapier'
         },
-        data: ''
+        data: null
       },
       auth_fields: {
         email: 'contact@zapier.com'

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -150,10 +150,6 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
-      movie_post_poll_default_headers: function(bundle) {
-        return [z.JSON.parse(bundle.response.content)];
-      },
-
       movie_pre_poll_dynamic_dropdown: function(bundle) {
         bundle.request.method = 'POST';
         bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
@@ -165,7 +161,14 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
-      movie_post_poll_dynamic_dropdown: function(bundle) {
+      movie_pre_poll_null_request_data: function(bundle) {
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        bundle.request.params.requestDataIsNull =
+          bundle.request.data === null ? 'yes' : 'no';
+        return bundle.request;
+      },
+
+      movie_post_poll_make_array: function(bundle) {
         return [z.JSON.parse(bundle.response.content)];
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -409,7 +409,7 @@ describe('Integration Test', () => {
         'movie_pre_poll'
       );
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
-        'movie_post_poll_default_headers',
+        'movie_post_poll_make_array',
         'movie_post_poll'
       );
       const _compiledApp = schemaTools.prepareApp(appDef);
@@ -441,7 +441,7 @@ describe('Integration Test', () => {
         'movie_pre_poll'
       );
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
-        'movie_post_poll_dynamic_dropdown',
+        'movie_post_poll_make_array',
         'movie_post_poll'
       );
       const _compiledApp = schemaTools.prepareApp(appDef);
@@ -475,6 +475,29 @@ describe('Integration Test', () => {
         // should be available as response.json here.
         should.equal(echoed.json.name, 'test');
         should.equal(echoed.json.greeting, 'hello');
+      });
+    });
+
+    it('KEY_pre_poll, null request.data', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_null_request_data',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then(output => {
+        const echoed = output.results[0];
+        should.equal(echoed.args.requestDataIsNull[0], 'yes');
       });
     });
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -1053,12 +1053,12 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 
 * ```
   { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: 
+    operation:
      { perform: { url: 'http://fake-crm.getsandbox.com/users' },
        sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  { display: 
+  { display:
      { label: 'New User',
        description: 'Trigger when a new User is created in your account.',
        hidden: true },
@@ -1135,9 +1135,9 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 * ```
   { key: 'tag',
     noun: 'Tag',
-    get: 
+    get:
      { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: 
+       operation:
         { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
           sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
@@ -1145,19 +1145,19 @@ Represents a resource, which will in turn power triggers, searches, or creates.
   { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: 
+    get:
      { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
        operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
   { key: 'tag',
     noun: 'Tag',
-    get: 
+    get:
      { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
        operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list: 
+    list:
      { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation: 
+       operation:
         { perform: { url: 'http://fake-crm.getsandbox.com/tags' },
           sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
@@ -1167,19 +1167,19 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 * ```
   { key: 'tag',
     noun: 'Tag',
-    get: 
+    get:
      { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
        operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list: 
+    list:
      { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation: 
+       operation:
         { perform: { url: 'http://fake-crm.getsandbox.com/tags' },
           sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
   { key: 'tag',
     noun: 'Tag',
-    get: 
+    get:
      { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
        operation: { perform: { url: 'http://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```


### PR DESCRIPTION
Fixes another issue in [PDE-1078](https://zapierorg.atlassian.net/browse/PDE-1078). For operations (triggers and searches) that default to a GET request, `bundle.request.data` should exactly be `null` instead of an empty object in their scripting methods (`pre_poll`, `pre_search`, etc).