### PR TITLE
fix(legacy-scripting-runner): add support for jquery $.each

### DIFF
--- a/packages/legacy-scripting-runner/$.js
+++ b/packages/legacy-scripting-runner/$.js
@@ -53,4 +53,8 @@ $.type = obj => {
   return typeof obj;
 };
 
+$.each = (arr, func) => {
+  arr.forEach((elem, i) => func.bind(elem)(i));
+};
+
 module.exports = $;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -147,6 +147,11 @@ const legacyScriptingSource = `
         contacts[0].trimmed = $.trim(' hello world  ');
         contacts[0].type = $.type(contacts);
 
+        var base = 1000;
+        $.each(contacts, function(index) {
+          this.anotherId = base + index;
+        });
+
         return contacts;
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -728,6 +728,10 @@ describe('Integration Test', () => {
         firstContact.isPlainObject.should.be.false();
         should.equal(firstContact.trimmed, 'hello world');
         should.equal(firstContact.type, 'array');
+
+        const secondContact = output.results[1];
+        should.equal(firstContact.anotherId, 1000);
+        should.equal(secondContact.anotherId, 1001);
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Allows to use jQuery `$.each` in legacy scripting.