### PR TITLE
docs(cli): Add clarification for Computed Fields support

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1429,6 +1429,8 @@ In OAuth and Session Auth, Zapier automatically stores every value from an integ
 
 You can return additional fields in these responses, on top of the expected `access_token` or `refresh_token` for OAuth and `sessionKey` for Session auth. They will be saved in `bundle.authData`. You can reference these fields in any subsequent API call as needed.
 
+> Note: Only OAuth and Session Auth support computed fields.
+
 If you want Zapier to validate that these additional fields exist, you need to use Computed Fields. If you define computed fields in your integration, Zapier will check to make sure those fields exist when it runs the authentication test API call.
 
 Computed fields work like any other field, though with `computed: true` property, and `required: false` as user can not enter computed fields themselves. Reference computed fields in API calls as `{{bundle.authData.field}}`, replacing `field` with that field's name from your test API call response.


### PR DESCRIPTION
The VB docs specify that Computed Fields only work with OAuth and Session Auth. I had a CLI user who didn't realize this, so I'm adding this to the CLI docs as well.

Please let me know if I should have changed this doc instead! https://github.com/zapier/visual-builder/blob/master/docs/_cli_docs/docs.md

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
