### PR TITLE
fix(legacy-scripting-runner): bundle.raw_url, _.template, and request fallback

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -231,7 +231,7 @@ const bundleConverter = async (bundle, event, z) => {
   const convertedBundle = {
     request: {
       method: requestMethod,
-      url: _.get(bundle, '_legacyUrl', '') || _.get(bundle, 'request.url', ''),
+      url: _.get(bundle, 'request.url', ''),
       headers: {
         'Content-Type': 'application/json'
       },
@@ -240,9 +240,12 @@ const bundleConverter = async (bundle, event, z) => {
     },
     auth_fields: _.get(bundle, 'authData', {}),
     meta,
-    zap,
-    url_raw: _.get(bundle, '_legacyUrl', '')
+    zap
   };
+
+  if (bundle._legacyUrl) {
+    convertedBundle.raw_url = convertedBundle.url_raw = bundle._legacyUrl;
+  }
 
   addAuthData(event, bundle, convertedBundle);
   addInputData(event, bundle, convertedBundle);

--- a/packages/legacy-scripting-runner/test/bundle.js
+++ b/packages/legacy-scripting-runner/test/bundle.js
@@ -7,6 +7,9 @@ const { bundleConverter } = require('../bundle');
 describe('bundleConverter', () => {
   const defaultBundle = {
     _legacyUrl: 'https://zapier.com',
+    request: {
+      url: 'https://zapier.com'
+    },
     inputData: {
       user: 'Zapier'
     },
@@ -29,6 +32,9 @@ describe('bundleConverter', () => {
   const defaultHookBundle = {
     _legacyUrl: 'https://zapier.com',
     _legacyEvent: 'message',
+    request: {
+      url: 'https://zapier.com'
+    },
     targetUrl: 'https://hooks.zapier.com/abc',
     inputData: {
       user: 'Zapier'
@@ -82,6 +88,7 @@ describe('bundleConverter', () => {
       },
       zap: { id: 0 },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -146,6 +153,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -183,6 +191,7 @@ describe('bundleConverter', () => {
     };
     const bundle = {
       _legacyUrl: 'https://zapier.com',
+      request: { url: 'https://zapier.com' },
       inputData: {
         user: 'Zapier'
       },
@@ -210,8 +219,7 @@ describe('bundleConverter', () => {
         id: 1,
         name: 'Zapier'
       },
-      meta: {
-      },
+      meta: {},
       auth_fields: {
         apiKey: 'Zapier-API-Key'
       },
@@ -219,6 +227,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -267,6 +276,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -321,6 +331,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -350,6 +361,7 @@ describe('bundleConverter', () => {
     const bundle = {
       _legacyUrl: 'https://zapier.com',
       _legacyEvent: 'message',
+      request: { url: 'https://zapier.com' },
       targetUrl: 'https://hooks.zapier.com/abc',
       inputData: {
         user: 'Zapier'
@@ -379,6 +391,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -433,6 +446,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -485,6 +499,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       trigger_fields: {
         user: 'Zapier'
       },
@@ -546,6 +561,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       action_fields: {
         user: 'Zapier'
       },
@@ -613,6 +629,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       action_fields: {
         user: 'Zapier'
       },
@@ -686,6 +703,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       search_fields: {
         user: 'Zapier'
       }
@@ -747,6 +765,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       search_fields: {
         user: 'Zapier'
       },
@@ -813,6 +832,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       search_fields: {
         user: 'Zapier'
       },
@@ -887,6 +907,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       search_fields: {
         user: 'Zapier'
       },
@@ -930,6 +951,7 @@ describe('bundleConverter', () => {
     const events = ['auth.oauth2.token.pre', 'auth.oauth2.refresh.pre'];
     const bundle = {
       _legacyUrl: 'https://zapier.com',
+      request: { url: 'https://zapier.com' },
       inputData: {
         user: 'Zapier'
       },
@@ -954,6 +976,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       oauth_data: {
         client_id: '1234',
         client_secret: 'asdf'
@@ -987,6 +1010,7 @@ describe('bundleConverter', () => {
     };
     const bundle = {
       _legacyUrl: 'https://zapier.com',
+      request: { url: 'https://zapier.com' },
       inputData: {
         user: 'Zapier'
       },
@@ -1017,6 +1041,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       oauth_data: {
         client_id: '1234',
         client_secret: 'asdf'
@@ -1048,6 +1073,7 @@ describe('bundleConverter', () => {
     const events = ['auth.session'];
     const bundle = {
       _legacyUrl: 'https://zapier.com',
+      request: { url: 'https://zapier.com' },
       inputData: {
         user: 'Zapier'
       },
@@ -1074,7 +1100,8 @@ describe('bundleConverter', () => {
       zap: {
         id: 0
       },
-      url_raw: 'https://zapier.com'
+      url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com'
     };
 
     const results = await Promise.all(
@@ -1098,6 +1125,7 @@ describe('bundleConverter', () => {
     const events = ['auth.connectionLabel'];
     const bundle = {
       _legacyUrl: 'https://zapier.com',
+      request: { url: 'https://zapier.com' },
       inputData: {
         user: 'Zapier'
       },
@@ -1123,6 +1151,7 @@ describe('bundleConverter', () => {
         id: 0
       },
       url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
       test_result: {
         user: 'Zapier'
       }


### PR DESCRIPTION
Fixes three bugs:

1. `bundle.raw_url` should be available for `KEY_(pre|post)_custom_X_fields` methods and have the original curly variables, such as `https://example.com/things/{{object_id}}` instead of `https://example.com/things/{{bundle.inputData.object_id}}`.
2. Underscore `_.template` should use `{{...}}` instead of the default `<% ... %>`.
3. The request object returned from a `KEY_pre` should be combined with `bundle.request` afterward. That means returning an empty object is equivalent to returning `bundle.request`.