### PR TITLE
fix(legacy-scripting-runner): 'this' should be bound to 'Zap'

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -523,7 +523,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
           );
 
           // method.length is the number of args method accepts
-          const method = Zap[methodName];
+          const method = Zap[methodName].bind(Zap);
           const isAsync = method.length > 1;
           let result;
           try {

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -211,12 +211,13 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
-      getAnS: function() {
-        return 's';
+      getMovesUrl: function() {
+        return '${AUTH_JSON_SERVER_URL}/movies';
       },
 
       movie_pre_poll_this_binding: function(bundle) {
-        bundle.request.url += this.getAnS();
+        // 'this' should be bound to 'Zap'
+        bundle.request.url = this.getMovesUrl();
         return bundle.request;
       },
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -211,6 +211,15 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      getAnS: function() {
+        return 's';
+      },
+
+      movie_pre_poll_this_binding: function(bundle) {
+        bundle.request.url += this.getAnS();
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -646,6 +646,25 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, this binding', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_this_binding',
+        'movie_pre_poll'
+      );
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then(output => {
+        const movies = output.results;
+        movies.length.should.greaterThan(1);
+      });
+    });
+
     it('KEY_pre_poll, _.template(bundle.request.url)', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -649,8 +649,8 @@ describe('Integration Test', () => {
     it('KEY_pre_poll, this binding', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
-        'movie_post_poll_underscore',
-        'movie_post_poll'
+        'movie_pre_poll_this_binding',
+        'movie_pre_poll'
       );
       const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
       const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -649,19 +649,22 @@ describe('Integration Test', () => {
     it('KEY_pre_poll, this binding', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
-        'movie_pre_poll_this_binding',
-        'movie_pre_poll'
+        'movie_post_poll_underscore',
+        'movie_post_poll'
       );
-      const _compiledApp = schemaTools.prepareApp(appDef);
-      const _app = createApp(appDef);
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
 
       const input = createTestInput(
         _compiledApp,
         'triggers.movie.operation.perform'
       );
+      input.bundle.authData = { api_key: 'secret' };
       return _app(input).then(output => {
         const movies = output.results;
         movies.length.should.greaterThan(1);
+        should.equal(movies[0].title, 'title 1');
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Using `this.something` in a scripting method should equivalent to `Zap.something`.