### PR TITLE
fix(legacy-scripting-runner): clean headers like legacy WB

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -197,6 +197,23 @@ const replaceCurliesInRequest = (request, bundle) => {
 const undoSmartCurlyReplacement = str =>
   str.replace(/{{\s*bundle\.[^.]+\.([^}\s]+)\s*}}/g, '{{$1}}');
 
+const cleanHeaders = headers => {
+  const newHeaders = {};
+  const badChars = /[\r\n\t]/g;
+  _.each(headers, (v, k) => {
+    if (k) {
+      k = k.replace(badChars, '').trim();
+    }
+    if (k) {
+      if (v) {
+        v = v.replace(badChars, '').trim();
+      }
+      newHeaders[k] = v;
+    }
+  });
+  return newHeaders;
+};
+
 const compileLegacyScriptingSource = (source, zcli, app) => {
   const { DOMParser, XMLSerializer } = require('xmldom');
   const {
@@ -585,6 +602,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         // Runs only when there's no KEY_pre_ method
         await addFilesToRequestBodyFromBody(request, bundle);
       }
+
+      request.headers = cleanHeaders(request.headers);
 
       const response = await zcli.request(request);
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -195,6 +195,12 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_invalid_chars_in_headers: function(bundle) {
+        bundle.request.headers['x-api-key'] = ' \\t\\n\\r H\\t E \\nY \\r\\n\\t ';
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -542,6 +542,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, invalid chars in headers', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_invalid_chars_in_headers',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then(output => {
+        const echoed = output.results[0];
+        should.equal(echoed.headers['X-Api-Key'], 'H E Y');
+      });
+    });
+
     it('KEY_post_poll, with jQuery', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

legacy-scripting-runner should clean headers just as Web Builder [does it](https://github.com/zapier/zapier/blob/0b95996f00238b3e092547a1478e4dc23972c5de/web/backend/zapier/useful/request_extras.py#L505).