### PR TITLE
tooling(boilerplate): wait for schema to be published when building boilerplate

### DIFF
--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -92,9 +92,9 @@ const ensureNoUncommittedChanges = () => {
 const promptPackagesToBump = async () => {
   const answer = await inquirer.prompt([
     {
-      type: 'checkbox',
+      type: 'list',
       message: 'What package(s) you want to bump?',
-      name: 'packages',
+      name: 'package',
       choices: [
         {
           name: `cli, core, schema (currently ${PACKAGE_ORIG_VERSIONS.cli})`,
@@ -109,7 +109,7 @@ const promptPackagesToBump = async () => {
       ]
     }
   ]);
-  return answer.packages;
+  return [answer.package];
 };
 
 const promptVersionToBump = async packageName => {
@@ -320,7 +320,9 @@ const main = async () => {
   }
 
   console.log(
-    `\nDone! Now you should ${bold.underline('git push origin master --tags')}.`
+    `\nDone! Review the change with ${bold.underline(
+      'git diff HEAD~1..HEAD'
+    )} then ${bold.underline('git push origin master --tags')}.`
   );
   return 0;
 };

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -53,6 +53,21 @@ if [[ "$CORE_VERSION" != "" && "$LEGACY_VERSION" != "" ]]; then
     echo "Let's wait for a second for the packages to be available on npm..."
     sleep 10
 
+    retries=0
+    SCHEMA_VERSION=$(curl https://registry.npmjs.org/zapier-platform-schema/latest | jq -r .version)
+    until [ $SCHEMA_VERSION == $CORE_VERSION ] || [ retries == 60 ]
+    do
+        echo "Waiting for zapier-platform-schema to be published to npm..."
+        sleep 5
+        SCHEMA_VERSION=$(curl https://registry.npmjs.org/zapier-platform-schema/latest | jq -r .version)
+        ((retries++))
+    done
+
+    if [[ $SCHEMA_VERSION != $CORE_VERSION ]]; then
+        echo "Latest version of zapier-platform-schema still hasn't published to npm. Can't build boilerplate, sorry."
+        exit 1
+    fi
+
     # Build boilerplate and let Zapier know about this
     ./boilerplate/scripts/build.sh $CORE_VERSION $LEGACY_VERSION &&
     ./boilerplate/scripts/upload.sh $CORE_VERSION &&


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes https://travis-ci.com/github/zapier/zapier-platform/builds/155448960#L1293, an issue I ran into when releasing 9.2.0. We'll test it again if it works next time we release a new version.

Also changes the bump script so we can only bump either `cli/core/schema` or `legacy-scripting-runner`. Bumping both doesn't really work. `legacy-scripting-runner` would have to wait until the new version of `core/schema` to be published but we aren't doing that.