### PR TITLE
 docs(cli) fix double `App.App.` in unit test snippet

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4071,7 +4071,7 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
 
       <span class="hljs-comment">// Pass appTester the path to the trigger you want to call,</span>
       <span class="hljs-comment">// and the input bundle. appTester returns a promise for results.</span>
-      appTester(App.App.triggers.recipe.operation.perform, bundle)
+      appTester(App.triggers.recipe.operation.perform, bundle)
         .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
           <span class="hljs-comment">// Make assertions</span>
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2444,7 +2444,7 @@ describe('triggers', () => {
 
       // Pass appTester the path to the trigger you want to call,
       // and the input bundle. appTester returns a promise for results.
-      appTester(App.App.triggers.recipe.operation.perform, bundle)
+      appTester(App.triggers.recipe.operation.perform, bundle)
         .then(results => {
           // Make assertions
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -4071,7 +4071,7 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
 
       <span class="hljs-comment">// Pass appTester the path to the trigger you want to call,</span>
       <span class="hljs-comment">// and the input bundle. appTester returns a promise for results.</span>
-      appTester(App.App.triggers.recipe.operation.perform, bundle)
+      appTester(App.triggers.recipe.operation.perform, bundle)
         .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
           <span class="hljs-comment">// Make assertions</span>
 

--- a/packages/cli/snippets/mocha-test.js
+++ b/packages/cli/snippets/mocha-test.js
@@ -20,7 +20,7 @@ describe('triggers', () => {
 
       // Pass appTester the path to the trigger you want to call,
       // and the input bundle. appTester returns a promise for results.
-      appTester(App.App.triggers.recipe.operation.perform, bundle)
+      appTester(App.triggers.recipe.operation.perform, bundle)
         .then(results => {
           // Make assertions
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
