### PR TITLE
fix(cli): Remove required property from parent field in line-items snippet

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2426,7 +2426,6 @@ issue: {
     inputFields: [
       {
         <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItems&apos;</span>,
-        <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
         <span class="hljs-attr">children</span>: [
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItemId&apos;</span>,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1445,7 +1445,6 @@ const App = {
     inputFields: [
       {
         key: 'lineItems',
-        required: true,
         children: [
           {
             key: 'lineItemId',

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2426,7 +2426,6 @@ issue: {
     inputFields: [
       {
         <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItems&apos;</span>,
-        <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
         <span class="hljs-attr">children</span>: [
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;lineItemId&apos;</span>,

--- a/packages/cli/snippets/input-fields-children.js
+++ b/packages/cli/snippets/input-fields-children.js
@@ -5,7 +5,6 @@ const App = {
     inputFields: [
       {
         key: 'lineItems',
-        required: true,
         children: [
           {
             key: 'lineItemId',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Resolves https://github.com/zapier/zapier-platform/issues/81 by removing the `required` property line from the parent field in the affected snippet. 