### PR TITLE
docs(cli) add new commands to docs

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -732,7 +732,7 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier init ./some/path</code></li>
-<li><code>zaper init . --template typescript</code></li>
+<li><code>zapier init . --template typescript</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -245,20 +245,31 @@ a code {
       <ul>
 <li><a href="#zapier-cli-reference">Zapier CLI Reference</a></li>
 <li><a href="#commands">Commands</a><ul>
+<li><a href="#apps">apps</a></li>
 <li><a href="#build">build</a></li>
 <li><a href="#collaborate">collaborate</a></li>
 <li><a href="#convert">convert</a></li>
 <li><a href="#delete">delete</a></li>
+<li><a href="#deprecate">deprecate</a></li>
 <li><a href="#describe">describe</a></li>
 <li><a href="#env">env</a></li>
 <li><a href="#help">help</a></li>
+<li><a href="#history">history</a></li>
+<li><a href="#init">init</a></li>
 <li><a href="#invite">invite</a></li>
 <li><a href="#link">link</a></li>
+<li><a href="#login">login</a></li>
+<li><a href="#logout">logout</a></li>
 <li><a href="#logs">logs</a></li>
+<li><a href="#migrate">migrate</a></li>
+<li><a href="#promote">promote</a></li>
 <li><a href="#push">push</a></li>
 <li><a href="#register">register</a></li>
 <li><a href="#scaffold">scaffold</a></li>
+<li><a href="#test">test</a></li>
 <li><a href="#upload">upload</a></li>
+<li><a href="#validate">validate</a></li>
+<li><a href="#versions">versions</a></li>
 </ul>
 </li>
 </ul>
@@ -291,6 +302,29 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h1 id="commands">Commands</h1>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="apps">apps</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Lists any apps that you have admin access to.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier apps</code></p><p>This command also checks the current directory for a linked app.</p><p><strong>Flags</strong></p><ul>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -454,6 +488,35 @@ $ zapier collaborate user@example.com --remove
 <span class="hljs-comment">#   Deleting 1.0.0 - done!</span>
 <span class="hljs-comment">#   Deletion successful!</span>
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="deprecate">deprecate</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Marks a non-production version of your app as deprecated, with removal by a certain date.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier deprecate VERSION DATE</code></p><p>Use this when an app version will not be supported or start breaking at a known date.</p><p>Zapier will send an email warning users of the deprecation once a date is set, they&apos;ll start seeing it as &quot;Deprecated&quot; in the UI, and once the deprecation date arrives, if the Zaps weren&apos;t updated, they&apos;ll be paused and the users will be emailed again explaining what happened.</p><p>After the deprecation date has passed it will be safe to delete that app version.</p><blockquote>
+<p>Do not use this if you have non-breaking changes, such as fixing help text.</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>version</code> | The version to deprecate.</li>
+<li>(required) <code>date</code> | The date (YYYY-MM-DD) when Zapier will make the specified version unavailable.</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier deprecate 1.2.3 2011-10-01</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -626,6 +689,59 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="history">history</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Gets the history of your app.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier history</code></p><p>History includes all the changes made over the lifetime of your app. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.</p><p><strong>Flags</strong></p><ul>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="init">init</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Initializes a new Zapier app. Optionally uses a template.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier init PATH</code></p><p>After running this, you&apos;ll have a new example app in your directory. If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><blockquote>
+<p>Note: this doesn&apos;t register or deploy the app with Zapier - try the <code>zapier register</code> and <code>zapier push</code> commands for that!</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>path</code> | Where to create the new app. If the directory doesn&apos;t exist, it will be created. If the directory isn&apos;t empty, we&apos;ll ask for confirmation</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-t, --template</code> | The template to start your app with. One of <code>[minimal | trigger | search | create | basic-auth | custom-auth | digest-auth | oauth2 | oauth1-trello | oauth1-tumblr | oauth1-twitter | session-auth | dynamic-dropdown | files | middleware | resource | rest-hooks | search-or-create | babel | typescript | github | onedrive]</code>. Defaults to <code>minimal</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier init ./some/path</li>
+<li>zaper init . --template typescript</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h2 id="invite">invite</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -726,6 +842,51 @@ $ zapier invite user@example.com --remove
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="login">login</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Configures your <code>~/.zapierrc</code> with a deploy key.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier login</code></p><p><strong>Flags</strong></p><ul>
+<li><code>-s, --sso</code> | Use this flag if you log into Zapier a Single Sign-On (SSO) button and don&apos;t have a Zapier password</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="logout">logout</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Deactivates your acive deploy key and resets <code>~/.zapierrc</code>.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier logout</code></p><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h2 id="logs">logs</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -776,6 +937,78 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 <span class="hljs-comment"># &#x2502;     Timestamp   &#x2502; 2016-01-01T23:04:36-05:00            &#x2502;</span>
 <span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="migrate">migrate</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Migrates users from one version of your app to another.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier migrate FROMVERSION TOVERSION [PERCENT]</code></p><p>Starts a migration to move users between different versions of your app. You may also &quot;revert&quot; by simply swapping the from/to verion strings in the command line arguments (i.e. <code>zapier migrate 1.0.1 1.0.0</code>).</p><p>Only migrate users between non-breaking versions, use <code>zapier deprecate</code> if you have breaking changes!</p><p>Migrations can take between 5-10 minutes, so be patient and check <code>zapier history</code> to track the status.</p><p>Note: since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.</p><blockquote>
+<p>Tip: We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.</p>
+</blockquote><blockquote>
+<p>Tip 2: You can migrate a single user by using <code>--user</code> (i.e. <code>zapier migrate 1.0.0 1.0.1 --user=user@example.com</code>).</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>fromVersion</code> | The version FROM which to migrate users.</li>
+<li>(required) <code>toVersion</code> | The version TO which to migrate users.</li>
+<li><code>percent</code> | Percentage (between 1 and 100) of users to migrate.</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>--user</code> | Migrate only this user</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier migrate 1.0.0 1.0.1</li>
+<li>zapier migrate 1.0.1 2.0.0 10</li>
+<li>zapier migrate 2.0.0 2.0.1 <a href="mailto:--user=user@example.com">--user=user@example.com</a></li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="promote">promote</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Promotes a specific version to public access.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier promote VERSION</code></p><p>Promotes an app version into production (non-private) rotation, which means new users can use this app version.</p><ul>
+<li><p>This [1mdoes[22m mark the version as the official public version - all other versions &amp; users are grandfathered.</p>
+</li>
+<li><p>This does [1mNOT[22m build/upload or deploy a version to Zapier - you should <code>zapier push</code> first.</p>
+</li>
+<li><p>This does [1mNOT[22m move old users over to this version - <code>zapier migrate 1.0.0 1.0.1</code> does that.</p>
+</li>
+<li><p>This does [1mNOT[22m recommend old users stop using this version - <code>zapier deprecate 1.0.0 2017-01-01</code> does that.</p>
+</li>
+</ul><p>Promotes are an inherently safe operation for all existing users of your app.</p><blockquote>
+<p>If this is your first time promoting - this will start the platform quality assurance process by alerting the Zapier platform team of your intent to make your app public. We&apos;ll respond within a few business days.</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>version</code> | The version you want promote.</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier promote 1.0.0</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -896,6 +1129,35 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="test">test</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Tests your app via <code>npm test</code>.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is effectively the same as <code>npm test</code>, except we also validate your app and set up the environment. We recommend using mocha as your testing framework.</p><p><strong>Flags</strong></p><ul>
+<li><code>-t, --timeout</code> | Set test-case timeout in milliseconds  Defaults to <code>2000</code>.</li>
+<li><code>--grep</code> | Only run tests matching pattern</li>
+<li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before <code>npm test</code></li>
+<li><code>--yarn</code> | Use yarn instead of npm</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier test</li>
+<li>zapier test -t 30000 --grep api --skip-validate</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h2 id="upload">upload</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -919,6 +1181,57 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 <span class="hljs-comment">#</span>
 <span class="hljs-comment"># Upload of build/build.zip and build/source.zip complete! Try `zapier versions` now!</span>
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="validate">validate</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Validates your Zapier app.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier validate</code></p><p>Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during <code>zapier build</code>, <code>zapier upload</code>, <code>zapier push</code> or even as a test in <code>zapier test</code>.</p><p><strong>Flags</strong></p><ul>
+<li><code>--without-style</code> | Forgo pinging the Zapier server to run further checks</li>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier validate</li>
+<li>zapier validate --without-style</li>
+<li>zapier validate --format json</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="versions">versions</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Lists the versions of your app available for use in the Zapier editor.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier versions</code></p><p><strong>Flags</strong></p><ul>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -512,7 +512,7 @@ $ zapier collaborate user@example.com --remove
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier deprecate 1.2.3 2011-10-01</li>
+<li><code>zapier deprecate 1.2.3 2011-10-01</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -731,8 +731,8 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 <li><code>-t, --template</code> | The template to start your app with. One of <code>[minimal | trigger | search | create | basic-auth | custom-auth | digest-auth | oauth2 | oauth1-trello | oauth1-tumblr | oauth1-twitter | session-auth | dynamic-dropdown | files | middleware | resource | rest-hooks | search-or-create | babel | typescript | github | onedrive]</code>. Defaults to <code>minimal</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier init ./some/path</li>
-<li>zaper init . --template typescript</li>
+<li><code>zapier init ./some/path</code></li>
+<li><code>zaper init . --template typescript</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -965,9 +965,9 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 <li><code>--user</code> | Migrate only this user</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier migrate 1.0.0 1.0.1</li>
-<li>zapier migrate 1.0.1 2.0.0 10</li>
-<li>zapier migrate 2.0.0 2.0.1 <a href="mailto:--user=user@example.com">--user=user@example.com</a></li>
+<li><code>zapier migrate 1.0.0 1.0.1</code></li>
+<li><code>zapier migrate 1.0.1 2.0.0 10</code></li>
+<li><code>zapier migrate 2.0.0 2.0.1 --user=user@example.com</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1004,7 +1004,7 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier promote 1.0.0</li>
+<li><code>zapier promote 1.0.0</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1147,8 +1147,8 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 <li><code>--yarn</code> | Use yarn instead of npm</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier test</li>
-<li>zapier test -t 30000 --grep api --skip-validate</li>
+<li><code>zapier test</code></li>
+<li><code>zapier test -t 30000 --grep api --skip-validate</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1202,9 +1202,9 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 <li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier validate</li>
-<li>zapier validate --without-style</li>
-<li>zapier validate --format json</li>
+<li><code>zapier validate</code></li>
+<li><code>zapier validate --without-style</code></li>
+<li><code>zapier validate --format json</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,7 +197,7 @@ After the deprecation date has passed it will be safe to delete that app version
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier deprecate 1.2.3 2011-10-01
+* `zapier deprecate 1.2.3 2011-10-01`
 
 
 ## describe
@@ -389,8 +389,8 @@ After running this, you'll have a new example app in your directory. If you re-r
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier init ./some/path
-* zaper init . --template typescript
+* `zapier init ./some/path`
+* `zaper init . --template typescript`
 
 
 ## invite
@@ -587,9 +587,9 @@ Note: since a migration is only for non-breaking changes, users are not emailed 
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier migrate 1.0.0 1.0.1
-* zapier migrate 1.0.1 2.0.0 10
-* zapier migrate 2.0.0 2.0.1 --user=user@example.com
+* `zapier migrate 1.0.0 1.0.1`
+* `zapier migrate 1.0.1 2.0.0 10`
+* `zapier migrate 2.0.0 2.0.1 --user=user@example.com`
 
 
 ## promote
@@ -619,7 +619,7 @@ Promotes are an inherently safe operation for all existing users of your app.
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier promote 1.0.0
+* `zapier promote 1.0.0`
 
 
 ## push
@@ -741,8 +741,8 @@ This command is effectively the same as `npm test`, except we also validate your
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier test
-* zapier test -t 30000 --grep api --skip-validate
+* `zapier test`
+* `zapier test -t 30000 --grep api --skip-validate`
 
 
 ## upload
@@ -780,9 +780,9 @@ Runs the standard validation routine powered by json-schema that checks your app
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier validate
-* zapier validate --without-style
-* zapier validate --format json
+* `zapier validate`
+* `zapier validate --without-style`
+* `zapier validate --format json`
 
 
 ## versions

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -390,7 +390,7 @@ After running this, you'll have a new example app in your directory. If you re-r
 
 **Examples**
 * `zapier init ./some/path`
-* `zaper init . --template typescript`
+* `zapier init . --template typescript`
 
 
 ## invite

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,19 @@ $ npm install -g zapier-platform-cli
 
 # Commands
 
+## apps
+
+> Lists any apps that you have admin access to.
+
+**Usage**: `zapier apps`
+
+This command also checks the current directory for a linked app.
+
+**Flags**
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output
+
+
 ## build
 
   > Builds a pushable zip from the current directory.
@@ -160,6 +173,31 @@ $ zapier delete version 1.0.0
 #   Deleting 1.0.0 - done!
 #   Deletion successful!
 ```
+
+
+## deprecate
+
+> Marks a non-production version of your app as deprecated, with removal by a certain date.
+
+**Usage**: `zapier deprecate VERSION DATE`
+
+Use this when an app version will not be supported or start breaking at a known date.
+
+Zapier will send an email warning users of the deprecation once a date is set, they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
+
+After the deprecation date has passed it will be safe to delete that app version.
+
+> Do not use this if you have non-breaking changes, such as fixing help text.
+
+**Arguments**
+* (required) `version` | The version to deprecate.
+* (required) `date` | The date (YYYY-MM-DD) when Zapier will make the specified version unavailable.
+
+**Flags**
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier deprecate 1.2.3 2011-10-01
 
 
 ## describe
@@ -320,6 +358,41 @@ $ │ logout      │ zapier logout                         │ Deactivates all 
 ```
 
 
+## history
+
+> Gets the history of your app.
+
+**Usage**: `zapier history`
+
+History includes all the changes made over the lifetime of your app. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.
+
+**Flags**
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output
+
+
+## init
+
+> Initializes a new Zapier app. Optionally uses a template.
+
+**Usage**: `zapier init PATH`
+
+After running this, you'll have a new example app in your directory. If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
+
+> Note: this doesn't register or deploy the app with Zapier - try the `zapier register` and `zapier push` commands for that!
+
+**Arguments**
+* (required) `path` | Where to create the new app. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation
+
+**Flags**
+* `-t, --template` | The template to start your app with. One of `[minimal | trigger | search | create | basic-auth | custom-auth | digest-auth | oauth2 | oauth1-trello | oauth1-tumblr | oauth1-twitter | session-auth | dynamic-dropdown | files | middleware | resource | rest-hooks | search-or-create | babel | typescript | github | onedrive]`. Defaults to `minimal`.
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier init ./some/path
+* zaper init . --template typescript
+
+
 ## invite
 
   > Manage the invitees/testers on your project. Can optionally specify a version or --remove.
@@ -414,6 +487,27 @@ $ zapier link
 ```
 
 
+## login
+
+> Configures your `~/.zapierrc` with a deploy key.
+
+**Usage**: `zapier login`
+
+**Flags**
+* `-s, --sso` | Use this flag if you log into Zapier a Single Sign-On (SSO) button and don't have a Zapier password
+* `-d, --debug` | Show extra debugging output
+
+
+## logout
+
+> Deactivates your acive deploy key and resets `~/.zapierrc`.
+
+**Usage**: `zapier logout`
+
+**Flags**
+* `-d, --debug` | Show extra debugging output
+
+
 ## logs
 
   > Prints recent logs. See help for filter arguments.
@@ -463,6 +557,69 @@ $ zapier logs --type=http
 # │     Timestamp   │ 2016-01-01T23:04:36-05:00            │
 # └─────────────────┴──────────────────────────────────────┘
 ```
+
+
+## migrate
+
+> Migrates users from one version of your app to another.
+
+**Usage**: `zapier migrate FROMVERSION TOVERSION [PERCENT]`
+
+Starts a migration to move users between different versions of your app. You may also "revert" by simply swapping the from/to verion strings in the command line arguments (i.e. `zapier migrate 1.0.1 1.0.0`).
+
+Only migrate users between non-breaking versions, use `zapier deprecate` if you have breaking changes!
+
+Migrations can take between 5-10 minutes, so be patient and check `zapier history` to track the status.
+
+Note: since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.
+
+> Tip: We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.
+
+> Tip 2: You can migrate a single user by using `--user` (i.e. `zapier migrate 1.0.0 1.0.1 --user=user@example.com`).
+
+**Arguments**
+* (required) `fromVersion` | The version FROM which to migrate users.
+* (required) `toVersion` | The version TO which to migrate users.
+* `percent` | Percentage (between 1 and 100) of users to migrate.
+
+**Flags**
+* `--user` | Migrate only this user
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier migrate 1.0.0 1.0.1
+* zapier migrate 1.0.1 2.0.0 10
+* zapier migrate 2.0.0 2.0.1 --user=user@example.com
+
+
+## promote
+
+> Promotes a specific version to public access.
+
+**Usage**: `zapier promote VERSION`
+
+Promotes an app version into production (non-private) rotation, which means new users can use this app version.
+
+* This [1mdoes[22m mark the version as the official public version - all other versions & users are grandfathered.
+
+* This does [1mNOT[22m build/upload or deploy a version to Zapier - you should `zapier push` first.
+
+* This does [1mNOT[22m move old users over to this version - `zapier migrate 1.0.0 1.0.1` does that.
+
+* This does [1mNOT[22m recommend old users stop using this version - `zapier deprecate 1.0.0 2017-01-01` does that.
+
+Promotes are an inherently safe operation for all existing users of your app.
+
+> If this is your first time promoting - this will start the platform quality assurance process by alerting the Zapier platform team of your intent to make your app public. We'll respond within a few business days.
+
+**Arguments**
+* (required) `version` | The version you want promote.
+
+**Flags**
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier promote 1.0.0
 
 
 ## push
@@ -568,6 +725,26 @@ $ zapier scaffold resource "Tag" --entry=index.js --dest=resources/tag
 ```
 
 
+## test
+
+> Tests your app via `npm test`.
+
+**Usage**: `zapier test`
+
+This command is effectively the same as `npm test`, except we also validate your app and set up the environment. We recommend using mocha as your testing framework.
+
+**Flags**
+* `-t, --timeout` | Set test-case timeout in milliseconds  Defaults to `2000`.
+* `--grep` | Only run tests matching pattern
+* `--skip-validate` | Forgo running `zapier validate` before `npm test`
+* `--yarn` | Use yarn instead of npm
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier test
+* zapier test -t 30000 --grep api --skip-validate
+
+
 ## upload
 
   > Upload the last build as a version.
@@ -587,3 +764,33 @@ $ zapier upload
 #
 # Upload of build/build.zip and build/source.zip complete! Try `zapier versions` now!
 ```
+
+
+## validate
+
+> Validates your Zapier app.
+
+**Usage**: `zapier validate`
+
+Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during `zapier build`, `zapier upload`, `zapier push` or even as a test in `zapier test`.
+
+**Flags**
+* `--without-style` | Forgo pinging the Zapier server to run further checks
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier validate
+* zapier validate --without-style
+* zapier validate --format json
+
+
+## versions
+
+> Lists the versions of your app available for use in the Zapier editor.
+
+**Usage**: `zapier versions`
+
+**Flags**
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn workspace zapier-platform-schema precommit && lint-staged"
+      "pre-commit": "lerna run --stream precommit && lint-staged"
     }
   },
   "lint-staged": {

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -732,7 +732,7 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier init ./some/path</code></li>
-<li><code>zaper init . --template typescript</code></li>
+<li><code>zapier init . --template typescript</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -245,20 +245,31 @@ a code {
       <ul>
 <li><a href="#zapier-cli-reference">Zapier CLI Reference</a></li>
 <li><a href="#commands">Commands</a><ul>
+<li><a href="#apps">apps</a></li>
 <li><a href="#build">build</a></li>
 <li><a href="#collaborate">collaborate</a></li>
 <li><a href="#convert">convert</a></li>
 <li><a href="#delete">delete</a></li>
+<li><a href="#deprecate">deprecate</a></li>
 <li><a href="#describe">describe</a></li>
 <li><a href="#env">env</a></li>
 <li><a href="#help">help</a></li>
+<li><a href="#history">history</a></li>
+<li><a href="#init">init</a></li>
 <li><a href="#invite">invite</a></li>
 <li><a href="#link">link</a></li>
+<li><a href="#login">login</a></li>
+<li><a href="#logout">logout</a></li>
 <li><a href="#logs">logs</a></li>
+<li><a href="#migrate">migrate</a></li>
+<li><a href="#promote">promote</a></li>
 <li><a href="#push">push</a></li>
 <li><a href="#register">register</a></li>
 <li><a href="#scaffold">scaffold</a></li>
+<li><a href="#test">test</a></li>
 <li><a href="#upload">upload</a></li>
+<li><a href="#validate">validate</a></li>
+<li><a href="#versions">versions</a></li>
 </ul>
 </li>
 </ul>
@@ -291,6 +302,29 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h1 id="commands">Commands</h1>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="apps">apps</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Lists any apps that you have admin access to.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier apps</code></p><p>This command also checks the current directory for a linked app.</p><p><strong>Flags</strong></p><ul>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -454,6 +488,35 @@ $ zapier collaborate user@example.com --remove
 <span class="hljs-comment">#   Deleting 1.0.0 - done!</span>
 <span class="hljs-comment">#   Deletion successful!</span>
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="deprecate">deprecate</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Marks a non-production version of your app as deprecated, with removal by a certain date.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier deprecate VERSION DATE</code></p><p>Use this when an app version will not be supported or start breaking at a known date.</p><p>Zapier will send an email warning users of the deprecation once a date is set, they&apos;ll start seeing it as &quot;Deprecated&quot; in the UI, and once the deprecation date arrives, if the Zaps weren&apos;t updated, they&apos;ll be paused and the users will be emailed again explaining what happened.</p><p>After the deprecation date has passed it will be safe to delete that app version.</p><blockquote>
+<p>Do not use this if you have non-breaking changes, such as fixing help text.</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>version</code> | The version to deprecate.</li>
+<li>(required) <code>date</code> | The date (YYYY-MM-DD) when Zapier will make the specified version unavailable.</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier deprecate 1.2.3 2011-10-01</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -626,6 +689,59 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="history">history</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Gets the history of your app.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier history</code></p><p>History includes all the changes made over the lifetime of your app. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.</p><p><strong>Flags</strong></p><ul>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="init">init</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Initializes a new Zapier app. Optionally uses a template.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier init PATH</code></p><p>After running this, you&apos;ll have a new example app in your directory. If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><blockquote>
+<p>Note: this doesn&apos;t register or deploy the app with Zapier - try the <code>zapier register</code> and <code>zapier push</code> commands for that!</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>path</code> | Where to create the new app. If the directory doesn&apos;t exist, it will be created. If the directory isn&apos;t empty, we&apos;ll ask for confirmation</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-t, --template</code> | The template to start your app with. One of <code>[minimal | trigger | search | create | basic-auth | custom-auth | digest-auth | oauth2 | oauth1-trello | oauth1-tumblr | oauth1-twitter | session-auth | dynamic-dropdown | files | middleware | resource | rest-hooks | search-or-create | babel | typescript | github | onedrive]</code>. Defaults to <code>minimal</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier init ./some/path</li>
+<li>zaper init . --template typescript</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h2 id="invite">invite</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -726,6 +842,51 @@ $ zapier invite user@example.com --remove
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="login">login</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Configures your <code>~/.zapierrc</code> with a deploy key.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier login</code></p><p><strong>Flags</strong></p><ul>
+<li><code>-s, --sso</code> | Use this flag if you log into Zapier a Single Sign-On (SSO) button and don&apos;t have a Zapier password</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="logout">logout</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Deactivates your acive deploy key and resets <code>~/.zapierrc</code>.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier logout</code></p><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h2 id="logs">logs</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -776,6 +937,78 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 <span class="hljs-comment"># &#x2502;     Timestamp   &#x2502; 2016-01-01T23:04:36-05:00            &#x2502;</span>
 <span class="hljs-comment"># &#x2514;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2534;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2500;&#x2518;</span>
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="migrate">migrate</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Migrates users from one version of your app to another.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier migrate FROMVERSION TOVERSION [PERCENT]</code></p><p>Starts a migration to move users between different versions of your app. You may also &quot;revert&quot; by simply swapping the from/to verion strings in the command line arguments (i.e. <code>zapier migrate 1.0.1 1.0.0</code>).</p><p>Only migrate users between non-breaking versions, use <code>zapier deprecate</code> if you have breaking changes!</p><p>Migrations can take between 5-10 minutes, so be patient and check <code>zapier history</code> to track the status.</p><p>Note: since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.</p><blockquote>
+<p>Tip: We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.</p>
+</blockquote><blockquote>
+<p>Tip 2: You can migrate a single user by using <code>--user</code> (i.e. <code>zapier migrate 1.0.0 1.0.1 --user=user@example.com</code>).</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>fromVersion</code> | The version FROM which to migrate users.</li>
+<li>(required) <code>toVersion</code> | The version TO which to migrate users.</li>
+<li><code>percent</code> | Percentage (between 1 and 100) of users to migrate.</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>--user</code> | Migrate only this user</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier migrate 1.0.0 1.0.1</li>
+<li>zapier migrate 1.0.1 2.0.0 10</li>
+<li>zapier migrate 2.0.0 2.0.1 <a href="mailto:--user=user@example.com">--user=user@example.com</a></li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="promote">promote</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Promotes a specific version to public access.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier promote VERSION</code></p><p>Promotes an app version into production (non-private) rotation, which means new users can use this app version.</p><ul>
+<li><p>This [1mdoes[22m mark the version as the official public version - all other versions &amp; users are grandfathered.</p>
+</li>
+<li><p>This does [1mNOT[22m build/upload or deploy a version to Zapier - you should <code>zapier push</code> first.</p>
+</li>
+<li><p>This does [1mNOT[22m move old users over to this version - <code>zapier migrate 1.0.0 1.0.1</code> does that.</p>
+</li>
+<li><p>This does [1mNOT[22m recommend old users stop using this version - <code>zapier deprecate 1.0.0 2017-01-01</code> does that.</p>
+</li>
+</ul><p>Promotes are an inherently safe operation for all existing users of your app.</p><blockquote>
+<p>If this is your first time promoting - this will start the platform quality assurance process by alerting the Zapier platform team of your intent to make your app public. We&apos;ll respond within a few business days.</p>
+</blockquote><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>version</code> | The version you want promote.</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier promote 1.0.0</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -896,6 +1129,35 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="test">test</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Tests your app via <code>npm test</code>.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is effectively the same as <code>npm test</code>, except we also validate your app and set up the environment. We recommend using mocha as your testing framework.</p><p><strong>Flags</strong></p><ul>
+<li><code>-t, --timeout</code> | Set test-case timeout in milliseconds  Defaults to <code>2000</code>.</li>
+<li><code>--grep</code> | Only run tests matching pattern</li>
+<li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before <code>npm test</code></li>
+<li><code>--yarn</code> | Use yarn instead of npm</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier test</li>
+<li>zapier test -t 30000 --grep api --skip-validate</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h2 id="upload">upload</h2>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -919,6 +1181,57 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 <span class="hljs-comment">#</span>
 <span class="hljs-comment"># Upload of build/build.zip and build/source.zip complete! Try `zapier versions` now!</span>
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="validate">validate</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Validates your Zapier app.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier validate</code></p><p>Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during <code>zapier build</code>, <code>zapier upload</code>, <code>zapier push</code> or even as a test in <code>zapier test</code>.</p><p><strong>Flags</strong></p><ul>
+<li><code>--without-style</code> | Forgo pinging the Zapier server to run further checks</li>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li>zapier validate</li>
+<li>zapier validate --without-style</li>
+<li>zapier validate --format json</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="versions">versions</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Lists the versions of your app available for use in the Zapier editor.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier versions</code></p><p><strong>Flags</strong></p><ul>
+<li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div>

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -512,7 +512,7 @@ $ zapier collaborate user@example.com --remove
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier deprecate 1.2.3 2011-10-01</li>
+<li><code>zapier deprecate 1.2.3 2011-10-01</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -731,8 +731,8 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
 <li><code>-t, --template</code> | The template to start your app with. One of <code>[minimal | trigger | search | create | basic-auth | custom-auth | digest-auth | oauth2 | oauth1-trello | oauth1-tumblr | oauth1-twitter | session-auth | dynamic-dropdown | files | middleware | resource | rest-hooks | search-or-create | babel | typescript | github | onedrive]</code>. Defaults to <code>minimal</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier init ./some/path</li>
-<li>zaper init . --template typescript</li>
+<li><code>zapier init ./some/path</code></li>
+<li><code>zaper init . --template typescript</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -965,9 +965,9 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 <li><code>--user</code> | Migrate only this user</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier migrate 1.0.0 1.0.1</li>
-<li>zapier migrate 1.0.1 2.0.0 10</li>
-<li>zapier migrate 2.0.0 2.0.1 <a href="mailto:--user=user@example.com">--user=user@example.com</a></li>
+<li><code>zapier migrate 1.0.0 1.0.1</code></li>
+<li><code>zapier migrate 1.0.1 2.0.0 10</code></li>
+<li><code>zapier migrate 2.0.0 2.0.1 --user=user@example.com</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1004,7 +1004,7 @@ $ zapier logs --<span class="hljs-built_in">type</span>=http
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier promote 1.0.0</li>
+<li><code>zapier promote 1.0.0</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1147,8 +1147,8 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 <li><code>--yarn</code> | Use yarn instead of npm</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier test</li>
-<li>zapier test -t 30000 --grep api --skip-validate</li>
+<li><code>zapier test</code></li>
+<li><code>zapier test -t 30000 --grep api --skip-validate</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -1202,9 +1202,9 @@ $ zapier scaffold resource <span class="hljs-string">&quot;Tag&quot;</span> --en
 <li><code>-f, --format</code> | undefined One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>
 </ul><p><strong>Examples</strong></p><ul>
-<li>zapier validate</li>
-<li>zapier validate --without-style</li>
-<li>zapier validate --format json</li>
+<li><code>zapier validate</code></li>
+<li><code>zapier validate --without-style</code></li>
+<li><code>zapier validate --format json</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -197,7 +197,7 @@ After the deprecation date has passed it will be safe to delete that app version
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier deprecate 1.2.3 2011-10-01
+* `zapier deprecate 1.2.3 2011-10-01`
 
 
 ## describe
@@ -389,8 +389,8 @@ After running this, you'll have a new example app in your directory. If you re-r
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier init ./some/path
-* zaper init . --template typescript
+* `zapier init ./some/path`
+* `zaper init . --template typescript`
 
 
 ## invite
@@ -587,9 +587,9 @@ Note: since a migration is only for non-breaking changes, users are not emailed 
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier migrate 1.0.0 1.0.1
-* zapier migrate 1.0.1 2.0.0 10
-* zapier migrate 2.0.0 2.0.1 --user=user@example.com
+* `zapier migrate 1.0.0 1.0.1`
+* `zapier migrate 1.0.1 2.0.0 10`
+* `zapier migrate 2.0.0 2.0.1 --user=user@example.com`
 
 
 ## promote
@@ -619,7 +619,7 @@ Promotes are an inherently safe operation for all existing users of your app.
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier promote 1.0.0
+* `zapier promote 1.0.0`
 
 
 ## push
@@ -741,8 +741,8 @@ This command is effectively the same as `npm test`, except we also validate your
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier test
-* zapier test -t 30000 --grep api --skip-validate
+* `zapier test`
+* `zapier test -t 30000 --grep api --skip-validate`
 
 
 ## upload
@@ -780,9 +780,9 @@ Runs the standard validation routine powered by json-schema that checks your app
 * `-d, --debug` | Show extra debugging output
 
 **Examples**
-* zapier validate
-* zapier validate --without-style
-* zapier validate --format json
+* `zapier validate`
+* `zapier validate --without-style`
+* `zapier validate --format json`
 
 
 ## versions

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -390,7 +390,7 @@ After running this, you'll have a new example app in your directory. If you re-r
 
 **Examples**
 * `zapier init ./some/path`
-* `zaper init . --template typescript`
+* `zapier init . --template typescript`
 
 
 ## invite

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -10,6 +10,19 @@ $ npm install -g zapier-platform-cli
 
 # Commands
 
+## apps
+
+> Lists any apps that you have admin access to.
+
+**Usage**: `zapier apps`
+
+This command also checks the current directory for a linked app.
+
+**Flags**
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output
+
+
 ## build
 
   > Builds a pushable zip from the current directory.
@@ -160,6 +173,31 @@ $ zapier delete version 1.0.0
 #   Deleting 1.0.0 - done!
 #   Deletion successful!
 ```
+
+
+## deprecate
+
+> Marks a non-production version of your app as deprecated, with removal by a certain date.
+
+**Usage**: `zapier deprecate VERSION DATE`
+
+Use this when an app version will not be supported or start breaking at a known date.
+
+Zapier will send an email warning users of the deprecation once a date is set, they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
+
+After the deprecation date has passed it will be safe to delete that app version.
+
+> Do not use this if you have non-breaking changes, such as fixing help text.
+
+**Arguments**
+* (required) `version` | The version to deprecate.
+* (required) `date` | The date (YYYY-MM-DD) when Zapier will make the specified version unavailable.
+
+**Flags**
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier deprecate 1.2.3 2011-10-01
 
 
 ## describe
@@ -320,6 +358,41 @@ $ │ logout      │ zapier logout                         │ Deactivates all 
 ```
 
 
+## history
+
+> Gets the history of your app.
+
+**Usage**: `zapier history`
+
+History includes all the changes made over the lifetime of your app. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.
+
+**Flags**
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output
+
+
+## init
+
+> Initializes a new Zapier app. Optionally uses a template.
+
+**Usage**: `zapier init PATH`
+
+After running this, you'll have a new example app in your directory. If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
+
+> Note: this doesn't register or deploy the app with Zapier - try the `zapier register` and `zapier push` commands for that!
+
+**Arguments**
+* (required) `path` | Where to create the new app. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation
+
+**Flags**
+* `-t, --template` | The template to start your app with. One of `[minimal | trigger | search | create | basic-auth | custom-auth | digest-auth | oauth2 | oauth1-trello | oauth1-tumblr | oauth1-twitter | session-auth | dynamic-dropdown | files | middleware | resource | rest-hooks | search-or-create | babel | typescript | github | onedrive]`. Defaults to `minimal`.
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier init ./some/path
+* zaper init . --template typescript
+
+
 ## invite
 
   > Manage the invitees/testers on your project. Can optionally specify a version or --remove.
@@ -414,6 +487,27 @@ $ zapier link
 ```
 
 
+## login
+
+> Configures your `~/.zapierrc` with a deploy key.
+
+**Usage**: `zapier login`
+
+**Flags**
+* `-s, --sso` | Use this flag if you log into Zapier a Single Sign-On (SSO) button and don't have a Zapier password
+* `-d, --debug` | Show extra debugging output
+
+
+## logout
+
+> Deactivates your acive deploy key and resets `~/.zapierrc`.
+
+**Usage**: `zapier logout`
+
+**Flags**
+* `-d, --debug` | Show extra debugging output
+
+
 ## logs
 
   > Prints recent logs. See help for filter arguments.
@@ -463,6 +557,69 @@ $ zapier logs --type=http
 # │     Timestamp   │ 2016-01-01T23:04:36-05:00            │
 # └─────────────────┴──────────────────────────────────────┘
 ```
+
+
+## migrate
+
+> Migrates users from one version of your app to another.
+
+**Usage**: `zapier migrate FROMVERSION TOVERSION [PERCENT]`
+
+Starts a migration to move users between different versions of your app. You may also "revert" by simply swapping the from/to verion strings in the command line arguments (i.e. `zapier migrate 1.0.1 1.0.0`).
+
+Only migrate users between non-breaking versions, use `zapier deprecate` if you have breaking changes!
+
+Migrations can take between 5-10 minutes, so be patient and check `zapier history` to track the status.
+
+Note: since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.
+
+> Tip: We recommend migrating a small subset of users first, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.
+
+> Tip 2: You can migrate a single user by using `--user` (i.e. `zapier migrate 1.0.0 1.0.1 --user=user@example.com`).
+
+**Arguments**
+* (required) `fromVersion` | The version FROM which to migrate users.
+* (required) `toVersion` | The version TO which to migrate users.
+* `percent` | Percentage (between 1 and 100) of users to migrate.
+
+**Flags**
+* `--user` | Migrate only this user
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier migrate 1.0.0 1.0.1
+* zapier migrate 1.0.1 2.0.0 10
+* zapier migrate 2.0.0 2.0.1 --user=user@example.com
+
+
+## promote
+
+> Promotes a specific version to public access.
+
+**Usage**: `zapier promote VERSION`
+
+Promotes an app version into production (non-private) rotation, which means new users can use this app version.
+
+* This [1mdoes[22m mark the version as the official public version - all other versions & users are grandfathered.
+
+* This does [1mNOT[22m build/upload or deploy a version to Zapier - you should `zapier push` first.
+
+* This does [1mNOT[22m move old users over to this version - `zapier migrate 1.0.0 1.0.1` does that.
+
+* This does [1mNOT[22m recommend old users stop using this version - `zapier deprecate 1.0.0 2017-01-01` does that.
+
+Promotes are an inherently safe operation for all existing users of your app.
+
+> If this is your first time promoting - this will start the platform quality assurance process by alerting the Zapier platform team of your intent to make your app public. We'll respond within a few business days.
+
+**Arguments**
+* (required) `version` | The version you want promote.
+
+**Flags**
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier promote 1.0.0
 
 
 ## push
@@ -568,6 +725,26 @@ $ zapier scaffold resource "Tag" --entry=index.js --dest=resources/tag
 ```
 
 
+## test
+
+> Tests your app via `npm test`.
+
+**Usage**: `zapier test`
+
+This command is effectively the same as `npm test`, except we also validate your app and set up the environment. We recommend using mocha as your testing framework.
+
+**Flags**
+* `-t, --timeout` | Set test-case timeout in milliseconds  Defaults to `2000`.
+* `--grep` | Only run tests matching pattern
+* `--skip-validate` | Forgo running `zapier validate` before `npm test`
+* `--yarn` | Use yarn instead of npm
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier test
+* zapier test -t 30000 --grep api --skip-validate
+
+
 ## upload
 
   > Upload the last build as a version.
@@ -587,3 +764,33 @@ $ zapier upload
 #
 # Upload of build/build.zip and build/source.zip complete! Try `zapier versions` now!
 ```
+
+
+## validate
+
+> Validates your Zapier app.
+
+**Usage**: `zapier validate`
+
+Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during `zapier build`, `zapier upload`, `zapier push` or even as a test in `zapier test`.
+
+**Flags**
+* `--without-style` | Forgo pinging the Zapier server to run further checks
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output
+
+**Examples**
+* zapier validate
+* zapier validate --without-style
+* zapier validate --format json
+
+
+## versions
+
+> Lists the versions of your app available for use in the Zapier editor.
+
+**Usage**: `zapier versions`
+
+**Flags**
+* `-f, --format` | undefined One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-d, --debug` | Show extra debugging output

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
     "preversion": "git pull && yarn validate",
     "prepack": "oclif-dev manifest",
     "postpack": "rm -f oclif.manifest.json",
+    "precommit": "yarn docs && git add docs README.md ../../docs",
     "version": "yarn docs && yarn gen-completions && git add docs/* goodies/* README.md",
     "postversion": "git push && git push --tags",
     "lint": "eslint zapier.js src snippets --fix",

--- a/packages/cli/src/commands/help.js
+++ b/packages/cli/src/commands/help.js
@@ -32,7 +32,7 @@ const help = (context, cmd) => {
           name,
           help: c.help || c.description.split('\n')[0],
           example: oclifCommands.has(name)
-            ? c.usage(name) // new
+            ? c.zUsage(name) // new
             : c.example // old
         };
       });

--- a/packages/cli/src/commands/help.js
+++ b/packages/cli/src/commands/help.js
@@ -6,6 +6,7 @@ const utils = require('../utils');
 const help = (context, cmd) => {
   const commands = require('./index');
   const oCommands = require('../oclif/oCommands');
+  const oclifCommands = new Set(Object.keys(oCommands));
 
   const allCommands = { ...commands, ...oCommands };
 
@@ -30,7 +31,9 @@ const help = (context, cmd) => {
         return {
           name,
           help: c.help || c.description.split('\n')[0],
-          example: c.example || (c.examples && c.examples[0])
+          example: oclifCommands.has(name)
+            ? c.usage(name) // new
+            : c.example // old
         };
       });
     utils.printData(commandList, [

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -206,7 +206,7 @@ class ZapierBaseCommand extends Command {
       ...(this.args ? ['', '**Arguments**', ...formattedArgs()] : []),
       ...(this.flags ? ['', '**Flags**', ...formattedFlags()] : []),
       ...(this.examples
-        ? ['', '**Examples**', this.examples.map(e => `* ${e}`).join('\n')]
+        ? ['', '**Examples**', this.examples.map(e => `* \`${e}\``).join('\n')]
         : [])
     ]
       .join('\n')

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -151,7 +151,8 @@ class ZapierBaseCommand extends Command {
   }
 
   // pulled from https://github.com/oclif/plugin-help/blob/73bfd5a861e65844a1d6c3a0a9638ee49d16fee8/src/command.ts
-  static usage(name) {
+  // renamed to avoid naming collision
+  static zUsage(name) {
     const formatArg = arg => {
       const argName = arg.name.toUpperCase();
       return arg.required ? argName : `[${argName}]`;
@@ -201,7 +202,7 @@ class ZapierBaseCommand extends Command {
       '',
       `> ${blurb}`,
       '',
-      `**Usage**: \`${this.usage(name)}\``,
+      `**Usage**: \`${this.zUsage(name)}\``,
       ...(lengthyDescription ? ['', lengthyDescription] : []),
       ...(this.args ? ['', '**Arguments**', ...formattedArgs()] : []),
       ...(this.flags ? ['', '**Flags**', ...formattedFlags()] : []),

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -149,6 +149,69 @@ class ZapierBaseCommand extends Command {
   stopSpinner({ success = true, message = undefined } = {}) {
     endSpinner(success, message);
   }
+
+  // pulled from https://github.com/oclif/plugin-help/blob/73bfd5a861e65844a1d6c3a0a9638ee49d16fee8/src/command.ts
+  static usage(name) {
+    const formatArg = arg => {
+      const argName = arg.name.toUpperCase();
+      return arg.required ? argName : `[${argName}]`;
+    };
+
+    return [
+      'zapier',
+      name,
+      ...(this.args || []).filter(a => !a.hidden).map(a => formatArg(a))
+    ].join(' ');
+  }
+
+  // this is fine for now but we'll want to hack into https://github.com/oclif/plugin-help/blob/master/src/command.ts at some point
+  // the presentation is wrapped into the formatting, so it's a little tough to pull out
+  static markdownHelp(name) {
+    const formattedArgs = () =>
+      this.args.map(arg =>
+        arg.hidden
+          ? null
+          : `* ${arg.required ? '(required) ' : ''}\`${arg.name}\` | ${
+              arg.description
+            }`
+      );
+    const formattedFlags = () =>
+      Object.entries(this.flags)
+        .map(([longName, flag]) =>
+          flag.hidden
+            ? null
+            : `* ${flag.required ? '(required) ' : ''}\`${
+                flag.char ? `-${flag.char}, ` : ''
+              }--${longName}\` | ${flag.description} ${
+                flag.options ? `One of \`[${flag.options.join(' | ')}]\`.` : ''
+              }${flag.default ? ` Defaults to \`${flag.default}\`.` : ''}
+      `.trim()
+        )
+        .filter(Boolean);
+
+    const descriptionParts = this.description.split('\n').filter(Boolean);
+    const blurb = descriptionParts[0];
+    const lengthyDescription =
+      descriptionParts.length > 1 ? descriptionParts.slice(1).join('\n\n') : '';
+
+    // Object.getPrototypeOf(this).constructor.flags
+
+    return [
+      `## ${name}`,
+      '',
+      `> ${blurb}`,
+      '',
+      `**Usage**: \`${this.usage(name)}\``,
+      ...(lengthyDescription ? ['', lengthyDescription] : []),
+      ...(this.args ? ['', '**Arguments**', ...formattedArgs()] : []),
+      ...(this.flags ? ['', '**Flags**', ...formattedFlags()] : []),
+      ...(this.examples
+        ? ['', '**Examples**', this.examples.map(e => `* ${e}`).join('\n')]
+        : [])
+    ]
+      .join('\n')
+      .trim();
+  }
 }
 
 module.exports = ZapierBaseCommand;

--- a/packages/cli/src/oclif/commands/apps.js
+++ b/packages/cli/src/oclif/commands/apps.js
@@ -23,7 +23,6 @@ class AppsCommand extends BaseCommand {
 }
 
 AppsCommand.flags = buildFlags({ opts: { format: true } });
-AppsCommand.examples = ['zapier apps'];
 AppsCommand.description = `Lists any apps that you have admin access to.
 
 This command also checks the current directory for a linked app.`;

--- a/packages/cli/src/oclif/commands/history.js
+++ b/packages/cli/src/oclif/commands/history.js
@@ -21,7 +21,6 @@ class HistoryCommand extends BaseCommand {
 }
 
 HistoryCommand.flags = buildFlags({ opts: { format: true } });
-HistoryCommand.examples = ['zapier history'];
 HistoryCommand.description = `Gets the history of your app.
 
 History includes all the changes made over the lifetime of your app. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.`;

--- a/packages/cli/src/oclif/commands/init.js
+++ b/packages/cli/src/oclif/commands/init.js
@@ -49,7 +49,7 @@ InitCommand.flags = buildFlags({
   commandFlags: {
     template: flags.string({
       char: 't',
-      description: 'start your app with a template',
+      description: 'The template to start your app with.',
       options: appTemplates,
       default: 'minimal'
     })
@@ -60,7 +60,7 @@ InitCommand.args = [
     name: 'path',
     required: true,
     description:
-      "Where to create the new app. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation."
+      "Where to create the new app. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation"
   }
 ];
 InitCommand.examples = [
@@ -71,6 +71,6 @@ InitCommand.description = `Initializes a new Zapier app. Optionally uses a templ
 
 After running this, you'll have a new example app in your directory. If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 
-> Note: this doesn't register or deploy the app with Zapier - try \`zapier register "Example"\` and \`zapier push\` for that!`;
+> Note: this doesn't register or deploy the app with Zapier - try the \`zapier register\` and \`zapier push\` commands for that!`;
 
 module.exports = InitCommand;

--- a/packages/cli/src/oclif/commands/init.js
+++ b/packages/cli/src/oclif/commands/init.js
@@ -65,7 +65,7 @@ InitCommand.args = [
 ];
 InitCommand.examples = [
   'zapier init ./some/path',
-  'zaper init . --template typescript'
+  'zapier init . --template typescript'
 ];
 InitCommand.description = `Initializes a new Zapier app. Optionally uses a template.
 

--- a/packages/cli/src/oclif/commands/login.js
+++ b/packages/cli/src/oclif/commands/login.js
@@ -143,7 +143,6 @@ LoginCommand.flags = buildFlags({
     })
   }
 });
-LoginCommand.examples = ['zapier login'];
 LoginCommand.description = `Configures your \`${AUTH_LOCATION_RAW}\` with a deploy key.`;
 
 module.exports = LoginCommand;

--- a/packages/cli/src/oclif/commands/logout.js
+++ b/packages/cli/src/oclif/commands/logout.js
@@ -33,7 +33,6 @@ class LogoutCommand extends BaseCommand {
 }
 
 LogoutCommand.flags = buildFlags();
-LogoutCommand.examples = ['zapier logout'];
 LogoutCommand.description = `Deactivates your acive deploy key and resets \`${AUTH_LOCATION_RAW}\`.`;
 
 module.exports = LogoutCommand;

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -23,7 +23,6 @@ class VersionCommand extends BaseCommand {
 }
 
 VersionCommand.flags = buildFlags({ opts: { format: true } });
-VersionCommand.examples = ['zapier versions'];
 VersionCommand.description = `Lists the versions of your app available for use in the Zapier editor.`;
 
 module.exports = VersionCommand;


### PR DESCRIPTION
We [noticed](https://zapier.slack.com/archives/C5Z9BP4U9/p1570028316375200) that the slack invite url was expired. I fixed it in master (https://github.com/zapier/zapier-platform/commit/74711f04f3bf1832f259387510e066f87cac24b8), and as a result, noticed that `cli.docs` wasn't getting run in the pre-commit. 

That's fixed here, plus adding code to format the command into markdown (so it's picked up by the `docs` command). 

This code was simplified from [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/master/src/command.ts), which we use. It would have been cool to be able to use the formatting functions without their `bold` and joining and stuff, so that's maybe a PR i'll make at some point. In any case, this is good for now.