### PR TITLE
fix(legacy-scripting-runner): add more jquery functions

### DIFF
--- a/example-apps/babel/package.json
+++ b/example-apps/babel/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "babel-polyfill": "6.26.0",
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/example-apps/basic-auth/package.json
+++ b/example-apps/basic-auth/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/create/package.json
+++ b/example-apps/create/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/custom-auth/package.json
+++ b/example-apps/custom-auth/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/digest-auth/package.json
+++ b/example-apps/digest-auth/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "7.6.1"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/dynamic-dropdown/package.json
+++ b/example-apps/dynamic-dropdown/package.json
@@ -14,7 +14,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "3.2.0",

--- a/example-apps/files/package.json
+++ b/example-apps/files/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "form-data": "2.1.4",
     "request": "2.81.0",
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/github/package.json
+++ b/example-apps/github/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/middleware/package.json
+++ b/example-apps/middleware/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "lodash": "4.17.11",
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/minimal/package.json
+++ b/example-apps/minimal/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/oauth1-trello/package.json
+++ b/example-apps/oauth1-trello/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/oauth1-tumblr/package.json
+++ b/example-apps/oauth1-tumblr/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0",
+    "zapier-platform-core": "8.4.1",
     "zapier-platform-schema": "7.4.0"
   },
   "devDependencies": {

--- a/example-apps/oauth1-twitter/package.json
+++ b/example-apps/oauth1-twitter/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0",
+    "zapier-platform-core": "8.4.1",
     "zapier-platform-schema": "7.4.0"
   },
   "devDependencies": {

--- a/example-apps/oauth2/package.json
+++ b/example-apps/oauth2/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/resource/package.json
+++ b/example-apps/resource/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/rest-hooks/package.json
+++ b/example-apps/rest-hooks/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/search-or-create/package.json
+++ b/example-apps/search-or-create/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/search/package.json
+++ b/example-apps/search/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/session-auth/package.json
+++ b/example-apps/session-auth/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/trigger/package.json
+++ b/example-apps/trigger/package.json
@@ -15,7 +15,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.3.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/example-apps/typescript/package.json
+++ b/example-apps/typescript/package.json
@@ -20,7 +20,7 @@
     "npm": ">=5.6.0"
   },
   "dependencies": {
-    "zapier-platform-core": "8.2.0"
+    "zapier-platform-core": "8.4.1"
   },
   "devDependencies": {
     "@types/mocha": "5.2.0",

--- a/packages/legacy-scripting-runner/$.js
+++ b/packages/legacy-scripting-runner/$.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const cheerio = require('cheerio');
 const xmldom = require('xmldom');
 
@@ -33,6 +34,23 @@ $.parseXML = data => {
   return xml;
 };
 
-$.parseJSON = json => JSON.parse(json);
+$.inArray = (elem, arr, i) => arr.indexOf(elem, i);
+$.isArray = Array.isArray;
+$.isEmptyObject = _.isEmpty;
+$.isFunction = _.isFunction;
+$.isNumeric = _.isNumber;
+$.isPlainObject = _.isPlainObject;
+$.parseJSON = JSON.parse;
+$.trim = _.trim;
+
+$.type = obj => {
+  if (obj == null) {
+    return obj + '';
+  }
+  if (Array.isArray(obj)) {
+    return 'array';
+  }
+  return typeof obj;
+};
 
 module.exports = $;

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "async": "2.6.1",
     "cheerio": "1.0.0-rc.2",
-    "deasync": "0.1.12",
+    "deasync": "0.1.15",
     "flat": "4.1.0",
     "jquery-param": "1.0.1",
     "lodash": "4.17.11",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -127,6 +127,16 @@ const legacyScriptingSource = `
         contacts[0].jqueryText = $('<div>jQuery works!</div>').text();
         contacts[0].jqueryParam = $.param({width: 1680, height: 1050});
         contacts[0].randomJson = $.parseJSON('{"hey":1}');
+
+        contacts[0].inArray = $.inArray('a', ['a', 'b', 'b', 'a'], 2);
+        contacts[0].isArray = $.isArray(contacts);
+        contacts[0].isEmptyObject = $.isEmptyObject(contacts);
+        contacts[0].isFunction = $.isFunction(function() {});
+        contacts[0].isNumeric = $.isNumeric(123);
+        contacts[0].isPlainObject = $.isPlainObject(contacts);
+        contacts[0].trimmed = $.trim(' hello world  ');
+        contacts[0].type = $.type(contacts);
+
         return contacts;
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -556,6 +556,15 @@ describe('Integration Test', () => {
         should.equal(firstContact.jqueryText, 'jQuery works!');
         should.equal(firstContact.jqueryParam, 'width=1680&height=1050');
         should.deepEqual(firstContact.randomJson, { hey: 1 });
+
+        should.equal(firstContact.inArray, 3);
+        firstContact.isArray.should.be.true();
+        firstContact.isEmptyObject.should.be.false();
+        firstContact.isFunction.should.be.true();
+        firstContact.isNumeric.should.be.true();
+        firstContact.isPlainObject.should.be.false();
+        should.equal(firstContact.trimmed, 'hello world');
+        should.equal(firstContact.type, 'array');
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,13 +3537,13 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-deasync@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.12.tgz#0159492a4133ab301d6c778cf01e74e63b10e549"
-  integrity sha512-gpacYo8FBZh3INBp2KOtrQp9kCO5faHvOmEZx3/cZTr3Mm8/kAYs7/Ws3E3OAH0ApBNK6Y6N+7+Dka2Zn2Fldw==
+deasync@0.1.15:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.15.tgz#788c4bbe6d32521233b28d23936de1bbadd2e112"
+  integrity sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==
   dependencies:
     bindings "~1.2.1"
-    nan "^2.0.7"
+    node-addon-api "^1.6.0"
 
 debug@2.2.0:
   version "2.2.0"
@@ -7685,7 +7685,7 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.0.7, nan@^2.12.1:
+nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -7766,6 +7766,11 @@ nock@10.0.6:
     propagate "^1.0.0"
     qs "^6.5.1"
     semver "^5.5.0"
+
+node-addon-api@^1.6.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
+  integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
 
 node-environment-flags@1.0.5:
   version "1.0.5"
@@ -11100,7 +11105,7 @@ zapier-platform-core@2.2.0:
     node-fetch "1.7.1"
     zapier-platform-schema "2.2.0"
 
-zapier-platform-core@7.6.1, zapier-platform-core@^7.6.0:
+zapier-platform-core@^7.6.0:
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/zapier-platform-core/-/zapier-platform-core-7.6.1.tgz#0219bf35ae5f725fdc8d74e6732af588561ea4ab"
   integrity sha512-qJQBNRqqGIBqz6bQqPMdHfC9y2zqz8XaW12M/IcJxf2bNr6OeaQXo6EG5mJxRevrnCwUUZA3gkuSBcZh5Lj7/Q==
@@ -11114,23 +11119,6 @@ zapier-platform-core@7.6.1, zapier-platform-core@^7.6.0:
     oauth-sign "0.9.0"
     semver "5.6.0"
     zapier-platform-schema "7.6.1"
-  optionalDependencies:
-    "@types/node" "8.10.20"
-
-zapier-platform-core@8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/zapier-platform-core/-/zapier-platform-core-8.2.0.tgz#f6d8a1320c1ed76387189a2e8fe15870744eb3f8"
-  integrity sha512-D0YQiDYFj6n5Yr+GHokhgCXxnLpeKCM3N25/dt9NVMALxxvO/zs3Sr0KhTH6xamoHHkBLo69GKmECugaAF/M8Q==
-  dependencies:
-    bluebird "3.5.0"
-    content-disposition "0.5.2"
-    dotenv "5.0.1"
-    form-data "2.3.2"
-    lodash "4.17.11"
-    node-fetch "1.7.1"
-    oauth-sign "0.9.0"
-    semver "5.6.0"
-    zapier-platform-schema "8.2.0"
   optionalDependencies:
     "@types/node" "8.10.20"
 
@@ -11157,14 +11145,6 @@ zapier-platform-schema@7.6.1:
   dependencies:
     jsonschema "1.1.1"
     lodash "4.17.10"
-
-zapier-platform-schema@8.2.1:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/zapier-platform-schema/-/zapier-platform-schema-8.2.1.tgz#1dcd38552ecced57022c39ca8d48d4b0004306de"
-  integrity sha512-8UFheE2KV4BzwDr1RKvsmSxtrc0jumLxxN+7yMm6lxfFKDITPTyfMlcg4SWuAEzbdC9jrZD7IFn8oX45i95J2w==
-  dependencies:
-    jsonschema "1.1.1"
-    lodash "4.17.11"
 
 zip-stream@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Adds support for more jQuery functions.

Also updates yarn.lock and core versions for example apps.