### PR TITLE
fix(legacy-scripting-runner): allow hooks without a polling URL

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -710,6 +710,14 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
   const runTrigger = async (bundle, key) => {
     const url = _.get(app, `legacy.triggers.${key}.operation.url`);
+    if (!url) {
+      const triggerType = _.get(app, `triggers.${key}.operation.type`);
+      if (triggerType === 'hook') {
+        // The hook has no polling URL, which is acceptable in WB
+        return [];
+      }
+    }
+
     const needsFlattenedData = _.get(app, 'legacy.needsFlattenedData');
     bundle.request.url = url;
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
