### PR TITLE
feat(legacy-scripting-runner): log converted bundles

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -357,6 +357,7 @@ const createEventNameToMethodMapping = key => {
 
 const legacyScriptingRunner = (Zap, zcli, input) => {
   const app = _.get(input, '_zapier.app');
+  const logger = _.get(input, '_zapier.logger');
 
   if (typeof Zap === 'string') {
     Zap = compileLegacyScriptingSource(Zap, zcli, app);
@@ -533,12 +534,17 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
             return;
           }
 
-          // Handle sync
-          if (!isAsync) {
-            parseFinalResult(result, event).then(res => {
-              resolve(res);
-            });
-          }
+          logger(`Called legacy scripting ${methodName}`, {
+            request_data: convertedBundle,
+            log_type: 'bundle'
+          }).then(() => {
+            // Handle sync
+            if (!isAsync) {
+              parseFinalResult(result, event).then(res => {
+                resolve(res);
+              });
+            }
+          });
         } else {
           resolve({});
         }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Every time a scripting method is run, log the converted bundle for debugging.