### PR TITLE
fix(cli): don't run analytics during tests

### DIFF
--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -45,26 +45,37 @@ const UPDATE_NOTIFICATION_INTERVAL = 1000 * 60 * 60 * 24 * 7; // one week
 const CHECK_REF_DOC_LINK =
   'https://platform.zapier.com/docs/integration-checks-reference';
 
+// can't just read from argv because they could have lots of extra data, such as
+// [ '/Users/david/.nvm/versions/node/v10.13.0/bin/node',
+//   '/Users/david/projects/zapier/platform/node_modules/.bin/mocha',
+//   'src/tests' ]
+const argvStr = process.argv.join(' ');
+const IS_TESTING =
+  argvStr.includes('mocha') ||
+  argvStr.includes('jest') ||
+  (process.env.NODE_ENV || '').toLowerCase().startsWith('test');
+
 module.exports = {
   ANALYTICS_KEY,
   ANALYTICS_MODES,
   API_PATH,
   AUTH_KEY,
-  AUTH_LOCATION,
   AUTH_LOCATION_RAW,
+  AUTH_LOCATION,
   BASE_ENDPOINT,
+  BLACKLISTED_PATHS,
   BUILD_DIR,
   BUILD_PATH,
   CHECK_REF_DOC_LINK,
-  SOURCE_PATH,
-  BLACKLISTED_PATHS,
   CURRENT_APP_FILE,
   DEFINITION_PATH,
   ENDPOINT,
+  IS_TESTING,
   LAMBDA_VERSION,
   PACKAGE_NAME,
   PACKAGE_VERSION,
   PLATFORM_PACKAGE,
+  SOURCE_PATH,
   STARTER_REPO,
   UPDATE_NOTIFICATION_INTERVAL
 };

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -31,7 +31,7 @@ class ZapierBaseCommand extends Command {
     // also, would be nice to plug into something a little more base-level so we catch invalid flags. Not super important
 
     return Promise.all([
-      recordAnalytics(this.id, true, Object.keys(this.args), this.flags),
+      this._recordAnalytics(),
 
       this.perform().catch(e => {
         this.stopSpinner({ success: false });
@@ -224,6 +224,14 @@ class ZapierBaseCommand extends Command {
     ]
       .join('\n')
       .trim();
+  }
+
+  _recordAnalytics() {
+    // if we got here, the command must be true
+    if (!this.args) {
+      throw new Error('unable to record analytics until args are parsed');
+    }
+    return recordAnalytics(this.id, true, Object.keys(this.args), this.flags);
   }
 }
 

--- a/packages/cli/src/tests/baseCommand.js
+++ b/packages/cli/src/tests/baseCommand.js
@@ -11,6 +11,9 @@ const ROW_HEADERS = [['Contact ID', 'id'], ['Neat Title', 'title']];
 
 class TestBaseCommand extends BaseCommand {
   throwForInvalidAppInstall() {}
+  _recordAnalytics() {
+    return Promise.resolve();
+  }
 }
 // logs both text and a table, which behave differently baed on the format flag
 class TestSampleCommand extends TestBaseCommand {

--- a/packages/cli/src/tests/testing.js
+++ b/packages/cli/src/tests/testing.js
@@ -1,0 +1,9 @@
+require('should');
+
+const { IS_TESTING } = require('../constants');
+
+describe('testing setup', () => {
+  it('should set IS_TESTING to true', () => {
+    IS_TESTING.should.be.true();
+  });
+});

--- a/packages/cli/src/tests/utils/analytics.js
+++ b/packages/cli/src/tests/utils/analytics.js
@@ -1,0 +1,9 @@
+require('should');
+const { shouldSkipAnalytics } = require('../../utils/analytics');
+
+describe('analytics', () => {
+  // causes a lot of noise
+  it('should not run analytics when testing', () => {
+    shouldSkipAnalytics().should.be.true();
+  });
+});

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -198,7 +198,7 @@ const getLinkedApp = appDir => {
       return callAPI('/apps/' + app.id);
     })
     .catch(e => {
-      if (process.env.NODE_ENV === 'test') {
+      if (constants.IS_TESTING) {
         console.error(e);
       }
       throw new Error(

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -121,7 +121,7 @@ const listFiles = dir => {
 const respectGitIgnore = (dir, paths) => {
   const gitIgnorePath = path.join(dir, '.gitignore');
   if (!fs.existsSync(gitIgnorePath)) {
-    if (process.env.NODE_ENV !== 'test') {
+    if (!constants.IS_TESTING) {
       console.log(
         '\n\n!!Warning!! There is no .gitignore, so we are including all files. This might make the source.zip file too large\n\n'
       );

--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -4,7 +4,11 @@ const _ = require('lodash');
 const prettier = require('prettier');
 const semver = require('semver');
 
-const { PACKAGE_VERSION, PLATFORM_PACKAGE } = require('../constants');
+const {
+  PACKAGE_VERSION,
+  PLATFORM_PACKAGE,
+  IS_TESTING
+} = require('../constants');
 const { copyFile, ensureDir, readFile, writeFile } = require('./files');
 const { snakeCase } = require('./misc');
 const { getPackageLatestVersion } = require('./npm');
@@ -471,7 +475,7 @@ const convertApp = async (appInfo, appDefinition, newAppDir, opts = {}) => {
   const defaultOpts = { legacy: true };
   const { legacy } = { ...defaultOpts, ...opts };
 
-  if (process.env.NODE_ENV === 'test') {
+  if (IS_TESTING) {
     startSpinner = endSpinner = () => null;
   }
 


### PR DESCRIPTION
I noticed a big surge of analytics on `linux` with odd behavior, such as no command (which should never be possible). Turns out the culprit was traivs. Fixed some minor bugs while I was in there.