### PR TITLE
docs(core,schema) update changelog.md links to point to zapier-platform repository

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,3 @@
-Read docs: https://zapier.github.io/zapier-platform-cli/.
+Read docs: https://zapier.github.io/zapier-platform/.
 
-Changelog: https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md
+Changelog: https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -1,3 +1,3 @@
-Read docs: https://zapier.github.io/zapier-platform-cli/.
+Read docs: https://zapier.github.io/zapier-platform/.
 
-Changelog: https://github.com/zapier/zapier-platform-cli/blob/master/CHANGELOG.md
+Changelog: https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

update links in changelog.md for core and schema to platform repository (archived cli repository has changelog up to 8.2.1)