### PR TITLE
fix(legacy-scripting-runner): run post method first before throwing response status error

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -633,11 +633,10 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
       const response = await zcli.request(request);
 
-      if (options.checkResponseStatus) {
-        response.throwForStatus();
-      }
-
       if (!options.parseResponse) {
+        if (options.checkResponseStatus) {
+          response.throwForStatus();
+        }
         return response;
       }
 
@@ -650,6 +649,13 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
           zcli,
           bundle
         );
+
+        if (options.checkResponseStatus) {
+          // Raising this error AFTER postMethod is executed allows devs to
+          // intercept and throw another error from postMethod
+          response.throwForStatus();
+        }
+
         if (options.defaultToResponse && !result) {
           try {
             result = zcli.JSON.parse(response.content);
@@ -658,6 +664,10 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
           }
         }
       } else {
+        if (options.checkResponseStatus) {
+          response.throwForStatus();
+        }
+
         try {
           result = zcli.JSON.parse(response.content);
         } catch {

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -503,6 +503,18 @@ const legacyScriptingSource = `
         return 'ok';
       },
 
+      movie_pre_write_intercept_error: function(bundle) {
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/status/418';
+        return bundle.request;
+      },
+
+      movie_post_write_intercept_error: function(bundle) {
+        if (bundle.response.status_code == 418) {
+          throw new HaltedException('teapot here, go find a coffee machine');
+        }
+        return z.JSON.parse(bundle.response.content);
+      },
+
       movie_pre_write_default_headers: function(bundle) {
         // Copy Accept and Content-Type to request body so we know they're
         // already available in pre_write

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1944,6 +1944,28 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_post_write, intercept error', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_write_intercept_error',
+        'movie_pre_write'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_write_intercept_error',
+        'movie_post_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).should.be.rejectedWith(
+        /teapot here, go find a coffee machine/
+      );
+    });
+
     it('KEY_pre_write & KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

If the response is an error (status code >= 400), Web Builder would call the `post` method then raise an exception for the error response.

But legacy-scripting-runner is doing it differently: It raises an exception without calling the post method. This PR fixes that.