### PR TITLE
refactor(core): fix smoke test cyclic dependency

### DIFF
--- a/packages/cli/src/smoke-tests/smoke-tests.js
+++ b/packages/cli/src/smoke-tests/smoke-tests.js
@@ -82,12 +82,14 @@ describe('smoke tests - setup will take some time', () => {
     fs.removeSync(context.workdir);
   });
 
-  it('package size should not change much', async () => {
+  it('package size should not change much', async function() {
     const packageName = 'zapier-platform-cli';
     const latestVersion = await getPackageLatestVersion(packageName);
     const baselineSize = await getPackageSize(packageName, latestVersion);
     const newSize = fs.statSync(context.package.path).size;
     newSize.should.be.within(baselineSize * 0.7, baselineSize * 1.3);
+
+    this.test.title += ` (${baselineSize} -> ${newSize} bytes)`;
   });
 
   it('cli executable should exist', () => {
@@ -134,11 +136,14 @@ describe('smoke tests - setup will take some time', () => {
     pkg.name.should.containEql('babel');
   });
 
-  it('zapier apps', function() {
+  it('zapier integrations', function() {
     if (!context.hasRC) {
       this.skip();
     }
-    const stdout = runCommand(context.cliBin, ['apps', '--format=json']);
+    const stdout = runCommand(context.cliBin, [
+      'integrations',
+      '--format=json'
+    ]);
     const result = JSON.parse(stdout);
     result.should.be.Array();
   });

--- a/packages/schema/smoke-test/smoke-test.js
+++ b/packages/schema/smoke-test/smoke-test.js
@@ -78,7 +78,7 @@ describe('smoke tests - setup will take some time', () => {
     fs.removeSync(context.workdir);
   });
 
-  it('package size should not change much', async () => {
+  it('package size should not change much', async function() {
     const baseUrl = 'https://registry.npmjs.org/zapier-platform-schema';
     let res = await fetch(baseUrl);
     const packageInfo = await res.json();
@@ -93,6 +93,8 @@ describe('smoke tests - setup will take some time', () => {
     const baselineSize = res.headers.get('content-length');
     const newSize = fs.statSync(context.package.path).size;
     newSize.should.be.within(baselineSize * 0.7, baselineSize * 1.3);
+
+    this.test.title += ` (${baselineSize} -> ${newSize} bytes)`;
   });
 
   it('should to able to validate app definitions', () => {

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -134,6 +134,31 @@ const promptVersionToBump = async packageName => {
   return answer.versionToBump;
 };
 
+const bumpMainPackagesForExampleApps = versionToBump => {
+  const examplesDir = path.join(REPO_DIR, 'example-apps');
+  fs.readdirSync(examplesDir, { withFileTypes: true }).map(item => {
+    if (item.isDirectory()) {
+      const packageJsonPath = path.join(examplesDir, item.name, 'package.json');
+      const packageJson = readJson(packageJsonPath);
+
+      ['cli', 'core', 'schema'].map(packageName => {
+        const packageFullName = `zapier-platform-${packageName}`;
+        if (packageJson.dependencies) {
+          const depVersion = packageJson.dependencies[packageFullName];
+          if (depVersion) {
+            console.log(
+              `${item.name}'s dependency ${packageName} ${depVersion} -> ${versionToBump}`
+            );
+            packageJson.dependencies[packageFullName] = versionToBump;
+          }
+        }
+      });
+
+      writeJson(packageJsonPath, packageJson);
+    }
+  });
+};
+
 // Main packages are cli, core, schema
 const bumpMainPackages = versionToBump => {
   const PACKAGES = ['cli', 'core', 'schema'];
@@ -185,6 +210,7 @@ const bumpExtensionPackage = (packageName, versionToBump) => {
 const bumpPackages = (packageName, versionToBump) => {
   if (packageName === 'cli, core, schema') {
     bumpMainPackages(versionToBump);
+    bumpMainPackagesForExampleApps(versionToBump);
   } else {
     bumpExtensionPackage(packageName, versionToBump);
   }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Addresses [PDE-1318](https://zapierorg.atlassian.net/browse/PDE-1318).

There's a cyclic dependency in our release process:
1. `yarn bump` bumps example apps' core version
2. core's smoke tests do live `npm install` on the example apps. Since the new core version hasn't published to npm yet, the install would fail.
3. To successfully `npm publish`, smoke tests must pass. But smoke tests couldn't pass because of 2.

This PR addresses 2 so core's smoke tests no longer download the new core version from npm.

There are some minor changes. I'll annotate them in the comments.