### PR TITLE
fix(legacy-scripting-runner): $.each should accept an array element at second arg

### DIFF
--- a/packages/legacy-scripting-runner/$.js
+++ b/packages/legacy-scripting-runner/$.js
@@ -54,7 +54,7 @@ $.type = obj => {
 };
 
 $.each = (arr, func) => {
-  arr.forEach((elem, i) => func.bind(elem)(i));
+  arr.forEach((elem, i) => func.bind(elem)(i, elem));
 };
 
 module.exports = $;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -148,8 +148,10 @@ const legacyScriptingSource = `
         contacts[0].type = $.type(contacts);
 
         var base = 1000;
-        $.each(contacts, function(index) {
-          this.anotherId = base + index;
+        $.each(contacts, function(index, item) {
+          // 'item' and 'this' should be the same object
+          this.anotherId = base;
+          item.anotherId += index;
         });
 
         return contacts;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Allows jQuery `$.each` to have a second argument. Example:

```js
var arr = ['a', 'b', 'c'];
$.each(arr, function(index, item) {
  // ...
});
```