### PR TITLE
fix(cli): analytics shouldn't need a valid app install

### DIFF
--- a/packages/cli/src/utils/misc.js
+++ b/packages/cli/src/utils/misc.js
@@ -79,9 +79,15 @@ const isValidNodeVersion = (version = process.version) =>
 
 const isValidAppInstall = command => {
   if (
-    ['help', 'init', 'login', 'integrations', 'convert', 'logout'].includes(
-      command
-    )
+    [
+      'analytics',
+      'help',
+      'init',
+      'login',
+      'integrations',
+      'convert',
+      'logout'
+    ].includes(command)
   ) {
     return { valid: true };
   }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

`zapier analytics` is not an app-specific command, so it shouldn't need a valid app install.