### PR TITLE
fix(cli): allow Node version >= 10 in package.json generated by `zapier convert`

### DIFF
--- a/packages/cli/scaffold/convert/package.template.json
+++ b/packages/cli/scaffold/convert/package.template.json
@@ -7,7 +7,7 @@
     "test": "mocha --recursive -t 10000"
   },
   "engines": {
-    "node": "8.10.0",
+    "node": ">=8.10.0",
     "npm": ">=5.6.0"
   },
   "dependencies": {

--- a/packages/cli/scaffold/convert/package.template.json
+++ b/packages/cli/scaffold/convert/package.template.json
@@ -7,7 +7,7 @@
     "test": "mocha --recursive -t 10000"
   },
   "engines": {
-    "node": ">=8.10.0",
+    "node": ">=10",
     "npm": ">=5.6.0"
   },
   "dependencies": {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Originally `zapier convert` generates a `package.json` that pinpoints Node version to 8.10, which creates a minor inconvenience because developers need to manually edit`package.json` to fix it. This PR saves that trouble.