### PR TITLE
fix(legacy-scripting-runner): pass through bundle.rawRequest for hooks

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -97,7 +97,7 @@ const addInputData = (event, bundle, convertedBundle) => {
       convertedBundle.read_context = bundle.inputData;
     }
   } else if (event.name === 'hydrate.method') {
-    _.extend(convertedBundle, bundle.inputData.bundle);
+    Object.assign(convertedBundle, bundle.inputData.bundle);
   }
 };
 
@@ -127,11 +127,15 @@ const addHookData = (event, bundle, convertedBundle) => {
 };
 
 const addRequestData = async (event, z, bundle, convertedBundle) => {
-  const headers = _.get(bundle, 'request.headers', {});
-  _.extend(convertedBundle.request.headers, headers);
+  Object.assign(
+    convertedBundle.request.headers,
+    _.get(bundle, 'request.headers')
+  );
 
-  const params = _.get(bundle, 'request.params', {});
-  _.extend(convertedBundle.request.params, params);
+  Object.assign(
+    convertedBundle.request.params,
+    _.get(bundle, 'request.params')
+  );
 
   const body = _.get(bundle, 'request.body');
   if (!_.isEmpty(body)) {
@@ -265,8 +269,8 @@ const bundleConverter = async (bundle, event, z) => {
 
   addAuthData(event, bundle, convertedBundle);
   addInputData(event, bundle, convertedBundle);
-  addHookData(event, bundle, convertedBundle);
   await addRequestData(event, z, bundle, convertedBundle);
+  addHookData(event, bundle, convertedBundle);
   addResponse(event, bundle, convertedBundle);
 
   return convertedBundle;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -291,6 +291,16 @@ const legacyScriptingSource = `
         return results;
       },
 
+      contact_hook_scripting_catch_hook_raw_request: function(bundle) {
+        // Make sure bundle.request is kept intact
+        return {
+          id: 1,
+          headers: bundle.request.headers,
+          querystring: bundle.request.querystring,
+          content: bundle.request.content
+        };
+      },
+
       // To be replaced with 'contact_hook_scripting_pre_hook' at runtime to enable
       contact_hook_scripting_pre_hook_disabled: function(bundle) {
         bundle.request.url = bundle.request.url.replace('/users/', '/movies/');

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1144,6 +1144,34 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_catch_hook, raw request', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'contact_hook_scripting_catch_hook_raw_request',
+        'contact_hook_scripting_catch_hook'
+      );
+      const app = createApp(appDef);
+      const input = createTestInput(
+        appDef,
+        'triggers.contact_hook_scripting.operation.perform'
+      );
+      input.bundle.rawRequest = {
+        headers: {
+          'Content-Type': 'application/xml',
+          'Http-X-Custom': 'hello'
+        },
+        content: '<name>Tom</name>',
+        querystring: 'foo=bar'
+      };
+      return app(input).then(output => {
+        const result = output.results[0];
+        should.equal(result.headers['Content-Type'], 'application/xml');
+        should.equal(result.headers['Http-X-Custom'], 'hello');
+        should.equal(result.content, '<name>Tom</name>');
+        should.equal(result.querystring, 'foo=bar');
+      });
+    });
+
     it('REST Hook should ignore KEY_pre_hook', () => {
       // Not a Notication REST hook, KEY_pre_hook should be ignored
       const appDef = _.cloneDeep(appDefinition);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

When catching a hook, we should pass `bundle.rawRequest` to `KEY_catch_hook` as `bundle.request`.