### PR TITLE
fix(legacy-scripting-runner): add object-first flag to runCreate

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -341,7 +341,13 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       }
       throw new Error('JSON results array could not be located.');
     } else if (type.startsWith('object-')) {
-      if (_.isPlainObject(result)) {
+      if (['number', 'string', 'boolean'].includes(typeof result)) {
+        // primitive types that aren't null or undefined
+        return { message: result };
+      } else if (_.isEmpty(result)) {
+        // null, undefined, empty object or array
+        return {};
+      } else if (_.isPlainObject(result)) {
         return result;
       } else if (
         Array.isArray(result) &&
@@ -911,7 +917,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       key,
       'create.pre',
       'create.post',
-      'create.write'
+      'create.write',
+      { ensureType: 'object-first' }
     );
   };
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -519,12 +519,12 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.meta = {
-        'isLoadingSample': true,
-        'isFillingDynamicDropdown': true,
-        'isTestingAuth': false,
-        'isPopulatingDedupe': true,
-        'limit': 20,
-        'page': 1
+        isLoadingSample: true,
+        isFillingDynamicDropdown: true,
+        isTestingAuth: false,
+        isPopulatingDedupe: true,
+        limit: 20,
+        page: 1
       };
       return _app(input).then(output => {
         const echoed = output.results[0];
@@ -1550,6 +1550,50 @@ describe('Integration Test', () => {
         should.equal(movie.title, 'Arrival');
         should.equal(movie.genre, 'Sci-fi');
         should.equal(movie.year, 2016);
+      });
+    });
+
+    it('sync KEY_write empty list', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'movie_write_sync',
+        'movie_write'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = [];
+
+      return app(input).then(output => {
+        should.deepEqual(output.results, {});
+      });
+    });
+
+    it('sync KEY_write primitive', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'movie_write_sync',
+        'movie_write'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = [1234];
+
+      return app(input).then(output => {
+        should.deepEqual(output.results, { message: 1234 });
       });
     });
 


### PR DESCRIPTION
We need to cover the functionality in python, which returns empty dicts if an empty list or null value is provided.