### PR TITLE
fix(cli): Fix the SSO login link

### DIFF
--- a/packages/cli/src/oclif/commands/login.js
+++ b/packages/cli/src/oclif/commands/login.js
@@ -43,7 +43,7 @@ const isValidDeployKey = k =>
 class LoginCommand extends BaseCommand {
   promptForDeployKey() {
     this.log(
-      `To generate a deploy key, go to ${DEPLOY_KEY_DASH_URL}, create/copy a key, and then paste the result below.`
+      `To generate a deploy key, go to ${DEPLOY_KEY_DASH_URL} and create/copy a key, then paste the result below.`
     );
     return this.prompt('Paste your Deploy Key here:', {
       validate: isValidDeployKey


### PR DESCRIPTION
The link previously contained a trailing comma which is attached to the URL when selected.
Previously this was routing to [https://zapier.com/developer/partner-settings/deploy-keys/,](https://zapier.com/developer/partner-settings/deploy-keys/,) which goes to 404.
This has been updated to go to [https://zapier.com/developer/partner-settings/deploy-keys/](https://zapier.com/developer/partner-settings/deploy-keys/)

The previous text looked like:

```
zapier login --sso
Your /Users/calebfroese/.zapierrc has not been set up yet.

To generate a deploy key, go to https://zapier.com/developer/partner-settings/deploy-keys/, create/copy a key, and then paste the result below.
? Paste your Deploy Key here:
```

Which now looks like

```
zapier login --sso
Your /Users/calebfroese/.zapierrc has not been set up yet.

To generate a deploy key, go to https://zapier.com/developer/partner-settings/deploy-keys/ and create/copy a key, then paste the result below.
? Paste your Deploy Key here:
```

This resolves issue #156