### PR TITLE
fix(cli): convert command crashes over a trailing comment

### DIFF
--- a/packages/cli/src/tests/utils/convert.js
+++ b/packages/cli/src/tests/utils/convert.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');
 
+const { cloneDeep } = require('lodash');
 const should = require('should');
 
 const { convertLegacyApp, convertVisualApp } = require('../../utils/convert');
@@ -380,6 +381,14 @@ describe('convert', () => {
       should(createFile.includes('getInputFields = ')).be.true();
       should(createFile.includes('getInputFields0')).be.false();
       should(createFile.includes('getInputFields1 = ')).be.true();
+    });
+
+    it('should not break over a comment', async () => {
+      // https://github.com/zapier/zapier-platform/issues/142
+      const appDefinition = cloneDeep(visualAppDefinition);
+      appDefinition.triggers.codemode.operation.perform.source +=
+        '\n// a comment';
+      await convertVisualApp(visualApp, appDefinition, tempAppDir);
     });
   });
 });

--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -157,7 +157,7 @@ const renderStep = (type, definition) => {
       if (func && func.source) {
         const args = func.args || ['z', 'bundle'];
         functionBlock.push(
-          `const ${funcName} = (${args.join(', ')}) => {${func.source}};`
+          `const ${funcName} = (${args.join(', ')}) => {\n${func.source}\n};`
         );
 
         exportBlock.operation[funcName] = makePlaceholder(funcName);
@@ -178,7 +178,9 @@ const renderStep = (type, definition) => {
             funcNum ? funcNum++ : ++funcNum && ''
           }`;
           functionBlock.push(
-            `const ${funcName} = (${args.join(', ')}) => {${maybeFunc.source}};`
+            `const ${funcName} = (${args.join(', ')}) => {\n${
+              maybeFunc.source
+            }\n};`
           );
 
           exportBlock.operation[key][index] = makePlaceholder(funcName);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes #142.