### PR TITLE
fix(legacy-scripting-runner): allow legacy actions to return non-json data

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -616,9 +616,19 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       bundle.request = request;
 
       const postMethod = postMethodName ? Zap[postMethodName] : null;
-      result = postMethod
-        ? await runEvent({ key, name: postEventName, response }, zcli, bundle)
-        : zcli.JSON.parse(response.content);
+      if (postMethod) {
+        result = await runEvent(
+          { key, name: postEventName, response },
+          zcli,
+          bundle
+        );
+      } else {
+        try {
+          result = zcli.JSON.parse(response.content);
+        } catch {
+          result = {};
+        }
+      }
     }
 
     result = ensureIsType(result, options.ensureType);

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -445,6 +445,11 @@ const legacyScriptingSource = `
         };
       },
 
+      movie_pre_write_no_content: function(bundle) {
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/status/204';
+        return bundle.request;
+      },
+
       movie_write_default_headers: function(bundle) {
         bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
         bundle.request.data = z.JSON.stringify({

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1496,6 +1496,25 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_write, no content', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'movie_pre_write_no_content',
+        'movie_pre_write'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then(output => {
+        should.deepEqual(output.results, {});
+      });
+    });
+
     it('KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.url += 's';


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes an issue where we allow an action URL to return `204 no content` or a non-JSON data in the legacy platform.