### PR TITLE
fix(core): show variable name in curlies type error

### DIFF
--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -77,10 +77,12 @@ const recurseReplaceBank = (obj, bank = {}) => {
         (Array.isArray(replacementValue) || _.isPlainObject(replacementValue));
 
       if (shouldThrowTypeError) {
+        const bareKey = _.trimEnd(_.trimStart(key, '{'), '}');
         throw new TypeError(
-          `Cannot reliably interpolate objects or arrays into a string. We received an ${getObjectType(
-            replacementValue
-          )}:\n"${replacementValue}"`
+          'Cannot reliably interpolate objects or arrays into a string. ' +
+            `Variable \`${bareKey}\` is an ${getObjectType(
+              replacementValue
+            )}:\n"${replacementValue}"`
         );
       }
 

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -713,7 +713,8 @@ describe('request client', () => {
           message: 'No arrays, thank you: {{bundle.inputData.badData}}'
         }
       }).should.be.rejectedWith(
-        'Cannot reliably interpolate objects or arrays into a string. We received an Array:\n"1,2,3"'
+        'Cannot reliably interpolate objects or arrays into a string. ' +
+          'Variable `bundle.inputData.badData` is an Array:\n"1,2,3"'
       );
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

We've seen many developers getting confused by the error message `Cannot reliable interpolate objects or arrays into a string`. It can be hard to figure out which trigger or action is having an issue without knowing the variable being resolved.

This PR changes the error message from:

```
Cannot reliable interpolate objects or arrays into a string. We received an Array:
"1,2,3"
```

to

```
Cannot reliable interpolate objects or arrays into a string. Variable `bundle.inputData.foo` is an Array:
"1,2,3"
```