### PR TITLE
tooling: custom bump script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "root",
   "private": true,
   "devDependencies": {
+    "chalk": "2.4.2",
     "eslint": "6.2.2",
     "eslint-config-prettier": "6.1.0",
     "eslint-config-standard": "14.0.1",
@@ -11,10 +12,12 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.1",
     "husky": "3.0.4",
+    "inquirer": "7.0.3",
     "lerna": "3.16.4",
     "lint-staged": "9.2.4",
     "mocha": "6.2.0",
     "prettier": "1.18.2",
+    "semver": "7.1.1",
     "should": "13.2.3"
   },
   "workspaces": [
@@ -25,7 +28,7 @@
     "lint": "lerna run --stream --ignore zapier-platform-example-app-* lint",
     "lint-examples": "eslint examples",
     "validate": "lerna run --ignore zapier-platform-example-app-* validate",
-    "bump": "lerna version --exact --force-publish=zapier-platform-cli,zapier-platform-core,zapier-platform-schema",
+    "bump": "./scripts/bump.js",
     "build-boilerplate": "yarn workspace zapier-platform-core build-boilerplate",
     "upload-boilerplate": "yarn workspace zapier-platform-core upload-boilerplate"
   },

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -32,8 +32,7 @@ const PACKAGE_ORIG_VERSIONS = [
     'package.json'
   );
   const packageJson = readJson(packageJsonPath);
