### PR TITLE
fix(legacy-scripting-runner): allow post_oauthv2_token to return nothing

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -569,10 +569,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       //       returns the first top-level array in the result if result
       //       is an object.
       //   - 'object-first': returns the first object if result is an array.
+      // * defaultToResponse: default to response if post method returns empty
       checkResponseStatus: true,
       parseResponse: true,
       ensureType: false,
       resetRequestForFullMethod: false,
+      defaultToResponse: false,
 
       ...options
     };
@@ -640,6 +642,13 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
           zcli,
           bundle
         );
+        if (options.defaultToResponse && !result) {
+          try {
+            result = zcli.JSON.parse(response.content);
+          } catch {
+            result = {};
+          }
+        }
       } else {
         try {
           result = zcli.JSON.parse(response.content);
@@ -773,7 +782,9 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       bundle,
       '',
       'auth.oauth2.token.pre',
-      'auth.oauth2.token.post'
+      'auth.oauth2.token.post',
+      undefined,
+      { defaultToResponse: true }
     ).catch(() => {
       request = bundle.request;
       request.body = {};
@@ -789,7 +800,9 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         bundle,
         '',
         'auth.oauth2.token.pre',
-        'auth.oauth2.token.post'
+        'auth.oauth2.token.post',
+        undefined,
+        { defaultToResponse: true }
       );
     });
   };

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "aws-sdk": "2.140.0",
     "nock": "10.0.6",
-    "zapier-platform-core": "^7.6.0"
+    "zapier-platform-core": ">=7.6.0"
   }
 }

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -87,10 +87,13 @@ const legacyScriptingSource = `
 
       pre_oauthv2_refresh_bundle_load: function(bundle) {
         bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
-        debugger;
         bundle.request.data = qs.stringify(bundle.load);
         bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
         return bundle.request;
+      },
+
+      post_oauthv2_token_returns_nothing: function(bundle) {
+        // do nothing
       },
 
       get_connection_label: function(bundle) {
@@ -568,7 +571,6 @@ const legacyScriptingSource = `
           type: 'dict',
           list: true
         });
-        debugger;
         return fields;
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -388,6 +388,34 @@ describe('Integration Test', () => {
         });
       });
     });
+
+    it('post_oauthv2_token, returns nothing', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'post_oauthv2_token:',
+        'dont_care:'
+      );
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'post_oauthv2_token_returns_nothing',
+        'post_oauthv2_token'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.getAccessToken'
+      );
+      input.bundle.inputData = {
+        redirect_uri: 'https://example.com',
+        code: 'one_time_code'
+      };
+      return app(input).then(output => {
+        should.equal(output.results.access_token, 'a_token');
+        should.equal(output.results.something_custom, 'alright!');
+        should.not.exist(output.results.name);
+      });
+    });
   });
 
   describe('polling trigger', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,11 +1133,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.9.tgz#4f251a1ed77ac7ef09d456247d67fc8173f6b9da"
   integrity sha512-+6VygF9LbG7Gaqeog2G7u1+RUcmo0q1rI+2ZxdIg2fAUngk5Vz9fOCHXdloNUOHEPd1EuuOpL5O0CdgN9Fx5UQ==
 
-"@types/node@8.10.20":
-  version "8.10.20"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
-  integrity sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==
-
 "@types/node@^10":
   version "10.17.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
@@ -2323,11 +2318,6 @@ bl@^3.0.0:
   dependencies:
     readable-stream "^3.0.1"
 
-bluebird@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
-  integrity sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=
-
 bluebird@3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
@@ -3125,13 +3115,6 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     inline-source-map "~0.6.0"
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
-
-combined-stream@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
-  integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
-  dependencies:
-    delayed-stream "~1.0.0"
 
 combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.8"
@@ -4015,11 +3998,6 @@ dot-prop@^4.1.0, dot-prop@^4.2.0:
   integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
   dependencies:
     is-obj "^1.0.0"
-
-dotenv@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
-  integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
 
 dotenv@8.1.0:
   version "8.1.0"
@@ -4955,15 +4933,6 @@ form-data@2.1.4, form-data@~2.1.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
-form-data@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
     mime-types "^2.1.12"
 
 form-data@2.5.0:
@@ -6588,11 +6557,6 @@ jsonpointer@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
   integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
 
-jsonschema@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.1.1.tgz#3cede8e3e411d377872eefbc9fdf26383cbc3ed9"
-  integrity sha1-PO3o4+QR03eHLu+8n98mODy8Ptk=
-
 jsonschema@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.2.tgz#83ab9c63d65bf4d596f91d81195e78772f6452bc"
@@ -7071,11 +7035,6 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
-
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
 
 lodash@4.17.11:
   version "4.17.11"
@@ -11145,31 +11104,6 @@ yauzl@^2.4.2:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
-
-zapier-platform-core@^7.6.0:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/zapier-platform-core/-/zapier-platform-core-7.6.1.tgz#0219bf35ae5f725fdc8d74e6732af588561ea4ab"
-  integrity sha512-qJQBNRqqGIBqz6bQqPMdHfC9y2zqz8XaW12M/IcJxf2bNr6OeaQXo6EG5mJxRevrnCwUUZA3gkuSBcZh5Lj7/Q==
-  dependencies:
-    bluebird "3.5.0"
-    content-disposition "0.5.2"
-    dotenv "5.0.1"
-    form-data "2.3.2"
-    lodash "4.17.10"
-    node-fetch "1.7.1"
-    oauth-sign "0.9.0"
-    semver "5.6.0"
-    zapier-platform-schema "7.6.1"
-  optionalDependencies:
-    "@types/node" "8.10.20"
-
-zapier-platform-schema@7.6.1:
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/zapier-platform-schema/-/zapier-platform-schema-7.6.1.tgz#cb0bd7bd4aee824d5b0ceb4cdd5985ebf12ca01a"
-  integrity sha512-dukEV5CczloLfDSb5N05syIkqcOZSZjHt6bOBKkN6G66O90epM+KFWb4BuO9YUO2Q6pHRUjIR9rTZN/P60s5Yw==
-  dependencies:
-    jsonschema "1.1.1"
-    lodash "4.17.10"
 
 zip-stream@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Allows `post_oauthv2_token` to return nothing and default to the response content.

Also updates the core dependency for legacy-scripting-runner.
