### PR TITLE
Preserve values that also include empty curlies

### DIFF
--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -653,12 +653,16 @@ describe('request client', () => {
         url: 'https://httpbin.org/post',
         method: 'POST',
         body: {
-          empty: '{{bundle.inputData.empty}}'
+          empty: '{{bundle.inputData.empty}}',
+          partial: 'text {{bundle.inputData.partial}}',
+          value: 'exists'
         }
       }).then(response => {
         const { json } = response.json;
 
         should(json.empty).eql('');
+        should(json.partial).eql('text ');
+        should(json.value).eql('exists');
       });
     });
 


### PR DESCRIPTION
fix(core): Preserve values that also include empty curlies in request body

Fixes a bug where we expect `body: { partial: 'text {{123__unresolved_curly}}' } }` to include `'text'` in the value sent to the API. 

Instead we were removing the whole field from the request if we found an unresolved curly. This fix preserves the hardcoded value so that:
```js
body: { partial: 'text {{123__unresolved_curly}}' } }

// becomes

body: { partial: 'text' } }
```
