### PR TITLE
[schema] Allow RefResources to have commas in the labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
     }
   },
   "lint-staged": {
-    "*.{js,json}": [
+    "*.{js}": [
       "eslint --fix",
+      "git add"
+    ],
+    "*.{js,json}": [
       "prettier --write",
       "git add"
     ]

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -894,6 +894,7 @@ Reference a resource by key and the data it returns. In the format of: `{resourc
 
 * `'contact.id'`
 * `'contact.id.firstName,lastName'`
+* `'contact.id.name'`
 
 #### Anti-Examples
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -286,7 +286,7 @@ Represents the fundamental mechanics of a search/create.
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
+`resource` | no | [/KeySchema](#keyschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.
 `performResume` | no | [/FunctionSchema](#functionschema) | A function that parses data from a perform + callback to resume this action. For use with callback semantics
 `performGet` | no | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | How will Zapier get a single record? If you find yourself reaching for this - consider resources and their built-in get methods.
@@ -312,7 +312,7 @@ Represents the fundamental mechanics of a create.
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
+`resource` | no | [/KeySchema](#keyschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.
 `performResume` | no | [/FunctionSchema](#functionschema) | A function that parses data from a perform + callback to resume this action. For use with callback semantics
 `performGet` | no | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | How will Zapier get a single record? If you find yourself reaching for this - consider resources and their built-in get methods.
@@ -378,7 +378,7 @@ Represents the inbound mechanics of hooks with optional subscribe/unsubscribe. D
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
 `type` | **yes** (with exceptions, see description) | `string` in (`'hook'`) | Must be explicitly set to `"hook"` unless this hook is defined as part of a resource, in which case it's optional.
-`resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
+`resource` | no | [/KeySchema](#keyschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | [/FunctionSchema](#functionschema) | A function that processes the inbound webhook request.
 `performList` | **yes** (with exceptions, see description) | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Can get "live" data on demand instead of waiting for a hook. If you find yourself reaching for this - consider resources and their built-in hook/list methods. Note: this is required for public apps to ensure the best UX for the end-user. For private apps, you can ignore warnings about this property with the `--without-style` flag during `zapier push`.
 `performSubscribe` | **yes** (with exceptions, see description) | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Takes a URL and any necessary data from the user and subscribes. Note: this is required for public apps to ensure the best UX for the end-user. For private apps, you can ignore warnings about this property with the `--without-style` flag during `zapier push`.
@@ -405,7 +405,7 @@ Represents the fundamental mechanics of triggers, searches, or creates.
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
+`resource` | no | [/KeySchema](#keyschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.
 `inputFields` | no | [/DynamicFieldsSchema](#dynamicfieldsschema) | What should the form a user sees and configures look like?
 `outputFields` | no | [/DynamicFieldsSchema](#dynamicfieldsschema) | What fields of data will this return? Will use resource outputFields if missing, will also use sample if available.
@@ -430,7 +430,7 @@ Represents the fundamental mechanics of a trigger.
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
 `type` | no | `string` in (`'polling'`) | Clarify how this operation works (polling == pull or hook == push).
-`resource` | no | [/RefResourceSchema](#refresourceschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
+`resource` | no | [/KeySchema](#keyschema) | Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.
 `perform` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.
 `canPaginate` | no | `boolean` | Does this endpoint support a page offset?
 `inputFields` | no | [/DynamicFieldsSchema](#dynamicfieldsschema) | What should the form a user sees and configures look like?
@@ -887,18 +887,24 @@ Reference a resource by key and the data it returns. In the format of: `{resourc
 #### Details
 
 * **Type** - `string`
-* **Pattern** - `^[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?(\.[a-zA-Z0-9_]+)?$`
+* **Pattern** - `^[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+,?[a-zA-Z0-9_]+)?$`
 * **Source Code** - [lib/schemas/RefResourceSchema.js](https://github.com/zapier/zapier-platform-schema/blob/v8.2.1/lib/schemas/RefResourceSchema.js)
 
 #### Examples
 
-* `'contact'`
 * `'contact.id'`
-* `'contact.id.full_name'`
+* `'contact.id.firstName,lastName'`
 
 #### Anti-Examples
 
+* `'contact'`
 * `'Contact.list.id.full_name'`
+* `'contact.id,name'`
+* `'cont,act.id,name'`
+* `'contact'`
+* `'contact.id.,,'`
+* `'contact.id.a,,'`
+* `'contact.id.a,b,c'`
 
 -----
 

--- a/packages/schema/examples/definition.json
+++ b/packages/schema/examples/definition.json
@@ -183,8 +183,7 @@
       "list": {
         "display": {
           "label": "New Contact",
-          "description":
-            "Trigger when a new Contact is created in your account."
+          "description": "Trigger when a new Contact is created in your account."
         },
         "operation": {
           "perform": {
@@ -250,7 +249,7 @@
               "key": "owner_id",
               "label": "Owner",
               "type": "integer",
-              "dynamic": "user"
+              "dynamic": "user.id"
             },
             {
               "key": "tag_id",
@@ -275,15 +274,14 @@
       "operation": {
         "resource": "contact",
         "perform": {
-          "url":
-            "http://fake-crm.getsandbox.com/contacts?tag_id={{inputData.tagId}}"
+          "url": "http://fake-crm.getsandbox.com/contacts?tag_id={{inputData.tagId}}"
         },
         "inputFields": [
           {
             "key": "tagId",
             "label": "Tag",
             "type": "integer",
-            "dynamic": "tag"
+            "dynamic": "tag.id"
           }
         ],
         "sample": {
@@ -373,10 +371,6 @@
         "perform": {
           "url": "http://fake-crm.getsandbox.com/tags?name={{inputData.name}}"
         },
-        "sample": {
-          "id": 385,
-          "name": "proactive enable ROI"
-        },
         "resource": "tag",
         "inputFields": [
           {
@@ -449,13 +443,13 @@
             "key": "owner_id",
             "label": "Owner",
             "type": "integer",
-            "dynamic": "user"
+            "dynamic": "user.id"
           },
           {
             "key": "tag_id",
             "label": "Tag",
             "type": "integer",
-            "dynamic": "tag"
+            "dynamic": "tag.id"
           }
         ],
         "resource": "contact",

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -104,7 +104,7 @@
       "id": "/RefResourceSchema",
       "description": "Reference a resource by key and the data it returns. In the format of: `{resource_key}.{foreign_key}(.{human_label_key})`.",
       "type": "string",
-      "pattern": "^[a-zA-Z0-9_]+(\\.[a-zA-Z0-9_]+)?(\\.[a-zA-Z0-9_]+)?$"
+      "pattern": "^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+(\\.[a-zA-Z0-9_]+,?[a-zA-Z0-9_]+)?$"
     },
     "FieldChoicesSchema": {
       "id": "/FieldChoicesSchema",
@@ -561,6 +561,13 @@
       "description": "Like [/FieldsSchema](#fieldsschema) but you can provide functions to create dynamic or custom fields.",
       "$ref": "/FieldOrFunctionSchema"
     },
+    "KeySchema": {
+      "id": "/KeySchema",
+      "description": "A unique identifier for this item.",
+      "type": "string",
+      "minLength": 2,
+      "pattern": "^[a-zA-Z]+[a-zA-Z0-9_]*$"
+    },
     "ResultsSchema": {
       "id": "/ResultsSchema",
       "description": "An array of objects suitable for returning in perform calls.",
@@ -613,7 +620,7 @@
       "properties": {
         "resource": {
           "description": "Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.",
-          "$ref": "/RefResourceSchema"
+          "$ref": "/KeySchema"
         },
         "perform": {
           "description": "How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.",
@@ -667,7 +674,7 @@
         },
         "resource": {
           "description": "Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.",
-          "$ref": "/RefResourceSchema"
+          "$ref": "/KeySchema"
         },
         "perform": {
           "description": "A function that processes the inbound webhook request.",
@@ -760,7 +767,7 @@
         },
         "resource": {
           "description": "Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.",
-          "$ref": "/RefResourceSchema"
+          "$ref": "/KeySchema"
         },
         "perform": {
           "description": "How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.",
@@ -807,7 +814,7 @@
       "properties": {
         "resource": {
           "description": "Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.",
-          "$ref": "/RefResourceSchema"
+          "$ref": "/KeySchema"
         },
         "perform": {
           "description": "How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.",
@@ -942,13 +949,6 @@
       },
       "additionalProperties": false
     },
-    "KeySchema": {
-      "id": "/KeySchema",
-      "description": "A unique identifier for this item.",
-      "type": "string",
-      "minLength": 2,
-      "pattern": "^[a-zA-Z]+[a-zA-Z0-9_]*$"
-    },
     "ResourceSchema": {
       "id": "/ResourceSchema",
       "description": "Represents a resource, which will in turn power triggers, searches, or creates.",
@@ -1066,7 +1066,7 @@
       "properties": {
         "resource": {
           "description": "Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.",
-          "$ref": "/RefResourceSchema"
+          "$ref": "/KeySchema"
         },
         "perform": {
           "description": "How will Zapier get the data? This can be a function like `(z) => [{id: 123}]` or a request like `{url: 'http...'}`.",

--- a/packages/schema/lib/schemas/BasicOperationSchema.js
+++ b/packages/schema/lib/schemas/BasicOperationSchema.js
@@ -4,9 +4,9 @@ const makeSchema = require('../utils/makeSchema');
 
 const DynamicFieldsSchema = require('./DynamicFieldsSchema');
 const FunctionSchema = require('./FunctionSchema');
-const RefResourceSchema = require('./RefResourceSchema');
 const RequestSchema = require('./RequestSchema');
 const ResultsSchema = require('./ResultsSchema');
+const KeySchema = require('./KeySchema');
 
 module.exports = makeSchema(
   {
@@ -19,7 +19,7 @@ module.exports = makeSchema(
       resource: {
         description:
           'Optionally reference and extends a resource. Allows Zapier to automatically tie together samples, lists and hooks, greatly improving the UX. EG: if you had another trigger reusing a resource but filtering the results.',
-        $ref: RefResourceSchema.id
+        $ref: KeySchema.id
       },
       perform: {
         description:
@@ -52,11 +52,5 @@ module.exports = makeSchema(
     },
     additionalProperties: false
   },
-  [
-    DynamicFieldsSchema,
-    FunctionSchema,
-    RefResourceSchema,
-    RequestSchema,
-    ResultsSchema
-  ]
+  [DynamicFieldsSchema, FunctionSchema, KeySchema, RequestSchema, ResultsSchema]
 );

--- a/packages/schema/lib/schemas/RefResourceSchema.js
+++ b/packages/schema/lib/schemas/RefResourceSchema.js
@@ -7,7 +7,16 @@ module.exports = makeSchema({
   description:
     'Reference a resource by key and the data it returns. In the format of: `{resource_key}.{foreign_key}(.{human_label_key})`.',
   type: 'string',
-  examples: ['contact', 'contact.id', 'contact.id.full_name'],
-  antiExamples: ['Contact.list.id.full_name'],
-  pattern: '^[a-zA-Z0-9_]+(\\.[a-zA-Z0-9_]+)?(\\.[a-zA-Z0-9_]+)?$'
+  examples: ['contact.id', 'contact.id.firstName,lastName'],
+  antiExamples: [
+    'contact',
+    'Contact.list.id.full_name',
+    'contact.id,name',
+    'cont,act.id,name',
+    'contact',
+    'contact.id.,,',
+    'contact.id.a,,',
+    'contact.id.a,b,c'
+  ],
+  pattern: '^[a-zA-Z0-9_]+\\.[a-zA-Z0-9_]+(\\.[a-zA-Z0-9_]+,?[a-zA-Z0-9_]+)?$'
 });

--- a/packages/schema/lib/schemas/RefResourceSchema.js
+++ b/packages/schema/lib/schemas/RefResourceSchema.js
@@ -7,7 +7,7 @@ module.exports = makeSchema({
   description:
     'Reference a resource by key and the data it returns. In the format of: `{resource_key}.{foreign_key}(.{human_label_key})`.',
   type: 'string',
-  examples: ['contact.id', 'contact.id.firstName,lastName'],
+  examples: ['contact.id', 'contact.id.firstName,lastName', 'contact.id.name'],
   antiExamples: [
     'contact',
     'Contact.list.id.full_name',


### PR DESCRIPTION
This brings the `contact.id.firstName,lastName` dynamic dropdown pattern to CLI! I've confirmed it works:

`contact.id.lastName,firstName,lastName`: 
![](https://zappy.zapier.com/F765FC49-DF92-41D3-90E8-2695358E7862.png)

This involves couple of changes:

1. change `resource` property to `KeySchema` since `dynamic: 'contact'` is an error in the editor
2. That allows us to make more assertions about the shape of actual references, which needs the shape `x.y(.z)?`. We also now include an optional comma clause (but only 1, I got nervous the regex would get unwieldy. We could also simplify it and just allow commas anywhere, but I worry someone will mess it up and it'll be very unclear why their dynamic dropdown isn't working)

Very strictly speaking, this is a semver.major since before it was valid to have `dynamic: 'x'` and on this version, it won't be. That said, that wouldn't have produced a working app anyway, so i don't feel too bad about including this in a lesser release if it comes to that.

--- 

Note that I'm OOO next week, so if this is ✅, I'd appreciate if you merged it for me. Thanks!