### PR TITLE
fix(legacy-scripting-runner): stop immediately when scripting method errors

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -530,6 +530,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
             result = method(convertedBundle, optionalCallback);
           } catch (err) {
             reject(err);
+            return;
           }
 
           // Handle sync

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -221,6 +221,12 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_error: function(bundle) {
+        var foo;
+        foo.bar = 1;
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -668,6 +668,22 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, error properly', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_error',
+        'movie_pre_poll'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return app(input).should.be.rejectedWith(/'bar' of undefined/);
+    });
+
     it('KEY_pre_poll, _.template(bundle.request.url)', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

See 👇 for why.