### PR TITLE
fix(cli): update to latest format of validate endpoint

### DIFF
--- a/packages/cli/src/oclif/commands/validate.js
+++ b/packages/cli/src/oclif/commands/validate.js
@@ -75,12 +75,12 @@ class ValidateCommand extends BaseCommand {
       emptyMessage: 'App checks passed, no issues found.'
     });
 
-    if (checkResult.errors && checkResult.errors.length) {
+    if (checkResult.errors && checkResult.errors.results.length) {
       process.exitCode = 1;
       this.log(
         'Errors will block you from pushing; warnings will only block you from going public or promoting a version.\n'
       );
-    } else if (checkResult.warnings.length) {
+    } else if (checkResult.warnings && checkResult.warnings.results.length) {
       this.log(
         'Your app looks great! Warnings only block you from going public or promoting a version.\n'
       );

--- a/packages/cli/src/utils/display.js
+++ b/packages/cli/src/utils/display.js
@@ -279,7 +279,12 @@ const getYesNoInput = (question, showCtrlC = true) => {
 const flattenCheckResult = checkResult => {
   const res = [];
   for (const severity in checkResult) {
-    for (const issueGroup of checkResult[severity]) {
+    const results = checkResult[severity].results;
+    if (!results) {
+      continue;
+    }
+
+    for (const issueGroup of results) {
       if (!issueGroup.violations) {
         break;
       }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Adopts the new response format of `/api/platform/cli/check`, which was changed by https://github.com/zapier/zapier/pull/31726.