### PR TITLE
feat(legacy-scripting-runner): support for dynamic OAuth client ID and secret

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -39,7 +39,11 @@ const {
   isFileField,
   LazyFile
 } = require('./file');
-const middlewareFactory = require('./middleware-factory');
+const {
+  createBeforeRequest,
+  createAfterResponse,
+  renderTemplate
+} = require('./middleware-factory');
 
 const FIELD_TYPE_CONVERT_MAP = {
   // field_type_in_wb: field_type_in_cli
@@ -650,23 +654,94 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       app,
       'legacy.authentication.oauth1Config.requestTokenUrl'
     );
+
+    const templateContext = Object.assign(
+      {},
+      bundle.authData,
+      bundle.inputData
+    );
+    const consumerKey = renderTemplate(process.env.CLIENT_ID, templateContext);
+    const consumerSecret = renderTemplate(
+      process.env.CLIENT_SECRET,
+      templateContext
+    );
+
     return fetchOAuth1Token(url, {
-      oauth_consumer_key: process.env.CLIENT_ID,
-      oauth_consumer_secret: process.env.CLIENT_SECRET,
+      oauth_consumer_key: consumerKey,
+      oauth_consumer_secret: consumerSecret,
       oauth_signature_method: 'HMAC-SHA1',
       oauth_callback: bundle.inputData.redirect_uri
     });
   };
 
