### PR TITLE
fix(legacy-scripting-runner): exclude a field from bundle.aciton_fields if "Send in JSON body" is unchecked

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -237,7 +237,7 @@ const bundleConverter = async (bundle, event, z) => {
     }, {});
 
   // Attach to bundle so we can reuse it
-  bundle._unflatInputData = unflattenObject(filteredInputData || {});
+  bundle._unflatInputData = unflattenObject(filteredInputData);
 
   const meta = convertBundleMeta(bundle.meta);
   const zap = _.get(bundle, 'meta.zap') || { id: 0 };

--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -228,8 +228,16 @@ const bundleConverter = async (bundle, event, z) => {
     }
   }
 
+  // From inputData, remove keys that are in fieldsExcludedFromBody
+  const excludedFieldKeys = bundle._fieldsExcludedFromBody || [];
+  const filteredInputData = Object.keys(bundle.inputData || {})
+    .filter(key => !excludedFieldKeys.includes(key))
+    .reduce((fields, key) => {
+      return { [key]: bundle.inputData[key], ...fields };
+    }, {});
+
   // Attach to bundle so we can reuse it
-  bundle._unflatInputData = unflattenObject(_.clone(bundle.inputData || {}));
+  bundle._unflatInputData = unflattenObject(filteredInputData || {});
 
   const meta = convertBundleMeta(bundle.meta);
   const zap = _.get(bundle, 'meta.zap') || { id: 0 };

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1061,6 +1061,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       bundle._legacyUrl = url;
     }
 
+    bundle._fieldsExcludedFromBody = fieldsExcludedFromBody;
+
     return runEventCombo(
       bundle,
       key,

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1034,6 +1034,9 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     const legacyProps = _.get(app, `legacy.creates.${key}.operation`) || {};
     const needsFlattenedData = _.get(app, 'legacy.needsFlattenedData');
     const url = legacyProps.url;
+
+    // This represents the "Send to Action Endpoint URL in JSON body" checkbox.
+    // If unchecked, the action field will be in this array.
     const fieldsExcludedFromBody = legacyProps.fieldsExcludedFromBody || [];
 
     const inputFields =

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -427,6 +427,19 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_write_action_fields: function(bundle) {
+        // Make sure bundle.action_fields is filtered, bundle.action_fields_full
+        // isn't, and bundle.action_fields_raw still got curlies
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.data = z.JSON.stringify({
+          action_fields: bundle.action_fields,
+          action_fields_full: bundle.action_fields_full,
+          action_fields_raw: bundle.action_fields_raw,
+          orig_data: z.JSON.parse(bundle.request.data)
+        });
+        return bundle.request;
+      },
+
       movie_post_write_sloppy_mode: function(bundle) {
         // Would throw a ReferenceError in strict mode
         data = z.JSON.parse(bundle.response.content);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In Web Builder, there's a "Send in Action Endpoint URL in JSON body" checkbox for each action field:
![](https://zappy.zapier.com/4c5f9c96c4a938cef55299b017946d49.png)

Currently, legacy-scripting-runner respects this checkbox for `bundle.request.data` but not for `bundle.action_fields`. Action fields that disable this option (unchecked) shouldn't go to `bundle.action_fields` but still appear in `bundle.action_fields_full` and bundle.action_fields_raw`.