### PR TITLE
fix(core): add `new` to url call

### DIFF
--- a/packages/core/src/http-middlewares/before/add-digest-auth-header.js
+++ b/packages/core/src/http-middlewares/before/add-digest-auth-header.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const urllib = require('url');
-
 const fetch = require('node-fetch');
 
 const { NotImplementedError } = require('../../errors');
@@ -15,7 +13,7 @@ const buildDigestHeader = (username, password, url, method, creds) => {
     );
   }
 
-  const path = new urllib.URL(url).path;
+  const path = new URL(url).pathname;
 
   const HA1 = md5(`${username}:${creds.realm}:${password}`);
   const HA2 = md5(`${method}:${path}`);

--- a/packages/core/src/http-middlewares/before/add-digest-auth-header.js
+++ b/packages/core/src/http-middlewares/before/add-digest-auth-header.js
@@ -15,7 +15,7 @@ const buildDigestHeader = (username, password, url, method, creds) => {
     );
   }
 
-  const path = urllib.URL(url).path;
+  const path = new urllib.URL(url).path;
 
   const HA1 = md5(`${username}:${creds.realm}:${password}`);
   const HA2 = md5(`${method}:${path}`);

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -5,6 +5,7 @@ const request = require('../src/tools/request-client');
 
 const prepareRequest = require('../src/http-middlewares/before/prepare-request');
 const addBasicAuthHeader = require('../src/http-middlewares/before/add-basic-auth-header');
+const addDigestAuthHeader = require('../src/http-middlewares/before/add-digest-auth-header');
 const prepareResponse = require('../src/http-middlewares/after/prepare-response');
 const applyMiddleware = require('../src/middleware');
 const oauth1SignRequest = require('../src/http-middlewares/before/oauth1-sign-request');
@@ -340,7 +341,31 @@ describe('http addBasicAuthHeader before middelware', () => {
     req = addBasicAuthHeader({}, z, bundle);
     should.not.exist(req.headers);
   });
+});
 
+describe('http addDigestAuthHeader before middleware', () => {
+  it('computes the Authorization header', async () => {
+    const origReq = {
+      url: 'https://httpbin.zapier-tooling.com/digest-auth/auth/joe/mypass/MD5',
+      headers: {}
+    };
+    const z = {};
+    const bundle = {
+      authData: {
+        username: 'joe',
+        password: 'mypass'
+      }
+    };
+    const req = await addDigestAuthHeader(origReq, z, bundle);
+    const res = await request(req);
+    res.status.should.eql(200);
+
+    const json = await res.json();
+    json.user.should.eql('joe');
+  });
+});
+
+describe('http oauth1SignRequest before middelware', () => {
   it('should sign request for oauth1', () => {
     const origReq = {
       method: 'post',


### PR DESCRIPTION
fixes the problem described [here](https://zapier.slack.com/archives/C5Z9BP4U9/p1580763373284900)

it doesn't look like we've got any testing here, which is why this may have gone undetected so long? I'm also puzzled at why this would have worked at all recently and only broke when we did the godzilla core 8 -> upgrade. In any case, this will fix the issue. 