+  const runOAuth1AuthorizeUrl = bundle => {
+    let url = _.get(app, 'legacy.authentication.oauth1Config.authorizeUrl');
+    if (!url) {
+      return '';
+    }
+
+    url = replaceCurliesInRequest({ url }, bundle).url;
+    const urlObj = new URL(url);
+
+    if (!urlObj.searchParams.has('oauth_token')) {
+      urlObj.searchParams.set('oauth_token', bundle.inputData.oauth_token);
+    }
+
+    return urlObj.href;
+  };
+
   const runOAuth1GetAccessToken = bundle => {
     const url = _.get(app, 'legacy.authentication.oauth1Config.accessTokenUrl');
+
+    const templateContext = Object.assign(
+      {},
+      bundle.authData,
+      bundle.inputData
+    );
+    const consumerKey = renderTemplate(process.env.CLIENT_ID, templateContext);
+    const consumerSecret = renderTemplate(
+      process.env.CLIENT_SECRET,
+      templateContext
+    );
+
     return fetchOAuth1Token(url, {
-      oauth_consumer_key: process.env.CLIENT_ID,
-      oauth_consumer_secret: process.env.CLIENT_SECRET,
+      oauth_consumer_key: consumerKey,
+      oauth_consumer_secret: consumerSecret,
       oauth_token: bundle.inputData.oauth_token,
       oauth_token_secret: bundle.inputData.oauth_token_secret,
       oauth_verifier: bundle.inputData.oauth_verifier
     });
+  };
+
+  const runOAuth2AuthorizeUrl = bundle => {
+    let url = _.get(app, 'legacy.authentication.oauth2Config.authorizeUrl');
+    if (!url) {
+      return '';
+    }
+
+    url = replaceCurliesInRequest({ url }, bundle).url;
+    const urlObj = new URL(url);
+
+    if (!urlObj.searchParams.has('client_id')) {
+      const templateContext = Object.assign(
+        {},
+        bundle.authData,
+        bundle.inputData
+      );
+      const clientId = renderTemplate(process.env.CLIENT_ID, templateContext);
+      urlObj.searchParams.set('client_id', clientId);
+    }
+    if (!urlObj.searchParams.has('redirect_uri')) {
+      urlObj.searchParams.set('redirect_uri', bundle.inputData.redirect_uri);
+    }
+    if (!urlObj.searchParams.has('response_type')) {
+      urlObj.searchParams.set('response_type', 'code');
+    }
+    if (!urlObj.searchParams.has('state')) {
+      urlObj.searchParams.set('state', bundle.inputData.state);
+    }
+
+    return urlObj.href;
   };
 
   const runOAuth2GetAccessToken = bundle => {
@@ -677,12 +752,23 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     request.url = url;
     request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
+    const templateContext = Object.assign(
+      {},
+      bundle.authData,
+      bundle.inputData
+    );
+    const clientId = renderTemplate(process.env.CLIENT_ID, templateContext);
+    const clientSecret = renderTemplate(
+      process.env.CLIENT_SECRET,
+      templateContext
+    );
+
     // Try two ways to get the token: POST with parameters in a form-encoded body. If
     // that returns a 4xx, retry a POST with parameters in querystring.
     const body = request.body;
     body.code = bundle.inputData.code;
-    body.client_id = process.env.CLIENT_ID;
-    body.client_secret = process.env.CLIENT_SECRET;
+    body.client_id = clientId;
+    body.client_secret = clientSecret;
     body.redirect_uri = bundle.inputData.redirect_uri;
     body.grant_type = 'authorization_code';
 
@@ -697,8 +783,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
       const params = request.params;
       params.code = bundle.inputData.code;
-      params.client_id = process.env.CLIENT_ID;
-      params.client_secret = process.env.CLIENT_SECRET;
+      params.client_id = clientId;
+      params.client_secret = clientSecret;
       params.redirect_uri = bundle.inputData.redirect_uri;
       params.grant_type = 'authorization_code';
 
@@ -722,9 +808,20 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     request.url = url;
     request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
+    const templateContext = Object.assign(
+      {},
+      bundle.authData,
+      bundle.inputData
+    );
+    const clientId = renderTemplate(process.env.CLIENT_ID, templateContext);
+    const clientSecret = renderTemplate(
+      process.env.CLIENT_SECRET,
+      templateContext
+    );
+
     const body = request.body;
-    body.client_id = process.env.CLIENT_ID;
-    body.client_secret = process.env.CLIENT_SECRET;
+    body.client_id = clientId;
+    body.client_secret = clientSecret;
     body.refresh_token = bundle.authData.refresh_token;
     body.grant_type = 'refresh_token';
 
@@ -733,8 +830,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       request.body = {};
 
       const params = request.params;
-      params.client_id = process.env.CLIENT_ID;
-      params.client_secret = process.env.CLIENT_SECRET;
+      params.client_id = clientId;
+      params.client_secret = clientSecret;
       params.refresh_token = bundle.authData.refresh_token;
       params.grant_type = 'refresh_token';
 
@@ -1098,8 +1195,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         return runEvent({ name: 'auth.connectionLabel' }, zcli, bundle);
       case 'auth.oauth1.requestToken':
         return runOAuth1GetRequestToken(bundle);
+      case 'auth.oauth1.authorize':
+        return runOAuth1AuthorizeUrl(bundle);
       case 'auth.oauth1.accessToken':
         return runOAuth1GetAccessToken(bundle);
+      case 'auth.oauth2.authorize':
+        return runOAuth2AuthorizeUrl(bundle);
       case 'auth.oauth2.token':
         return runOAuth2GetAccessToken(bundle);
       case 'auth.oauth2.refresh':
@@ -1139,8 +1240,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
   // Dynamically generate http middlewares based on auth config. The generated
   // middleware could be a no-op if the auth doesn't require a middleware.
-  const beforeRequest = middlewareFactory.createBeforeRequest(app);
-  const afterResponse = middlewareFactory.createAfterResponse(app);
+  const beforeRequest = createBeforeRequest(app);
+  const afterResponse = createAfterResponse(app);
 
   return {
     afterResponse,

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -352,7 +352,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     const options = {
       interpolate: /{{([\s\S]+?)}}/g
     };
-    const values = _.extend({}, bundle.authData, bundle.inputData, result);
+    const values = { ...bundle.authData, ...bundle.inputData, ...result };
     return _.template(templateString, options)(values);
   };
 
@@ -410,7 +410,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
           data[i][j] = textifyList(data[i][j]);
         } else if (_.isPlainObject(data[i][j])) {
           const flattened = flattenDictionary(j, data[i][j]);
-          data[i] = Object.assign(data[i], flattened);
+          data[i] = { ...data[i], ...flattened };
           delete data[i][j];
         }
       }