-  result[packageName] = packageJson.version;
-  return result;
+  return { ...result, [packageName]: packageJson.version };
 }, {});
 
 const ensureMainPackageVersionsAreSame = () => {

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const { bold, underline } = require('chalk');
+const { spawnSync } = require('child_process');
+const inquirer = require('inquirer');
+const semver = require('semver');
+
+const REPO_DIR = path.dirname(__dirname);
+
+const readJson = path => {
+  return JSON.parse(fs.readFileSync(path, { encoding: 'utf8' }));
+};
+
+const writeJson = (path, obj) => {
+  const content = JSON.stringify(obj, null, 2) + '\n';
+  fs.writeFileSync(path, content, { encoding: 'utf8' });
+};
+
+const PACKAGE_ORIG_VERSIONS = [
+  'cli',
+  'core',
+  'schema',
+  'legacy-scripting-runner'
+].reduce((result, packageName) => {
+  const packageJsonPath = path.join(
+    REPO_DIR,
+    'packages',
+    packageName,
+    'package.json'
+  );
+  const packageJson = readJson(packageJsonPath);
+  result[packageName] = packageJson.version;
+  return result;
+}, {});
+
+const ensureMainPackageVersionsAreSame = () => {
+  if (
+    !(
+      PACKAGE_ORIG_VERSIONS.cli === PACKAGE_ORIG_VERSIONS.core &&
+      PACKAGE_ORIG_VERSIONS.core === PACKAGE_ORIG_VERSIONS.schema
+    )
+  ) {
+    throw new Error(
+      'Packages must have the same version number.\nInstead, we got ' +
+        JSON.stringify(PACKAGE_ORIG_VERSIONS)
+    );
+  }
+};
+
+const promptPackagesToBump = async () => {
+  const answer = await inquirer.prompt([
+    {
+      type: 'checkbox',
+      message: 'What package(s) you want to bump?',
+      name: 'packages',
+      choices: [
+        {
+          name: `cli, core, schema (currently ${PACKAGE_ORIG_VERSIONS.cli})`,
+          value: 'cli, core, schema'
+        },
+        {
+          name: `legacy-scripting-runner (currently ${
+            PACKAGE_ORIG_VERSIONS['legacy-scripting-runner']
+          })`,
+          value: 'legacy-scripting-runner'
+        }
+      ]
+    }
+  ]);
+  return answer.packages;
+};
+
+const promptVersionToBump = async packageName => {
+  const currentVersion = PACKAGE_ORIG_VERSIONS[packageName];
+
+  const choices = ['patch', 'minor', 'major'].map(bumpType => {
+    const version = semver.inc(currentVersion, bumpType);
+    return {
+      name: `${version} (${bumpType})`,
+      value: version
+    };
+  });
+
+  const answer = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'versionToBump',
+      message: `Version to bump for ${underline(packageName)}?`,
+      choices
+    }
+  ]);
+  return answer.versionToBump;
+};
+
+const bumpMainPackagesForExampleApps = versionToBump => {
+  const examplesDir = path.join(REPO_DIR, 'example-apps');
+  fs.readdirSync(examplesDir, { withFileTypes: true }).map(item => {
+    if (item.isDirectory()) {
+      const packageJsonPath = path.join(examplesDir, item.name, 'package.json');
+      const packageJson = readJson(packageJsonPath);
+
+      ['cli', 'core', 'schema'].map(packageName => {
+        const packageFullName = `zapier-platform-${packageName}`;
+        if (packageJson.dependencies) {
+          const depVersion = packageJson.dependencies[packageFullName];
+          if (depVersion) {
+            console.log(
+              `${item.name}'s dependency ${packageName} ${depVersion} -> ${versionToBump}`
+            );
+            packageJson.dependencies[packageFullName] = versionToBump;
+          }
+        }
+      });
+
+      writeJson(packageJsonPath, packageJson);
+    }
+  });
+};
+
+// Main packages are cli, core, schema
+const bumpMainPackages = versionToBump => {
+  const PACKAGES = ['cli', 'core', 'schema'];
+
+  PACKAGES.map(packageName => {
+    const packageJsonPath = path.join(
+      REPO_DIR,
+      'packages',
+      packageName,
+      'package.json'
+    );
+    const packageJson = readJson(packageJsonPath);
+
+    console.log(
+      `${packageName} ${PACKAGE_ORIG_VERSIONS[packageName]} -> ${versionToBump}`
+    );
+    packageJson.version = versionToBump;
+
+    PACKAGES.map(depName => {
+      const depFullName = `zapier-platform-${depName}`;
+      const depVersion = packageJson.dependencies[depFullName];
+      if (depVersion) {
+        console.log(
+          `${packageName}'s dependency ${depName} ${depVersion} -> ${versionToBump}`
+        );
+        packageJson.dependencies[depFullName] = versionToBump;
+      }
+    });
+
+    writeJson(packageJsonPath, packageJson);
+  });
+};
+
+// "Extension package", such as legacy-scripting-runner
+const bumpExtensionPackage = (packageName, versionToBump) => {
+  const packageJsonPath = path.join(
+    REPO_DIR,
+    'packages',
+    packageName,
+    'package.json'
+  );
+  const packageJson = readJson(packageJsonPath);
+
+  console.log(`${packageName} ${packageJson.version} -> ${versionToBump}`);
+  packageJson.version = versionToBump;
+  writeJson(packageJsonPath, packageJson);
+};
+
+const bump = (packageName, versionToBump) => {
+  if (packageName === 'cli, core, schema') {
+    bumpMainPackages(versionToBump);
+    bumpMainPackagesForExampleApps(versionToBump);
+  } else {
+    bumpExtensionPackage(packageName, versionToBump);
+  }
+};
+
+const gitAdd = () => {
+  const result = spawnSync(
+    'git',
+    ['add', 'packages/*/package.json', 'example-apps/*/package.json'],
+    {
+      stdio: [0, 1, 2]
+    }
+  );
+
+  if (result.status !== 0) {
+    throw new Error('git-add failed');
+  }
+};
+
+const gitCommit = versionsToBump => {
+  const messageParts = Object.keys(versionsToBump).map(packageName => {
+    const fromVersion = PACKAGE_ORIG_VERSIONS[packageName];
+    const toVersion = versionsToBump[packageName];
+    return `${packageName} ${fromVersion} -> ${toVersion}`;
+  });
+  const message = 'Bump ' + messageParts.join(', ');
+  const result = spawnSync('git', ['commit', '-m', message], {
+    stdio: [0, 1, 2]
+  });
+
+  if (result.status !== 0) {
+    throw new Error('git-commit failed');
+  }
+};
+
+const gitTag = versionsToBump => {
+  const toVersions = Object.keys(versionsToBump).reduce(
+    (result, packageName) => {
+      const toVersion = versionsToBump[packageName];
+      if (packageName === 'cli, core, schema') {
+        result.cli = result.core = result.schema = toVersion;
+      } else {
+        result[packageName] = toVersion;
+      }
+      return result;
+    },
+    {}
+  );
+
+  Object.keys(toVersions).map(packageName => {
+    const version = toVersions[packageName];
+    const tag = `zapier-platform-${packageName}@${version}`;
+
+    const result = spawnSync('git', ['tag', '-a', tag, '-m', tag], {
+      stdio: [0, 1, 2]
+    });
+
+    if (result.status !== 0) {
+      throw new Error('git-tag failed');
+    }
+  });
+};
+
+const main = async () => {
+  try {
+    ensureMainPackageVersionsAreSame();
+  } catch (err) {
+    console.error(err.message);
+    return 1;
+  }
+
+  // Currently we bump cli, core, schema together
+  PACKAGE_ORIG_VERSIONS['cli, core, schema'] = PACKAGE_ORIG_VERSIONS.cli;
+
+  const packagesToBump = await promptPackagesToBump();
+  if (packagesToBump.length === 0) {
+    console.log('No packages selected, nothing to do here');
+    return 0;
+  }
+
+  const versionsToBump = {};
+  for (const packageName of packagesToBump) {
+    versionsToBump[packageName] = await promptVersionToBump(packageName);
+  }
+
+  Object.keys(versionsToBump).map(packageName => {
+    bump(packageName, versionsToBump[packageName]);
+  });
+
+  try {
+    gitAdd();
+    gitCommit(versionsToBump);
+    gitTag(versionsToBump);
+  } catch (err) {
+    console.error(err.message);
+    return 1;
+  }
+
+  console.log(
+    `\nDone! Now you can ${bold.underline('git push origin master --tags')}.`
+  );
+
+  return 0;
+};
+
+main().then(exitCode => {
+  if (exitCode) {
+    process.exit(exitCode);
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1310,6 +1310,13 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
+ansi-escapes@^4.2.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.0.tgz#a4ce2b33d6b214b7950d8595c212f12ac9cc569d"
+  integrity sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==
+  dependencies:
+    type-fest "^0.8.1"
+
 ansi-red@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
@@ -1331,6 +1338,11 @@ ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2779,6 +2791,15 @@ chai@^4.1.2:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -2789,15 +2810,6 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -2920,6 +2932,13 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
 
 cli-spinners@^2.0.0:
   version "2.2.0"
@@ -4070,6 +4089,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 encoding@^0.1.11:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
@@ -4760,6 +4784,13 @@ figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
+figures@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.1.0.tgz#4b198dd07d8d71530642864af2d45dd9e459c4ec"
+  integrity sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -5893,6 +5924,25 @@ inquirer@6.5.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.0.3.tgz#f9b4cd2dff58b9f73e8d43759436ace15bed4567"
+  integrity sha512-+OiOVeVydu4hnCGLCSX+wedovR/Yzskv9BFqUNNKq9uU2qg7LCcCo3R86S2E7WLo0y/x2pnEZfZe1CoYnORUAw==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^2.4.2"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.2.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
+    strip-ansi "^5.1.0"
+    through "^2.3.6"
+
 inquirer@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
@@ -6116,6 +6166,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -7022,7 +7077,7 @@ lodash@4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@4.17.15, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -7668,7 +7723,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -9305,6 +9360,14 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -9392,6 +9455,13 @@ rxjs@^6.3.3, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.5.3:
+  version "6.5.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
+  integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -9457,6 +9527,11 @@ semver@6.3.0, semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
+  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -9951,6 +10026,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string-width@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
 string.prototype.trimleft@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
@@ -10015,6 +10099,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -10465,6 +10556,11 @@ type-fest@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
+type-fest@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
+  integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type@^1.0.1:
   version "1.2.0"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Part of [PDE-870](https://zapierorg.atlassian.net/browse/PDE-870) to fix our currently broken release process.

Originally, we used `lerna version`, which doesn't fit our needs entirely and isn't easy to customize. So I ended up manually editing `package.json`s and adding git tags a lot when releases packages.

This PR adds a standalone and interactive script `./scripts/bump.js` (can also be executed with `yarn bump`), which does the following things:

1. ask us which package(s) and the version(s) to bump
   ![](https://zappy.zapier.com/CAF41B66-6778-480E-BBFB-C7747A6EBA2B.png)
2. bump the selected packages by editing their `package.json`
3. update example apps' dependencies in `package.json`
4. git commit the changes
5. add the necessary git tags

Once the script finished, the only thing we need to do is to `git push origin master --tags`. When Travis CI sees the git tags on GitHub, it will publish the packages to npm for us.