### PR TITLE
fix(legacy-scripting-runner): fix file upload issues

### DIFF
--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -579,6 +579,21 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      file_pre_write_wrong_content_type: function(bundle) {
+        // Files should always be sent as multipart/form-data, no matter what
+        // the developer sets here
+        bundle.request.headers['Content-Type'] = 'applicaiton/x-www-form-urlencoded';
+        bundle.request.data = z.JSON.parse(bundle.request.data);
+        return bundle.request;
+      },
+
+      file2_pre_write_rename_file_field: function(bundle) {
+        bundle.request.files = {
+          file: bundle.request.files.file_1
+        };
+        return bundle.request;
+      },
+
       /*
        * Search
        */
@@ -874,6 +889,25 @@ const FileUpload = {
   }
 };
 
+const FileUpload2 = {
+  key: 'file2',
+  noun: 'File',
+  display: {
+    label: 'Upload a File 2'
+  },
+  operation: {
+    perform: {
+      source: "return z.legacyScripting.run(bundle, 'create', 'file2');"
+    },
+    inputFields: [
+      { key: 'id', label: 'ID', type: 'string' },
+      { key: 'name', label: 'Name', type: 'string' },
+      { key: 'file_1', label: 'File', type: 'file' }
+    ],
+    outputFields: [{ key: 'id', label: 'ID', type: 'integer' }]
+  }
+};
+
 const RecipeCreate = {
   key: 'recipe',
   noun: 'Recipe',
@@ -946,8 +980,9 @@ const App = {
   },
   creates: {
     [MovieCreate.key]: MovieCreate,
+    [RecipeCreate.key]: RecipeCreate,
     [FileUpload.key]: FileUpload,
-    [RecipeCreate.key]: RecipeCreate
+    [FileUpload2.key]: FileUpload2
   },
   searches: {
     [MovieSearch.key]: MovieSearch
@@ -1018,15 +1053,20 @@ const App = {
           fieldsExcludedFromBody: ['title']
         }
       },
+      recipe: {
+        operation: {
+          url: `${AUTH_JSON_SERVER_URL}{{bundle.inputData.urlPath}}`,
+          inputFieldsUrl: `${AUTH_JSON_SERVER_URL}{{bundle.inputData.urlPath}}`
+        }
+      },
       file: {
         operation: {
           url: `${AUTH_JSON_SERVER_URL}/upload`
         }
       },
-      recipe: {
+      file2: {
         operation: {
-          url: `${AUTH_JSON_SERVER_URL}{{bundle.inputData.urlPath}}`,
-          inputFieldsUrl: `${AUTH_JSON_SERVER_URL}{{bundle.inputData.urlPath}}`
+          url: `${AUTH_JSON_SERVER_URL}/upload`
         }
       }
     },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2298,6 +2298,62 @@ describe('Integration Test', () => {
       });
     });
 
+    it('file upload, KEY_pre_write, wrong content type', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'file_pre_write_wrong_content_type',
+        'file_pre_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.file.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        filename: 'dont.care',
+        file: 'https://httpbin.zapier-tooling.com/image/png'
+      };
+      return app(input).then(output => {
+        const file = output.results.file;
+        should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
+
+        const filename = output.results.filename;
+        should.equal(filename, 'dont.care');
+      });
+    });
+
+    it('file upload, KEY_pre_write, rename file field', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'file2_pre_write_rename_file_field',
+        'file2_pre_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.file2.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        id: 'whatever',
+        name: 'a pig',
+        file_1: 'https://httpbin.zapier-tooling.com/image/png'
+      };
+      return app(input).then(output => {
+        const file = output.results.file;
+        should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
+
+        const data = JSON.parse(output.results.data);
+        should.equal(data.id, 'whatever');
+        should.equal(data.name, 'a pig');
+      });
+    });
+
     describe('legacyMethodHydrator', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);


### PR DESCRIPTION
Fixes three `KEY_pre_write` bugs dealing with file upload:

* Developers can set an arbitrary `Content-Type` request header in `KEY_pre_write`, we should correct it to `multipart/form-data` no matter what.
* If `request.data` returned by `KEY_pre_write` is an object, we should separate each field in the multipart request instead of serializing them into a `data` field as a JSON string.
* We should allow developers to rename a file field in `KEY_pre_write`.

For more detail, see the newly-added test cases.