### PR TITLE
fix(cli) Run validation during build against `/check` endpoint

### DIFF
--- a/packages/cli/src/oclif/commands/validate.js
+++ b/packages/cli/src/oclif/commands/validate.js
@@ -14,7 +14,7 @@ class ValidateCommand extends BaseCommand {
     const errors = await localAppCommand({ command: 'validate' });
 
     const newErrors = errors.map(error => ({
-      error,
+      ...error,
       property: error.property.replace(/^instance/, 'App'),
       docLinks: (error.docLinks || []).join('\n')
     }));

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -202,11 +202,11 @@ const getLinkedApp = appDir => {
         console.error(e);
       }
       throw new Error(
-        `Unable to complete that operation. Either: your auth file is stale (run \`${colors.cyan(
-          'zapier login'
-        )}\`) or your ${
-          constants.CURRENT_APP_FILE
-        } points to an app you can't access (run \`${colors.cyan(
+        `Unable to complete that operation. Either:
+  * your auth file is stale (run \`${colors.cyan('zapier login')}\`)
+  * your ${
+    constants.CURRENT_APP_FILE
+  } points to an app you can't access (run \`${colors.cyan(
           'zapier link'
         )}\` to refresh the link to an existing app or \`${colors.cyan(
           'zapier register'

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -31,7 +31,7 @@ const {
   getLinkedAppConfig,
   checkCredentials,
   upload: _uploadFunc,
-  callAPI
+  validateApp
 } = require('./api');
 
 const { runCommand, isWindows } = require('./misc');
@@ -382,15 +382,14 @@ const _buildFunc = async ({
 
   // No need to mention specifically we're validating style checks as that's
   //   implied from `zapier validate`, though it happens as a separate process
-  const styleChecksResponse = await callAPI('/style-check', {
-    skipDeployKey: true,
-    method: 'POST',
-    body: rawDefinition
-  });
+  const styleChecksResponse = await validateApp(rawDefinition);
 
-  const styleErrors = styleChecksResponse.errors;
-  if (!_.isEmpty(styleErrors)) {
-    debug('\nErrors:\n', styleErrors, '\n');
+  if (_.get(styleChecksResponse, ['errors', 'total_failures'])) {
+    debug(
+      '\nErrors:\n',
+      prettyJSONstringify(styleChecksResponse.errors.results),
+      '\n'
+    );
     throw new Error(
       'We hit some style validation errors, try running `zapier validate` to see them!'
     );


### PR DESCRIPTION
We were still using `/style-check` for the api call that happens during the `build` validation step. We should combine these at some point, but for now it's ok. 