### PR TITLE
fix(cli) tie example apps to package version

### DIFF
--- a/packages/cli/src/utils/example-apps.js
+++ b/packages/cli/src/utils/example-apps.js
@@ -2,12 +2,15 @@ const fetch = require('node-fetch');
 const path = require('path');
 const fse = require('fs-extra');
 const AdmZip = require('adm-zip');
+const debug = require('debug')('zapier:example-apps');
 
 const xdg = require('./xdg');
 const { copyDir } = require('./files');
+const { PACKAGE_VERSION } = require('../constants');
 
-const REPO_ZIP_URL =
-  'https://codeload.github.com/zapier/zapier-platform/zip/master';
+const REPO_ZIP_URL = `https://codeload.github.com/zapier/zapier-platform/zip/zapier-platform-cli%40${PACKAGE_VERSION}`;
+const zipName = `zapier-platform-zapier-platform-cli-${PACKAGE_VERSION}`;
+const folderName = `zapier-platform-cached`; // version independant
 
 const checkCacheUpToDate = async repoDir => {
   const etagPath = path.join(repoDir, 'etag');
@@ -24,7 +27,7 @@ const checkCacheUpToDate = async repoDir => {
 };
 
 const downloadRepo = async destDir => {
-  const destZipPath = path.join(destDir, 'zapier-platform-master.zip');
+  const destZipPath = path.join(destDir, `${zipName}.zip`);
 
   const res = await fetch(REPO_ZIP_URL);
   const dest = fse.createWriteStream(destZipPath);
@@ -41,24 +44,29 @@ const downloadRepo = async destDir => {
   zip.extractAllTo(destDir, true);
 
   // Save etag for cache validation
-  const etagPath = path.join(destDir, 'zapier-platform-master', 'etag');
+  // this could probably just be cli version, but this is fine too
+  const etagPath = path.join(destDir, zipName, 'etag');
   fse.writeFileSync(etagPath, res.headers.get('etag'));
 
   fse.removeSync(destZipPath);
+  fse.renameSync(path.join(destDir, zipName), path.join(destDir, folderName));
 
   return destZipPath;
 };
 
 const ensureRepoCached = async () => {
   const cacheDir = xdg.ensureCacheDir();
-  const repoDir = path.join(cacheDir, 'zapier-platform-master');
+  const repoDir = path.join(cacheDir, folderName);
 
   if (fse.existsSync(repoDir)) {
-    if (!await checkCacheUpToDate(repoDir)) {
+    debug('repo exists');
+    if (!(await checkCacheUpToDate(repoDir))) {
+      debug('cached repo is stale, re-downloading');
       await fse.remove(repoDir);
       await downloadRepo(cacheDir);
     }
   } else {
+    debug('no cached repo, downloading');
     await downloadRepo(cacheDir);
   }
 


### PR DESCRIPTION
Previously, all versions of the CLI pulled from the master branch when making example apps. This was good because we could fixes to the example apps would be available right away. Less good because example apps might conflict with released versions of the CLI.

This came to a head when I merged https://github.com/zapier/zapier-platform/pull/124 and the build broke. Two main issues:

* Part of the build is calling `zapier init --template typescript` and `zapier build`. Now, this test was running using the master branch's `typescript` template but published `core@9.0.0`. Because that PR changed the TS configuration, the definitions in core were incompatible and it threw an error.
* apparently CI isn't run on PRs of forks. There's [good reason](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions) for this, but I didn't realize that was the case and merged a bad change.

Pinning examples to releases means slower bug fixes (which are infrequent anyway), but more control (and the ability to make breaking changes in the templates without affecting versions in the wild).