### PR TITLE
fix(legacy-scripting-runner) non-string-like headers shouldn't blow up

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -220,7 +220,7 @@ const cleanHeaders = headers => {
       k = k.replace(badChars, '').trim();
     }
     if (k) {
-      if (v) {
+      if (v && v.replace) {
         v = v.replace(badChars, '').trim();
       }
       newHeaders[k] = v;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -219,6 +219,12 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_number_header: function(bundle) {
+        bundle.request.headers['x-api-key'] = Math.floor( Date.now() / 1000 )
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        return bundle.request;
+      },
+
       getMovesUrl: function() {
         return '${AUTH_JSON_SERVER_URL}/movies';
       },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -646,6 +646,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, hash in headers', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_number_header',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then(output => {
+        const echoed = output.results[0];
+        should.exist(echoed.headers['X-Api-Key']);
+      });
+    });
+
     it('KEY_pre_poll, this binding', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(


### PR DESCRIPTION
Change header code to be a little more defensive around calling `.replace`