### PR TITLE
style(cli): make language of validate command consistent with UI

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -1261,8 +1261,8 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Validates your Zapier app.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier validate</code></p><p>Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during <code>zapier build</code>, <code>zapier upload</code>, <code>zapier push</code> or even as a test in <code>zapier test</code>.</p><p><strong>Flags</strong></p><ul>
+<p>Validates your Zapier integration.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier validate</code></p><p>Runs the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during <code>zapier build</code>, <code>zapier upload</code>, <code>zapier push</code> or even as a test in <code>zapier test</code>.</p><p><strong>Flags</strong></p><ul>
 <li><code>--without-style</code> | Forgo pinging the Zapier server to run further checks</li>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as <code>jq</code>. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -687,11 +687,11 @@ When this command is run, their Zaps will immediately turn off. They won't be ab
 
 ## validate
 
-> Validates your Zapier app.
+> Validates your Zapier integration.
 
 **Usage**: `zapier validate`
 
-Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during `zapier build`, `zapier upload`, `zapier push` or even as a test in `zapier test`.
+Runs the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during `zapier build`, `zapier upload`, `zapier push` or even as a test in `zapier test`.
 
 **Flags**
 * `--without-style` | Forgo pinging the Zapier server to run further checks

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -1261,8 +1261,8 @@ $ &#x2502; <span class="hljs-built_in">logout</span>      &#x2502; zapier <span 
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Validates your Zapier app.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier validate</code></p><p>Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during <code>zapier build</code>, <code>zapier upload</code>, <code>zapier push</code> or even as a test in <code>zapier test</code>.</p><p><strong>Flags</strong></p><ul>
+<p>Validates your Zapier integration.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier validate</code></p><p>Runs the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during <code>zapier build</code>, <code>zapier upload</code>, <code>zapier push</code> or even as a test in <code>zapier test</code>.</p><p><strong>Flags</strong></p><ul>
 <li><code>--without-style</code> | Forgo pinging the Zapier server to run further checks</li>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as <code>jq</code>. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output</li>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -687,11 +687,11 @@ When this command is run, their Zaps will immediately turn off. They won't be ab
 
 ## validate
 
-> Validates your Zapier app.
+> Validates your Zapier integration.
 
 **Usage**: `zapier validate`
 
-Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during `zapier build`, `zapier upload`, `zapier push` or even as a test in `zapier test`.
+Runs the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during `zapier build`, `zapier upload`, `zapier push` or even as a test in `zapier test`.
 
 **Flags**
 * `--without-style` | Forgo pinging the Zapier server to run further checks

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -133,8 +133,8 @@ class ZapierBaseCommand extends Command {
    * Print text in a list style.
    * @param {string[][]} items
    */
-  logList(items, { maxWidth = stdtermwidth } = {}) {
-    this.log(renderList(items, { spacer: '\n', maxWidth }));
+  logList(items) {
+    this.log(renderList(items, { spacer: '\n', maxWidth: stdtermwidth }));
   }
 
   /**

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -1,4 +1,6 @@
 const { Command } = require('@oclif/command');
+const { stdtermwidth } = require('@oclif/plugin-help/lib/screen');
+const { renderList } = require('@oclif/plugin-help/lib/list');
 const colors = require('colors/safe');
 
 const { startSpinner, endSpinner, formatStyles } = require('../utils/display');
@@ -125,6 +127,14 @@ class ZapierBaseCommand extends Command {
       // data comes out of the formatter ready to be printed (and it's always in the type to match the format) so we don't need to do anything special with it
       console.log(formatter(rows, headers));
     }
+  }
+
+  /**
+   * Print text in a list style.
+   * @param {string[][]} items
+   */
+  logList(items, { maxWidth = stdtermwidth } = {}) {
+    this.log(renderList(items, { spacer: '\n', maxWidth }));
   }
 
   /**

--- a/packages/cli/src/oclif/commands/validate.js
+++ b/packages/cli/src/oclif/commands/validate.js
@@ -30,7 +30,7 @@ class ValidateCommand extends BaseCommand {
 
     if (newErrors.length) {
       this.log(
-        'Your app is structurally invalid. Address concerns and run this command again.'
+        'Your integration is structurally invalid. Address concerns and run this command again.'
       );
       process.exitCode = 1;
     } else {
@@ -41,13 +41,15 @@ class ValidateCommand extends BaseCommand {
     if (this.flags['without-style'] || process.exitCode === 1) {
       if (process.exitCode === 1) {
         this.log(
-          colors.grey('\nSkipping app checks because app did not validate.')
+          colors.grey(
+            '\nSkipping integration checks because schema did not validate.'
+          )
         );
       }
       return;
     } else {
       this.log();
-      this.startSpinner('Running app checks');
+      this.startSpinner('Running integration checks');
 
       const rawDefinition = await localAppCommand({
         command: 'definition'
@@ -57,13 +59,17 @@ class ValidateCommand extends BaseCommand {
     }
 
     const doneMessage = checkResult.passes
-      ? `Running app checks ... ${checkResult.passes.length} checks passed`
+      ? `Running integration checks ... ${checkResult.passes.length} checks passed`
       : undefined;
     this.stopSpinner({ message: doneMessage });
 
     const checkIssues = flattenCheckResult(checkResult);
 
-    this.log('\nHere are the issues we found:');
+    this.log();
+    if (checkIssues.length) {
+      this.log('Here are the issues we found:');
+    }
+
     this.logTable({
       rows: checkIssues,
       headers: [
@@ -72,21 +78,34 @@ class ValidateCommand extends BaseCommand {
         ['Description', 'description'],
         ['Link', 'link']
       ],
-      emptyMessage: 'App checks passed, no issues found.'
+      emptyMessage: 'Integration checks passed, no issues found.'
     });
 
-    if (checkResult.errors && checkResult.errors.results.length) {
-      process.exitCode = 1;
-      this.log(
-        'Errors will block you from pushing; warnings will only block you from going public or promoting a version.\n'
-      );
-    } else if (checkResult.warnings && checkResult.warnings.results.length) {
-      this.log(
-        'Your app looks great! Warnings only block you from going public or promoting a version.\n'
-      );
-    } else {
-      this.log('Your app looks great!\n');
+    const errorDisplay = checkResult.errors.display_label;
+    const warningDisplay = checkResult.warnings.display_label;
+    const suggestionDisplay = checkResult.suggestions.display_label;
+
+    if (checkIssues.length) {
+      this.logList([
+        [
+          `- ${colors.bold(errorDisplay)}`,
+          'Issues that will prevent your integration from functioning ' +
+            'properly. They block you from pushing.'
+        ],
+        [
+          `- ${colors.bold(warningDisplay)}`,
+          'To-dos that must be addressed before your integration can be ' +
+            'included in the App Directory. They block you from promoting and ' +
+            'publishing.'
+        ],
+        [
+          `- ${colors.bold(suggestionDisplay)}`,
+          'Issues and recommendations that need human reviews by Zapier before ' +
+            "publishing your integration. They don't block."
+        ]
+      ]);
     }
+    this.log();
   }
 }
 
@@ -106,8 +125,8 @@ ValidateCommand.examples = [
   'zapier validate --without-style',
   'zapier validate --format json'
 ];
-ValidateCommand.description = `Validates your Zapier app.
+ValidateCommand.description = `Validates your Zapier integration.
 
-Runs the standard validation routine powered by json-schema that checks your app for any structural errors. This is the same routine that runs during \`zapier build\`, \`zapier upload\`, \`zapier push\` or even as a test in \`zapier test\`.`;
+Runs the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during \`zapier build\`, \`zapier upload\`, \`zapier push\` or even as a test in \`zapier test\`.`;
 
 module.exports = ValidateCommand;

--- a/packages/cli/src/utils/display.js
+++ b/packages/cli/src/utils/display.js
@@ -284,6 +284,8 @@ const flattenCheckResult = checkResult => {
       continue;
     }
 
+    const displaySeverity = checkResult[severity].display_label || severity;
+
     for (const issueGroup of results) {
       if (!issueGroup.violations) {
         break;
@@ -299,7 +301,7 @@ const flattenCheckResult = checkResult => {
       for (const violation of issueGroup.violations) {
         for (const result of violation.results) {
           res.push({
-            category: severity,
+            category: displaySeverity,
             method: `${opType}.${violation.type}`,
             description: `${result.message} (${result.tag})`,
             link: `${CHECK_REF_DOC_LINK}#${result.tag}`


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Addresses [PDE-1251](https://zapierorg.atlassian.net/browse/PDE-1251).

Before:

![](https://zappy.zapier.com/B1A67B2D-3479-4B05-AB0F-68F5A13C2794.png)

After:

![](https://zappy.zapier.com/494F2329-88A8-45CF-B3FB-858674542E8A.png)