### PR TITLE
Allow env variables containing equals

### DIFF
--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -30,7 +30,8 @@ class SetEnvCommand extends BaseCommand {
     // if we get here, we should have well-formed input
 
     const payload = valuesToSet.reduce((result, kvPair) => {
-      const [key, value] = kvPair.split('=');
+      const key = kvPair.split('=')[0]
+      const value = kvPair.split(/=(.+)/)[1] // Guards against SECURE_KEY=8n*e9!=92g
       result[key.toUpperCase()] = value;
       return result;
     }, {});

--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -30,8 +30,8 @@ class SetEnvCommand extends BaseCommand {
     // if we get here, we should have well-formed input
 
     const payload = valuesToSet.reduce((result, kvPair) => {
-      const key = kvPair.split('=')[0]
-      const value = kvPair.split(/=(.+)/)[1] // Guards against SECURE_KEY=8n*e9!=92g
+      const [key, ...valueParts] = kvPair.split('=')
+      const value = valueParts.join('=') // Guards against values with = characters
       result[key.toUpperCase()] = value;
       return result;
     }, {});


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

fix(cli): Correctly parse out env variables that contain an equal sign

Fixes a bug where we don't correctly parse env variables that contain an equal sign as part of the variable. An equal sign is a valid special character and occurs reasonably often in things such as CLIENT_SECRETS, etc. This seems to be a regression as the previous `env` command didn't parse those incorrectly.