### PR TITLE
fix(core) improve `appTester` types and bump node versions

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -14,10 +14,10 @@ export const tools: { env: { inject: (filename?: string) => void } };
 export const createAppTester: (
   appRaw: object,
   options?: { customStoreKey?: string }
-) => <T extends any, B extends Bundle>(
-  func: (z: ZObject, bundle: B) => Promise<T>,
+) => <T, B extends Bundle>(
+  func: (z: ZObject, bundle: B) => T | Promise<T>,
   bundle?: Partial<B> // partial so we don't have to make a full bundle in tests
-) => T extends Promise<T> ? T : Promise<T>;
+) => Promise<T>; // appTester always returns a promise
 
 // internal only
 // export const integrationTestHandler: () => any;
@@ -51,12 +51,14 @@ export interface Bundle<InputData = { [x: string]: any }> {
     headers: { [x: string]: string };
     content: string;
   }>;
-  cleanedRequest?: Partial<{
-    method: HttpMethod;
-    querystring: { [x: string]: string };
-    headers: { [x: string]: string };
-    content: { [x: string]: string };
-  }> | any;
+  cleanedRequest?:
+    | Partial<{
+        method: HttpMethod;
+        querystring: { [x: string]: string };
+        headers: { [x: string]: string };
+        content: { [x: string]: string };
+      }>
+    | any;
   subscribeData?: { id: string };
   targetUrl?: string;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,6 @@
     "mock-fs": "4.10.1"
   },
   "optionalDependencies": {
-    "@types/node": "8.10.20"
+    "@types/node": "^10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1138,6 +1138,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
   integrity sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==
 
+"@types/node@^10":
+  version "10.17.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
+  integrity sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
Per discussion in [this comment](https://github.com/zapier/zapier-platform/issues/8#issuecomment-591877355), tweaking the types for `appTester` so it accepts perform methods that are synchronous.

In addition to changing the output type of `perform`, I simplified what `appTester` itself returns, since it always returns a promise. This is safe because there was a logic error before and it always evaluated to `Promise<T>` anyway. You can test that in [the playground](https://www.typescriptlang.org/play/#code/C4TwDgpgBA5hB2EBOBLAxgMQK7zVAvFADwAqAfABQCGSMAXFCQJQFmNQQAewCAJgM5QACkgD2AWxT8IpNgH4o-YKngwoDeFnEAjZAG4AUAbSj4SqCdEAbBnESpMOPIQrAAFilUMq8EC3xs7p4wRgD0oVDioljSUKIAbsgcVGhuUAAGllbpUJ7xomhUwCimADRQ7tBIEMBYSPAV4NBSUFRWAO5UIILpmjrI6QbhrYIAZjQjUACSFj4VEFZW5ZXVAOSC8KK58GBYwBVuRVCHglRQ1bX1jZAZSiowg1kUIhJSEAB01fzWiRQAzH8mExjKJrM8xJJpJ8IN8rL9VlR+LxRqsgSCwQAmQHoqwUBFIlHAp6aRZE0G4nC8CCjTwQXhksEAb0q8AYqxpiFWAF8GbiANp-AC6vPBryhXx+EFFkI+ErhUsBQKAA).

Also bumps the included node types. Doesn't matter much, but it's nice to have up to date ones. 