### PR TITLE
fix(core) use NodeJS ReadableStream instead of DOM in TS definitions

### DIFF
--- a/example-apps/typescript/tsconfig.json
+++ b/example-apps/typescript/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2018",
     "module": "commonjs",
+    "lib": [
+      "es2018"
+    ],
     "outDir": "./lib",
     "rootDir": "./src",
     "strict": true

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -68,7 +68,7 @@ declare class RefreshAuthError extends Error {}
 // copied http stuff from external typings
 export interface HttpRequestOptions {
   agent?: Agent;
-  body?: string | Buffer | ReadableStream | object;
+  body?: string | Buffer | NodeJS.ReadableStream | object;
   compress?: boolean;
   follow?: number;
   form?: object;
@@ -103,7 +103,7 @@ export interface HttpResponse extends BaseHttpResponse {
 export interface RawHttpResponse extends BaseHttpResponse {
   content: Buffer;
   json: Promise<object | undefined>;
-  body: ReadableStream;
+  body: NodeJS.ReadableStream;
 }
 
 export interface ZObject {
@@ -138,7 +138,7 @@ export interface ZObject {
    */
   stashFile: {
     (
-      input: string | Buffer | ReadableStream,
+      input: string | Buffer | NodeJS.ReadableStream,
       knownLength?: number,
       filename?: string,
       contentType?: string


### PR DESCRIPTION
* use NodeJS.ReadableStream instead of ReadableStream from DOM
* set node tsconfig [recommended settings](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping) for node 10.x in example app
* explicitly provide only es2018 lib in tsconfig (to avoid accidental importing of DOM modules)