@@ -535,30 +535,28 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     fullEventName,
     options
   ) => {
-    options = _.extend(
-      {
-        // Options to deal with the final result returned by this function.
-        // * checkResponseStatus: throws an error if response status is not 2xx.
-        // * parseResponse:
-        //     assumes response content is JSON and parse it. post method won't
-        //     run if this is false.
-        // * ensureType: ensures the result type. Could be one of the following values:
-        //   - false:
-        //       returns whatever data parsed from response content or returned
-        //       by the post method.
-        //   - 'array-wrap': returns [result] if result is an object.
-        //   - 'array-first':
-        //       returns the first top-level array in the result if result
-        //       is an object.
-        //   - 'object-first': returns the first object if result is an array.
-        checkResponseStatus: true,
-        parseResponse: true,
-        ensureType: false,
+    options = {
+      // Options to deal with the final result returned by this function.
+      // * checkResponseStatus: throws an error if response status is not 2xx.
+      // * parseResponse:
+      //     assumes response content is JSON and parse it. post method won't
+      //     run if this is false.
+      // * ensureType: ensures the result type. Could be one of the following values:
+      //   - false:
+      //       returns whatever data parsed from response content or returned
+      //       by the post method.
+      //   - 'array-wrap': returns [result] if result is an object.
+      //   - 'array-first':
+      //       returns the first top-level array in the result if result
+      //       is an object.
+      //   - 'object-first': returns the first object if result is an array.
+      checkResponseStatus: true,
+      parseResponse: true,
+      ensureType: false,
+      resetRequestForFullMethod: false,
 
-        resetRequestForFullMethod: false
-      },
-      options
-    );
+      ...options
+    };
 
     if (bundle.request) {
       bundle.request = replaceCurliesInRequest(bundle.request, bundle);
@@ -584,10 +582,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     if (fullMethod) {
       if (options.resetRequestForFullMethod) {
         // Used by custom fields
-        _.extend(bundle.request, {
-          method: 'GET',
-          url: ''
-        });
+        bundle.request = { ...bundle.request, method: 'GET', url: '' };
       }
 
       // Running "full" scripting method like KEY_poll
@@ -597,7 +592,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       let request = preMethod
         ? await runEvent({ key, name: preEventName }, zcli, bundle)
         : {};
-      request = Object.assign({}, bundle.request, request);
+      request = { ...bundle.request, ...request };
 
       const isBodyStream = typeof _.get(request, 'body.pipe') === 'function';
       if (hasFileFields(bundle) && !isBodyStream) {
@@ -655,11 +650,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       'legacy.authentication.oauth1Config.requestTokenUrl'
     );
 
-    const templateContext = Object.assign(
-      {},
-      bundle.authData,
-      bundle.inputData
-    );
+    const templateContext = { ...bundle.authData, ...bundle.inputData };
     const consumerKey = renderTemplate(process.env.CLIENT_ID, templateContext);
     const consumerSecret = renderTemplate(
       process.env.CLIENT_SECRET,
@@ -693,11 +684,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   const runOAuth1GetAccessToken = bundle => {
     const url = _.get(app, 'legacy.authentication.oauth1Config.accessTokenUrl');
 
-    const templateContext = Object.assign(
-      {},
-      bundle.authData,
-      bundle.inputData
-    );
+    const templateContext = { ...bundle.authData, ...bundle.inputData };
     const consumerKey = renderTemplate(process.env.CLIENT_ID, templateContext);
     const consumerSecret = renderTemplate(
       process.env.CLIENT_SECRET,
@@ -723,11 +710,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     const urlObj = new URL(url);
 
     if (!urlObj.searchParams.has('client_id')) {
-      const templateContext = Object.assign(
-        {},
-        bundle.authData,
-        bundle.inputData
-      );
+      const templateContext = { ...bundle.authData, ...bundle.inputData };
       const clientId = renderTemplate(process.env.CLIENT_ID, templateContext);
       urlObj.searchParams.set('client_id', clientId);
     }
@@ -752,11 +735,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     request.url = url;
     request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
-    const templateContext = Object.assign(
-      {},
-      bundle.authData,
-      bundle.inputData
-    );
+    const templateContext = { ...bundle.authData, ...bundle.inputData };
     const clientId = renderTemplate(process.env.CLIENT_ID, templateContext);
     const clientSecret = renderTemplate(
       process.env.CLIENT_SECRET,
@@ -808,11 +787,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     request.url = url;
     request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
-    const templateContext = Object.assign(
-      {},
-      bundle.authData,
-      bundle.inputData
-    );
+    const templateContext = { ...bundle.authData, ...bundle.inputData };
     const clientId = renderTemplate(process.env.CLIENT_ID, templateContext);
     const clientSecret = renderTemplate(
       process.env.CLIENT_SECRET,

--- a/packages/legacy-scripting-runner/middleware-factory.js
+++ b/packages/legacy-scripting-runner/middleware-factory.js
@@ -138,10 +138,30 @@ const createBeforeRequest = app => {
       bundle.authData.oauth_token_secret
     ) {
       req.auth = req.auth || {};
-      req.auth.oauth_consumer_key =
-        req.auth.oauth_consumer_key || process.env.CLIENT_ID;
-      req.auth.oauth_consumer_secret =
-        req.auth.oauth_consumer_secret || process.env.CLIENT_SECRET;
+
+      let templateContext;
+
+      if (!req.auth.oauth_consumer_key) {
+        templateContext = Object.assign({}, bundle.authData, bundle.inputData);
+        req.auth.oauth_consumer_key = renderTemplate(
+          process.env.CLIENT_ID,
+          templateContext
+        );
+      }
+      if (!req.auth.oauth_consumer_secret) {
+        if (!templateContext) {
+          templateContext = Object.assign(
+            {},
+            bundle.authData,
+            bundle.inputData
+          );
+        }
+        req.auth.oauth_consumer_secret = renderTemplate(
+          process.env.CLIENT_SECRET,
+          templateContext
+        );
+      }
+
       req.auth.oauth_token =
         req.auth.oauth_token || bundle.authData.oauth_token;
       req.auth.oauth_token_secret =
@@ -205,5 +225,6 @@ const createAfterResponse = app => {
 
 module.exports = {
   createBeforeRequest,
-  createAfterResponse
+  createAfterResponse,
+  renderTemplate
 };

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -1056,6 +1056,8 @@ const App = {
 
     authentication: {
       oauth2Config: {
+        authorizeUrl: `${AUTH_JSON_SERVER_URL}/oauth/authorize`,
+
         // Incomplete URLs on purpose to test pre_oauthv2_token
         accessTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/access-`,
         refreshTokenUrl: `${AUTH_JSON_SERVER_URL}/oauth/refresh-`

--- a/packages/legacy-scripting-runner/test/example-app/oauth2.js
+++ b/packages/legacy-scripting-runner/test/example-app/oauth2.js
@@ -12,6 +12,10 @@ const testAuthSource = `
   });
 `;
 
+const getAuthorizeUrlSource = `
+  return z.legacyScripting.run(bundle, 'auth.oauth2.authorize');
+`;
+
 const getAccessTokenSource = `
   return z.legacyScripting.run(bundle, 'auth.oauth2.token');
 `;
@@ -46,14 +50,7 @@ module.exports = {
     ],
     oauth2Config: {
       authorizeUrl: {
-        method: 'GET',
-        url: `${AUTH_JSON_SERVER_URL}/oauth/authorize`,
-        params: {
-          client_id: '{{process.env.CLIENT_ID}}',
-          state: '{{bundle.inputData.state}}',
-          redirect_uri: '{{bundle.inputData.redirect_uri}}',
-          response_type: 'code'
-        }
+        source: getAuthorizeUrlSource
       },
       getAccessToken: {
         source: getAccessTokenSource

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -139,6 +139,33 @@ describe('Integration Test', () => {
       process.env = origEnv;
     });
 
+    it('oauth2 authorizeUrl, dynamic client id', () => {
+      process.env.CLIENT_ID = '{{my_client_id}}';
+      process.env.CLIENT_SECRET = '{{my_client_secret}}';
+
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.authorizeUrl'
+      );
+      input.bundle.inputData = {
+        my_client_id: '1234',
+        redirect_uri: 'https://example.com',
+        state: 'qwerty'
+      };
+      return app(input).then(output => {
+        should.equal(
+          output.results,
+          `${AUTH_JSON_SERVER_URL}/oauth/authorize?` +
+            'client_id=1234&redirect_uri=https%3A%2F%2Fexample.com&' +
+            'response_type=code&state=qwerty'
+        );
+      });
+    });
+
     it('pre_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Legacy Web Builder apps can use placeholders like `{{client_id}}` and `{{client_secret}}` for their OAuth2 client ID and secret to allow users to fill in their own values. This PR enables converted apps to do that too.

Note: WB doesn't have this ability for OAuth1. But since it's easy, I also added the feature for OAuth1 in this PR on the way.

Works with https://github.com/zapier/zapier/pull/34255.