### PR TITLE
fix(core): don't require both username and password for basic auth

### DIFF
--- a/packages/core/src/http-middlewares/before/add-basic-auth-header.js
+++ b/packages/core/src/http-middlewares/before/add-basic-auth-header.js
@@ -2,11 +2,14 @@
 
 // Computes the basic auth header for the request
 const addBasicAuthHeader = (req, z, bundle) => {
-  if (bundle.authData && bundle.authData.username && bundle.authData.password) {
-    const buff = Buffer.from(
-      `${bundle.authData.username}:${bundle.authData.password}`,
-      'utf8'
-    );
+  if (
+    bundle.authData &&
+    (bundle.authData.username || bundle.authData.password)
+  ) {
+    const username = bundle.authData.username || '';
+    const password = bundle.authData.password || '';
+
+    const buff = Buffer.from(`${username}:${password}`, 'utf8');
     const header = 'Basic ' + buff.toString('base64');
 
     if (req.headers) {

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -321,8 +321,7 @@ describe('http addBasicAuthHeader before middelware', () => {
     req.headers.Authorization.should.eql(expectedValue);
   });
 
-  it('does not add the header when username or password is missing', () => {
-    const origReq = {};
+  it('does not add the header when username and password are missing', () => {
     const z = {};
     const bundle = {
       authData: {
@@ -330,15 +329,15 @@ describe('http addBasicAuthHeader before middelware', () => {
         password: ''
       }
     };
-    var req = addBasicAuthHeader(origReq, z, bundle);
-    should.not.exist(req.headers);
+    let req = addBasicAuthHeader({}, z, bundle);
+    req.headers.Authorization.should.eql('Basic dXNlcjo=');
 
     bundle.authData.username = '';
-    req = addBasicAuthHeader(origReq, z, bundle);
+    req = addBasicAuthHeader({}, z, bundle);
     should.not.exist(req.headers);
 
     delete bundle.authData;
-    req = addBasicAuthHeader(origReq, z, bundle);
+    req = addBasicAuthHeader({}, z, bundle);
     should.not.exist(req.headers);
   });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In Web Builder, we allow username or password to be empty. For example, a developer can use an auth mapping like the following to do basic-auth-backed API key auth:

```
{
  "username": "{{api_key}}",
  "password": ""
}
```

In CLI core, however, we currently require both username and password to be non-empty for the basic auth middleware to add the auth header to the request. This causes trouble if we convert a WB app like that to CLI. Not sure why we did that in the first place, but I think it should be good if we allow either username or password to be empty.