### PR TITLE
chore(core): allow to build boilerplate from published packages

### DIFF
--- a/packages/core/bin/build-boilerplate.sh
+++ b/packages/core/bin/build-boilerplate.sh
@@ -23,14 +23,14 @@ FILE="$BUILD_DIR/$CORE_VERSION.zip"
 
 TIMESTAMP=`date +"%s"`
 
-# Build core and legacy-scripting-runner locally. Needs to generate a unique filename
-# with a timestamp to avoid yarn using cached packages.
-# See https://github.com/yarnpkg/yarn/issues/2165.
 if [ "$1" == "production" ]; then
     echo "Building from published packages"
     cd ../legacy-scripting-runner
     TIMESTAMP=""
 else
+    # Build core and legacy-scripting-runner locally. Needs to generate a unique filename
+    # with a timestamp to avoid yarn using cached packages.
+    # See https://github.com/yarnpkg/yarn/issues/2165.
     echo "Building from local"
     yarn pack --filename "./boilerplate/core-$TIMESTAMP.tgz"
     cd ../legacy-scripting-runner

--- a/packages/core/bin/build-boilerplate.sh
+++ b/packages/core/bin/build-boilerplate.sh
@@ -2,7 +2,7 @@
 
 # Usage like so:
 # ./build-boilerplate.sh
-# ./build-boilerplate.sh revert
+# ./build-boilerplate.sh production
 
 CONTENTS_DIR='boilerplate'
 BUILD_DIR='build-boilerplate'
@@ -26,9 +26,16 @@ TIMESTAMP=`date +"%s"`
 # Build core and legacy-scripting-runner locally. Needs to generate a unique filename
 # with a timestamp to avoid yarn using cached packages.
 # See https://github.com/yarnpkg/yarn/issues/2165.
-yarn pack --filename "./boilerplate/core-$TIMESTAMP.tgz"
-cd ../legacy-scripting-runner
-yarn pack --filename "../core/boilerplate/legacy-scripting-runner-$TIMESTAMP.tgz"
+if [ "$1" == "production" ]; then
+    echo "Building from published packages"
+    cd ../legacy-scripting-runner
+    TIMESTAMP=""
+else
+    echo "Building from local"
+    yarn pack --filename "./boilerplate/core-$TIMESTAMP.tgz"
+    cd ../legacy-scripting-runner
+    yarn pack --filename "../core/boilerplate/legacy-scripting-runner-$TIMESTAMP.tgz"
+fi
 
 cd ../core
 ./bin/update-boilerplate-dependencies.js $TIMESTAMP


### PR DESCRIPTION
Makes it easier to build boilerplate from published packages. This allows us to patch existing core boilerplate with the latest legacy-scripting-runner release.

Usage: `yarn build-boilerplate -- production`