### PR TITLE
feat(cli): add saml support

### DIFF
--- a/packages/cli/src/oclif/commands/login.js
+++ b/packages/cli/src/oclif/commands/login.js
@@ -2,11 +2,13 @@ const colors = require('colors/safe');
 
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
+const { flags } = require('@oclif/command');
 
 const {
   AUTH_LOCATION,
   AUTH_LOCATION_RAW,
-  AUTH_KEY
+  AUTH_KEY,
+  BASE_ENDPOINT
 } = require('../../constants');
 const {
   readCredentials,
@@ -15,6 +17,9 @@ const {
 } = require('../../utils/api');
 const { writeFile } = require('../../utils/files');
 const { prettyJSONstringify } = require('../../utils/display');
+const { isSamlEmail } = require('../../utils/credentials');
+
+const DEPLOY_KEY_DASH_URL = `${BASE_ENDPOINT}/developer/partner-settings/deploy-keys/`;
 
 const isValidTotpCode = i => {
   const num = parseInt(i, 10);
@@ -22,8 +27,29 @@ const isValidTotpCode = i => {
     ? true
     : 'Must be a 6 digit number';
 };
+const isValidDeployKey = k =>
+  k.length === 32
+    ? true
+    : `Must be a 32-character code copied from from ${DEPLOY_KEY_DASH_URL}`;
 
+/**
+ * there are a few says that someone might log into zapier:
+ * 1. Username + Password
+ * 2. Google/FB/etc SSO
+ * 3. Company-configured SAML
+ *
+ * Group 1 will definitely have a password. Group 2 might have a password if they created one, but might not. Group 3 definitely will not.
+ */
 class LoginCommand extends BaseCommand {
+  promptForDeployKey() {
+    this.log(
+      `To generate a deploy key, go to ${DEPLOY_KEY_DASH_URL}, create/copy a key, and then paste the result below.`
+    );
+    return this.prompt('Paste your Deploy Key here:', {
+      validate: isValidDeployKey
+    });
+  }
+
   async perform() {
     const checks = [
       readCredentials()
@@ -52,33 +78,49 @@ class LoginCommand extends BaseCommand {
         )
       );
     }
-    const username = await this.prompt(
-      'What is your Zapier login email address? (Ctrl-C to cancel)'
-    );
-    this.log(
-      `\n\nNow you'll enter your Zapier password.\nIf you log into Zapier via the ${colors.green(
-        'log in with Google button'
-      )}, you may not have a Zapier password.\nIf that's the case, go to https://zapier.com/app/login/forgot and create one.\n\n`
-    );
-    const password = await this.promptHidden(
-      'What is your Zapier login password?'
-    );
 
-    let goodResponse;
-    try {
-      goodResponse = await createCredentials(username, password);
-    } catch ({ errText, json: { errors } }) {
-      if (errors[0].startsWith('missing totp_code')) {
-        const code = await this.prompt(
-          'What is your current 6-digit 2FA code?',
-          { validate: isValidTotpCode }
-        );
-        goodResponse = await createCredentials(username, password, code);
+    let deployKey;
+
+    if (this.flags.sso) {
+      // category 3
+      deployKey = await this.promptForDeployKey();
+    } else {
+      const email = await this.prompt(
+        'What email address do you use to log into Zapier?'
+      );
+      if (await isSamlEmail(email)) {
+        // category 2
+        deployKey = await this.promptForDeployKey();
       } else {
-        this.error(errText);
+        // category 1
+        this.log(
+          `\n\nNow you'll enter your Zapier password.\nIf you log into Zapier via the ${colors.green(
+            'log in with Google button'
+          )} (or a different social network), you may not have a Zapier password.\nIf that's the case, hit CTRL+C and re-run this command with the ${colors.cyan(
+            `--sso`
+          )} flag.\n\n`
+        );
+        const password = await this.promptHidden(
+          'What is your Zapier password?'
+        );
+
+        let goodResponse;
+        try {
+          goodResponse = await createCredentials(email, password);
+        } catch ({ errText, json: { errors } }) {
+          if (errors[0].startsWith('missing totp_code')) {
+            const code = await this.prompt(
+              'What is your current 6-digit 2FA code?',
+              { validate: isValidTotpCode }
+            );
+            goodResponse = await createCredentials(email, password, code);
+          } else {
+            this.error(errText);
+          }
+        }
+        deployKey = goodResponse.key;
       }
     }
-    const deployKey = goodResponse.key;
     await writeFile(
       AUTH_LOCATION,
       prettyJSONstringify({
@@ -92,7 +134,15 @@ class LoginCommand extends BaseCommand {
   }
 }
 
-LoginCommand.flags = buildFlags();
+LoginCommand.flags = buildFlags({
+  commandFlags: {
+    sso: flags.boolean({
+      char: 's',
+      description:
+        "Use this flag if you log into Zapier a Single Sign-On (SSO) button and don't have a Zapier password"
+    })
+  }
+});
 LoginCommand.examples = ['zapier login'];
 LoginCommand.description = `Configure your \`${AUTH_LOCATION_RAW}\` with a deploy key.`;
 

--- a/packages/cli/src/tests/utils/api.js
+++ b/packages/cli/src/tests/utils/api.js
@@ -60,8 +60,13 @@ describe('api', () => {
   });
 
   describe('listEndpoint', () => {
+    before(() => {
+      if (!nock.isActive()) {
+        nock.activate();
+      }
+    });
+
     beforeEach(() => {
-      nock.disableNetConnect();
       process.env.ZAPIER_DEPLOY_KEY = answer;
       mock({
         [CURRENT_APP_FILE]: '{ "id": 2864, "key": "App2864", "extra": 5 }'
@@ -106,7 +111,10 @@ describe('api', () => {
     afterEach(() => {
       mock.restore();
       delete process.env.ZAPIER_DEPLOY_KEY;
-      nock.enableNetConnect();
+    });
+
+    after(() => {
+      nock.restore();
     });
   });
 });

--- a/packages/cli/src/tests/utils/credentials.js
+++ b/packages/cli/src/tests/utils/credentials.js
@@ -2,7 +2,7 @@ const { isSamlEmail } = require('../../utils/credentials');
 
 describe('SAML checking', () => {
   it('should throw for bad emails', async () => {
-    await isSamlEmail('asdf').should.be.rejected();
+    await isSamlEmail('asdf').should.be.rejectedWith('Invalid email');
   });
 
   it('should be false for non-saml emails', async () => {

--- a/packages/cli/src/tests/utils/credentials.js
+++ b/packages/cli/src/tests/utils/credentials.js
@@ -1,0 +1,18 @@
+const { isSamlEmail } = require('../../utils/credentials');
+
+describe('SAML checking', () => {
+  it('should throw for bad emails', async () => {
+    await isSamlEmail('asdf').should.be.rejected();
+  });
+
+  it('should be false for non-saml emails', async () => {
+    const res = await isSamlEmail('bruce@wayneenterprises.com');
+    res.should.be.false();
+  });
+
+  // TODO: need an actual saml email for this to work. They probably don't want their email in a test.
+  it.skip('should work for saml emails', async () => {
+    const res = await isSamlEmail('alfred@wayneenterprises.com');
+    res.should.be.true();
+  });
+});

--- a/packages/cli/src/utils/credentials.js
+++ b/packages/cli/src/utils/credentials.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+
+const isSamlEmail = async email => {
+  const rawResponse = await fetch(
+    `https://zapier.com/api/v4/idp-discovery/?email=${encodeURIComponent(
+      email
+    )}`
+  );
+  const { results = [], errors = [] } = await rawResponse.json();
+  if (errors.length) {
+    throw new Error(errors[0]);
+  }
+  return results.length > 0;
+};
+
+module.exports = { isSamlEmail };

--- a/packages/cli/src/utils/credentials.js
+++ b/packages/cli/src/utils/credentials.js
@@ -1,10 +1,9 @@
 const fetch = require('node-fetch');
+const { BASE_ENDPOINT } = require('../constants');
 
 const isSamlEmail = async email => {
   const rawResponse = await fetch(
-    `https://zapier.com/api/v4/idp-discovery/?email=${encodeURIComponent(
-      email
-    )}`
+    `${BASE_ENDPOINT}/api/v4/idp-discovery/?email=${encodeURIComponent(email)}`
   );
   const { results = [], errors = [] } = await rawResponse.json();
   if (errors.length) {


### PR DESCRIPTION
Duplicates https://github.com/zapier/zapier-platform-cli/pull/420. The salient change is that users can paste a deploy key instead of typing an email or password. if we know they're a SAML user based on their email, we can force them into that flow. Otherwise, the experience is the same. 