### PR TITLE
fix(schema) be a little more permissive with mutually exclusive fields

### DIFF
--- a/packages/schema/lib/constants.js
+++ b/packages/schema/lib/constants.js
@@ -16,5 +16,6 @@ module.exports = {
     ['dict', 'list'], // Use only one or the other
     ['dynamic', 'dict'], // dict is ignored
     ['dynamic', 'choices'] // choices are ignored
-  ]
+  ],
+  FIELD_SCHEMA_BOOLEANS: new Set(['dict', 'list'])
 };

--- a/packages/schema/test/functional-constraints/mutuallyExclusiveFields.js
+++ b/packages/schema/test/functional-constraints/mutuallyExclusiveFields.js
@@ -79,6 +79,42 @@ describe('mutuallyExclusiveFields', () => {
     );
   });
 
+  it('should not error on fields that have children and list when list is false', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...'
+          },
+          operation: {
+            perform: '$func$2$f$',
+            sample: { id: 1 },
+            inputFields: [
+              { key: 'orderId', type: 'number' },
+              {
+                key: 'line_items',
+                children: [
+                  {
+                    key: 'product'
+                  }
+                ],
+                list: false
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(0);
+  });
+
   it('should error on fields that have list and dict', () => {
     const definition = {
       version: '1.0.0',
@@ -151,6 +187,42 @@ describe('mutuallyExclusiveFields', () => {
     results.errors[0].stack.should.eql(
       "instance.creates.foo.inputFields[0] must not contain dynamic and dict, as they're mutually exclusive."
     );
+  });
+
+  it('should not error on fields that have dynamic and dict when dict is false', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...'
+          },
+          operation: {
+            perform: '$func$2$f$',
+            sample: { id: 1 },
+            inputFields: [
+              {
+                key: 'orderId',
+                type: 'number',
+                dynamic: 'foo.id.number',
+                dict: false
+              },
+              {
+                key: 'line_items',
+                list: true
+              }
+            ]
+          }
+        }
+      }
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(0);
   });
 
   it('should error on fields that have dynamic and choices', () => {


### PR DESCRIPTION
As part of https://github.com/zapier/zapier/pull/32518, I noticed that the frontend could get into a bad state where it was sending `{dict: false, list: false}` and schema was complaining that those were mutually exclusive. 

We can be a little more permissive here- it's only bad if they're truthy. My one unknown is that I'm not sure how the editor reads these values. If it also uses `_.has`, then this will cause weird behavior. @stevelikesmusic that's what I wanted to loop you in on if you could double check.