### PR TITLE
fix(legacy-scripting-runner): fix curly replacement

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -193,10 +193,6 @@ const replaceCurliesInRequest = (request, bundle) => {
   return cleaner.recurseReplaceBank(request, bank);
 };
 
-// Replace '{{bundle.inputData.abc}}' with '{{abc}}'
-const undoSmartCurlyReplacement = str =>
-  str.replace(/{{\s*bundle\.[^.]+\.([^}\s]+)\s*}}/g, '{{$1}}');
-
 const cleanHeaders = headers => {
   const newHeaders = {};
   const badChars = /[\r\n\t]/g;
@@ -763,7 +759,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     }
 
     if (url) {
-      bundle._legacyUrl = undoSmartCurlyReplacement(url);
+      bundle._legacyUrl = url;
     }
 
     let result = await runEventCombo(
@@ -901,7 +897,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       bundle.request.url = url;
 
       // Provide bundle.raw_url and bundle.url_raw
-      bundle._legacyUrl = undoSmartCurlyReplacement(url);
+      bundle._legacyUrl = url;
     }
 
     if (supportFullMethod) {
@@ -959,7 +955,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     bundle.request.body = body;
 
     if (url) {
-      bundle._legacyUrl = undoSmartCurlyReplacement(url);
+      bundle._legacyUrl = url;
     }
 
     return runEventCombo(
@@ -994,7 +990,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     bundle.request.url = url;
 
     if (url) {
-      bundle._legacyUrl = undoSmartCurlyReplacement(url);
+      bundle._legacyUrl = url;
     }
 
     return runEventCombo(

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -221,6 +221,13 @@ const legacyScriptingSource = `
         return [z.JSON.parse(response.content)];
       },
 
+      recipe_pre_poll_underscore_template: function(bundle) {
+        bundle.request.url = _.template(bundle.request.url, {
+          urlPath: '/recipes'
+        });
+        return bundle.request;
+      },
+
       /*
        * Hook Trigger
        */
@@ -858,6 +865,18 @@ const MovieTrigger = {
   }
 };
 
+const RecipeTrigger = {
+  key: 'recipe',
+  display: {
+    label: 'New Recipe'
+  },
+  operation: {
+    perform: {
+      source: "return z.legacyScripting.run(bundle, 'trigger', 'recipe');"
+    }
+  }
+};
+
 const MovieCreate = {
   key: 'movie',
   noun: 'Movie',
@@ -992,7 +1011,8 @@ const App = {
     [contactHookScriptingless.key]: contactHookScriptingless,
     [contactHookScripting.key]: contactHookScripting,
     [TestTrigger.key]: TestTrigger,
-    [MovieTrigger.key]: MovieTrigger
+    [MovieTrigger.key]: MovieTrigger,
+    [RecipeTrigger.key]: RecipeTrigger
   },
   creates: {
     [MovieCreate.key]: MovieCreate,
@@ -1053,6 +1073,12 @@ const App = {
       movie: {
         operation: {
           url: `${AUTH_JSON_SERVER_URL}/movies`
+        }
+      },
+      recipe: {
+        operation: {
+          url: `${AUTH_JSON_SERVER_URL}{{bundle.inputData.urlPath}}`,
+          outputFieldsUrl: `${AUTH_JSON_SERVER_URL}{{bundle.inputData.urlPath}}`
         }
       }
     },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -565,6 +565,27 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, _.template(bundle.request.url)', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'recipe_pre_poll_underscore_template',
+        'recipe_pre_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.recipe.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then(output => {
+        const firstRecipe = output.results[0];
+        should.equal(firstRecipe.name, 'name 1');
+      });
+    });
+
     it('KEY_post_poll, with jQuery', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

We replace `{{var}}` in URLs with `{{bundle.authData.var}}` or `{{bundle.inputData.var}}` when converting a WB app. This breaks developers' scripting code if they assume `{{var}}` is still in URLs. To fix, we should undo the replacement before passing the bundle to developers' scripting code.