### PR TITLE
fix(core): hide sensitive data from error messages

### DIFF
--- a/packages/core/src/http-middlewares/after/throw-for-stale-auth.js
+++ b/packages/core/src/http-middlewares/after/throw-for-stale-auth.js
@@ -1,12 +1,13 @@
 'use strict';
 
+const { stripQueryFromURL } = require('../../tools/http');
+
 const errors = require('../../errors');
 
 const throwForStaleAuth = resp => {
   if (resp.status === 401) {
-    const message = `Got ${resp.status} calling ${resp.request.method} ${
-      resp.request.url
-    }, triggering auth refresh.`;
+    const cleanURL = stripQueryFromURL(resp.request.url);
+    const message = `Got ${resp.status} calling ${resp.request.method} ${cleanURL}, triggering auth refresh.`;
     throw new errors.RefreshAuthError(message);
   }
 

--- a/packages/core/src/http-middlewares/after/throw-for-status.js
+++ b/packages/core/src/http-middlewares/after/throw-for-status.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const { stripQueryFromURL } = require('../../tools/http');
+
 const throwForStatus = resp => {
   if (resp.status > 300) {
-    const message = `Got ${resp.status} calling ${resp.request.method} ${
-      resp.request.url
-    }, expected 2xx.`;
+    const cleanURL = stripQueryFromURL(resp.request.url);
+    const message = `Got ${resp.status} calling ${resp.request.method} ${cleanURL}, expected 2xx.`;
     throw new Error(message);
   }
 

--- a/packages/core/src/tools/http.js
+++ b/packages/core/src/tools/http.js
@@ -1,3 +1,5 @@
+const { URL } = require('url');
+
 const _ = require('lodash');
 const fetch = require('node-fetch');
 
@@ -28,7 +30,7 @@ const parseHttpList = s => {
   let part = '';
 
   let escape = false;
-    let quote = false;
+  let quote = false;
 
   for (let i = 0; i < s.length; i++) {
     const cur = s.charAt(i);
@@ -97,11 +99,18 @@ const parseDictHeader = s => {
 const unheader = h =>
   h instanceof fetch.Headers && _.isFunction(h.toJSON) ? h.toJSON() : h;
 
+const stripQueryFromURL = url => {
+  // Strip off querystring for any sensitive data
+  const u = new URL(url);
+  return u.origin + u.pathname;
+};
+
 module.exports = {
   FORM_TYPE,
   JSON_TYPE,
   JSON_TYPE_UTF8,
   getContentType,
   parseDictHeader,
+  stripQueryFromURL,
   unheader
 };


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

URL querystring may contain sensitive data so shouldn't be shown in the error message.

Fixes https://github.com/zapier/zapier/issues/32319.