### PR TITLE
fix(legacy-scripting-runner): convert bundle.load correctly for oauth2

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -74,7 +74,7 @@ const addAuthData = (event, bundle, convertedBundle) => {
       client_id: process.env.CLIENT_ID,
       client_secret: process.env.CLIENT_SECRET
     };
-    convertedBundle.load = _.get(bundle, 'inputData', {});
+    convertedBundle.load = _.get(bundle, 'request.body', {});
   }
 };
 

--- a/packages/legacy-scripting-runner/test/bundle.js
+++ b/packages/legacy-scripting-runner/test/bundle.js
@@ -971,9 +971,7 @@ describe('bundleConverter', () => {
         data: ''
       },
       auth_fields: {},
-      load: {
-        user: 'Zapier'
-      },
+      load: {},
       meta: {},
       zap: {
         id: 0
@@ -1036,9 +1034,7 @@ describe('bundleConverter', () => {
         access_token: 'qwerty',
         refresh_token: 'zxcvb'
       },
-      load: {
-        user: 'Zapier'
-      },
+      load: {},
       meta: {},
       zap: {
         id: 0

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -85,6 +85,14 @@ const legacyScriptingSource = `
         };
       },
 
+      pre_oauthv2_refresh_bundle_load: function(bundle) {
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        debugger;
+        bundle.request.data = qs.stringify(bundle.load);
+        bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+        return bundle.request;
+      },
+
       get_connection_label: function(bundle) {
         return 'Hi ' + bundle.test_result.name;
       },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -334,6 +334,29 @@ describe('Integration Test', () => {
         });
       });
     });
+
+    it('pre_oauthv2_refresh, bundle.load', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'pre_oauthv2_refresh_bundle_load',
+        'pre_oauthv2_refresh'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.refreshAccessToken'
+      );
+      input.bundle.authData = {
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token'
+      };
+      return app(input).then(output => {
+        const response = output.results;
+        should.not.exist(response.headers.Authorization);
+        should.equal(response.form.refresh_token, 'my_refresh_token');
+      });
+    });
   });
 
   describe('polling trigger', () => {

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -354,7 +354,12 @@ describe('Integration Test', () => {
       return app(input).then(output => {
         const response = output.results;
         should.not.exist(response.headers.Authorization);
-        should.equal(response.form.refresh_token, 'my_refresh_token');
+        should.deepEqual(response.form, {
+          client_id: [process.env.CLIENT_ID],
+          client_secret: [process.env.CLIENT_SECRET],
+          grant_type: ['refresh_token'],
+          refresh_token: ['my_refresh_token']
+        });
       });
     });
   });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

`bundle.load` should be the same as `bundle.request.data` for pre_oauthv2_token` and `pre_oauthv2_refresh`.