### PR TITLE
chore(core): allow to specify core version when building a boilerplate

### DIFF
--- a/packages/core/bin/build-boilerplate.sh
+++ b/packages/core/bin/build-boilerplate.sh
@@ -7,26 +7,26 @@
 CONTENTS_DIR='boilerplate'
 BUILD_DIR='build-boilerplate'
 
-if [ -d $BUILD_DIR ]; then
-   rm -fr $BUILD_DIR
-fi
-
 mkdir -p $BUILD_DIR
 
 # Copy files
 cp "include/zapierwrapper.js" "$CONTENTS_DIR/"
 
 # Get current core version
-CORE_VERSION="$(node -p "require('./package.json').version")"
+if [ "$2" == "" ]; then
+    CORE_VERSION="$(node -p "require('./package.json').version")"
+else
+    CORE_VERSION=$2
+fi
 
 FILE="$BUILD_DIR/$CORE_VERSION.zip"
+rm -f $FILE
 
 TIMESTAMP=`date +"%s"`
 
 if [ "$1" == "production" ]; then
-    echo "Building from published packages"
-    cd ../legacy-scripting-runner
-    TIMESTAMP=""
+    echo "Building from published packages, core $CORE_VERSION"
+    ./bin/update-boilerplate-dependencies.js $CORE_VERSION
 else
     # Build core and legacy-scripting-runner locally. Needs to generate a unique filename
     # with a timestamp to avoid yarn using cached packages.
@@ -35,10 +35,10 @@ else
     yarn pack --filename "./boilerplate/core-$TIMESTAMP.tgz"
     cd ../legacy-scripting-runner
     yarn pack --filename "../core/boilerplate/legacy-scripting-runner-$TIMESTAMP.tgz"
-fi
 
-cd ../core
-./bin/update-boilerplate-dependencies.js $TIMESTAMP
+    cd ../core
+    ./bin/update-boilerplate-dependencies.js $TIMESTAMP
+fi
 
 # Install boilerplate deps, need to make sure local packages
 cd $CONTENTS_DIR

--- a/packages/core/bin/update-boilerplate-dependencies.js
+++ b/packages/core/bin/update-boilerplate-dependencies.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 const corePackageJson = require('zapier-platform-core/package.json');
 const lsrPackageJson = require('zapier-platform-legacy-scripting-runner/package.json');
 
+const isVersion = s => s && process.argv[2].match(/^\d+\.\d+\.\d+$/);
+
 // Read from ../, write to ./
 const boilerplatePackageJsonPath = './boilerplate/package.json';
 
@@ -17,6 +19,8 @@ if (process.argv.length === 3) {
   if (process.argv[2] === 'revert') {
     coreVersionToSet = 'PLACEHOLDER';
     lsrVersionToSet = 'PLACEHOLDER';
+  } else if (isVersion(process.argv[2])) {
+    coreVersionToSet = process.argv[2];
   } else {
     const timestamp = process.argv[2];
     coreVersionToSet = `file:./core-${timestamp}.tgz`;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Just a tooling improvement. This allows us to specify a zapier-platform-core version on npm when building a boilerplate zip. Example usage:

```
./bin/build-boilerplate.sh production 9.0.0
```