### PR TITLE
feat(core): New error classes that support error codes and statuses

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2733,6 +2733,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><code>z.errors</code> is a collection error classes that you can throw in your code, like <code>throw new z.errors.HaltedError(&apos;...&apos;)</code>.</p><p>The available errors are:</p><ul>
+<li>Error - Stops the current operation, allowing for (auto) replay. Read more on <a href="#general-errors">General Errors</a></li>
 <li>HaltedError - Stops current operation, but will never turn off Zap. Read more on <a href="#halting-execution">Halting Execution</a></li>
 <li>ExpiredAuthError - Turns off Zap and emails user to manually reconnect. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 <li>RefreshAuthError - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
@@ -3946,13 +3947,16 @@ various kinds of errors occur.</p>
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Errors due to a misconfiguration in a user&apos;s Zap should be handled in your app
-by throwing a standard JavaScript <code>Error</code> with a user-friendly message.
-Typically, this will be prettifying 4xx responses or APIs that return errors as
-200s with a payload that describes the error.</p><p>Example: <code>throw new Error(&apos;Your error message.&apos;);</code></p><p>A couple best practices to keep in mind:</p><ul>
+by throwing <code>z.errors.Error</code> with a user-friendly message and optional error and
+status code. Typically, this will be prettifying 4xx responses or APIs that return
+errors as 200s with a payload that describes the error.</p><p>Example: <code>throw new z.errors.Error(&apos;Contact name is too long.&apos;, &apos;InvalidData&apos;, 400);</code></p><p>A couple best practices to keep in mind:</p><ul>
 <li>Elaborate on terse messages. &quot;not_authenticated&quot; -&gt; &quot;Your API Key is invalid. Please reconnect your account.&quot;</li>
-<li>If the error calls out a specific field, surface that information to the user. &quot;Invalid Request&quot; -&gt; &quot;contact name is invalid&quot;</li>
-<li>If the error provides details about why a field is invalid, add that in too! &quot;contact name is invalid&quot; -&gt; &quot;contact name is too long&quot;</li>
-</ul><p>Note that if a Zap raises too many error messages it will be automatically
+<li>If the error calls out a specific field, surface that information to the user. &quot;Provided data is invalid&quot; -&gt; &quot;Contact name is invalid&quot;</li>
+<li>If the error provides details about why a field is invalid, add that in too! &quot;Contact name is invalid&quot; -&gt; &quot;Contact name is too long&quot;</li>
+<li>The second, optional argument should be a code that a computer could use to identify the type of error.</li>
+<li>The last, optional argument should be the HTTP status code, if any.</li>
+</ul><p>The code and status can be used by us to provide relevant troubleshooting to the
+user when we communicate the error.</p><p>Note that if a Zap raises too many error messages it will be automatically
 turned off, so only use these if the scenario is truly an error that needs to
 be fixed.</p>
     </div>
@@ -3977,7 +3981,7 @@ stopped for some specific reason) with a <code>HaltedError</code>. You might fin
 using this error in cases where a required pre-condition is not met. For instance,
 in a create to add an email address to a list where duplicates are not allowed,
 you would want to throw a <code>HaltedError</code> if the Zap attempted to add a duplicate.
-This would indicate failure, but it would be treated as a soft failure.</p><p>Unlike throwing <code>Error</code>, a Zap will never by turned off when this error is thrown
+This would indicate failure, but it would be treated as a soft failure.</p><p>Unlike throwing <code>z.errors.Error</code>, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).</p><p>Example: <code>throw new z.errors.HaltedError(&apos;Your reason.&apos;);</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -704,6 +704,7 @@ We provide several methods off of the `z` object, which is provided as the first
 
 The available errors are:
 
+* Error - Stops the current operation, allowing for (auto) replay. Read more on [General Errors](#general-errors)
 * HaltedError - Stops current operation, but will never turn off Zap. Read more on [Halting Execution](#halting-execution)
 * ExpiredAuthError - Turns off Zap and emails user to manually reconnect. Read more on [Stale Authentication Credentials](#stale-authentication-credentials)
 * RefreshAuthError - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on [Stale Authentication Credentials](#stale-authentication-credentials)
@@ -1222,17 +1223,22 @@ various kinds of errors occur.
 ### General Errors
 
 Errors due to a misconfiguration in a user's Zap should be handled in your app
-by throwing a standard JavaScript `Error` with a user-friendly message.
-Typically, this will be prettifying 4xx responses or APIs that return errors as
-200s with a payload that describes the error.
+by throwing `z.errors.Error` with a user-friendly message and optional error and
+status code. Typically, this will be prettifying 4xx responses or APIs that return
+errors as 200s with a payload that describes the error.
 
-Example: `throw new Error('Your error message.');`
+Example: `throw new z.errors.Error('Contact name is too long.', 'InvalidData', 400);`
 
 A couple best practices to keep in mind:
 
   * Elaborate on terse messages. "not_authenticated" -> "Your API Key is invalid. Please reconnect your account."
-  * If the error calls out a specific field, surface that information to the user. "Invalid Request" -> "contact name is invalid"
-  * If the error provides details about why a field is invalid, add that in too! "contact name is invalid" -> "contact name is too long"
+  * If the error calls out a specific field, surface that information to the user. "Provided data is invalid" -> "Contact name is invalid"
+  * If the error provides details about why a field is invalid, add that in too! "Contact name is invalid" -> "Contact name is too long"
+  * The second, optional argument should be a code that a computer could use to identify the type of error.
+  * The last, optional argument should be the HTTP status code, if any.
+
+The code and status can be used by us to provide relevant troubleshooting to the
+user when we communicate the error.
 
 Note that if a Zap raises too many error messages it will be automatically
 turned off, so only use these if the scenario is truly an error that needs to
@@ -1247,7 +1253,7 @@ in a create to add an email address to a list where duplicates are not allowed,
 you would want to throw a `HaltedError` if the Zap attempted to add a duplicate.
 This would indicate failure, but it would be treated as a soft failure.
 
-Unlike throwing `Error`, a Zap will never by turned off when this error is thrown
+Unlike throwing `z.errors.Error`, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).
 
 Example: `throw new z.errors.HaltedError('Your reason.');`

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2733,6 +2733,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><code>z.errors</code> is a collection error classes that you can throw in your code, like <code>throw new z.errors.HaltedError(&apos;...&apos;)</code>.</p><p>The available errors are:</p><ul>
+<li>Error - Stops the current operation, allowing for (auto) replay. Read more on <a href="#general-errors">General Errors</a></li>
 <li>HaltedError - Stops current operation, but will never turn off Zap. Read more on <a href="#halting-execution">Halting Execution</a></li>
 <li>ExpiredAuthError - Turns off Zap and emails user to manually reconnect. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 <li>RefreshAuthError - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
@@ -3946,13 +3947,16 @@ various kinds of errors occur.</p>
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Errors due to a misconfiguration in a user&apos;s Zap should be handled in your app
-by throwing a standard JavaScript <code>Error</code> with a user-friendly message.
-Typically, this will be prettifying 4xx responses or APIs that return errors as
-200s with a payload that describes the error.</p><p>Example: <code>throw new Error(&apos;Your error message.&apos;);</code></p><p>A couple best practices to keep in mind:</p><ul>
+by throwing <code>z.errors.Error</code> with a user-friendly message and optional error and
+status code. Typically, this will be prettifying 4xx responses or APIs that return
+errors as 200s with a payload that describes the error.</p><p>Example: <code>throw new z.errors.Error(&apos;Contact name is too long.&apos;, &apos;InvalidData&apos;, 400);</code></p><p>A couple best practices to keep in mind:</p><ul>
 <li>Elaborate on terse messages. &quot;not_authenticated&quot; -&gt; &quot;Your API Key is invalid. Please reconnect your account.&quot;</li>
-<li>If the error calls out a specific field, surface that information to the user. &quot;Invalid Request&quot; -&gt; &quot;contact name is invalid&quot;</li>
-<li>If the error provides details about why a field is invalid, add that in too! &quot;contact name is invalid&quot; -&gt; &quot;contact name is too long&quot;</li>
-</ul><p>Note that if a Zap raises too many error messages it will be automatically
+<li>If the error calls out a specific field, surface that information to the user. &quot;Provided data is invalid&quot; -&gt; &quot;Contact name is invalid&quot;</li>
+<li>If the error provides details about why a field is invalid, add that in too! &quot;Contact name is invalid&quot; -&gt; &quot;Contact name is too long&quot;</li>
+<li>The second, optional argument should be a code that a computer could use to identify the type of error.</li>
+<li>The last, optional argument should be the HTTP status code, if any.</li>
+</ul><p>The code and status can be used by us to provide relevant troubleshooting to the
+user when we communicate the error.</p><p>Note that if a Zap raises too many error messages it will be automatically
 turned off, so only use these if the scenario is truly an error that needs to
 be fixed.</p>
     </div>
@@ -3977,7 +3981,7 @@ stopped for some specific reason) with a <code>HaltedError</code>. You might fin
 using this error in cases where a required pre-condition is not met. For instance,
 in a create to add an email address to a list where duplicates are not allowed,
 you would want to throw a <code>HaltedError</code> if the Zap attempted to add a duplicate.
-This would indicate failure, but it would be treated as a soft failure.</p><p>Unlike throwing <code>Error</code>, a Zap will never by turned off when this error is thrown
+This would indicate failure, but it would be treated as a soft failure.</p><p>Unlike throwing <code>z.errors.Error</code>, a Zap will never by turned off when this error is thrown
 (even if it is raised more often than not).</p><p>Example: <code>throw new z.errors.HaltedError(&apos;Your reason.&apos;);</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -63,6 +63,9 @@ export interface Bundle<InputData = { [x: string]: any }> {
   targetUrl?: string;
 }
 
+declare class AppError extends Error {
+  constructor(message: string, code?: string, status?: number);
+}
 declare class HaltedError extends Error {}
 declare class ExpiredAuthError extends Error {}
 declare class RefreshAuthError extends Error {}
@@ -171,6 +174,7 @@ export interface ZObject {
   ) => string;
 
   errors: {
+    Error: typeof AppError;
     HaltedError: typeof HaltedError;
     ExpiredAuthError: typeof ExpiredAuthError;
     RefreshAuthError: typeof RefreshAuthError;

--- a/packages/core/src/errors.js
+++ b/packages/core/src/errors.js
@@ -3,6 +3,39 @@
 const util = require('util');
 const _ = require('lodash');
 
+class AppError extends Error {
+  constructor(message, code, status) {
+    super(
+      JSON.stringify({
+        message,
+        code,
+        status
+      })
+    );
+    this.name = 'AppError';
+    this.doNotContextify = true;
+  }
+}
+
+class ResponseError extends Error {
+  constructor(response) {
+    super(
+      JSON.stringify({
+        status: response.status,
+        headers: {
+          'content-type': response.headers.get('content-type')
+        },
+        content: response.content,
+        request: {
+          url: response.request.url
+        }
+      })
+    );
+    this.name = 'ResponseError';
+    this.doNotContextify = true;
+  }
+}
+
 // Make some of the errors we'll use!
 const createError = name => {
   const NewError = function(message = '') {
@@ -33,7 +66,10 @@ const exceptions = _.reduce(
     col[name] = createError(name);
     return col;
   },
-  {}
+  {
+    Error: AppError,
+    ResponseError
+  }
 );
 
 const isRequireError = ({ name, message }) =>

--- a/packages/core/src/http-middlewares/after/throw-for-stale-auth.js
+++ b/packages/core/src/http-middlewares/after/throw-for-stale-auth.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const { stripQueryFromURL } = require('../../tools/http');
-
 const errors = require('../../errors');
 
+/**
+ * The server-side will raise `RefreshAuthError` when `autoRefresh === true`.
+ * Once we always run `throwForStatus` or a custom `afterResponse`, we can drop `throwForStaleAuth`.
+ */
 const throwForStaleAuth = resp => {
   if (resp.status === 401) {
-    const cleanURL = stripQueryFromURL(resp.request.url);
-    const message = `Got ${resp.status} calling ${resp.request.method} ${cleanURL}, triggering auth refresh.`;
-    throw new errors.RefreshAuthError(message);
+    throw new errors.ResponseError(resp);
   }
 
   return resp;

--- a/packages/core/src/http-middlewares/after/throw-for-status.js
+++ b/packages/core/src/http-middlewares/after/throw-for-status.js
@@ -1,12 +1,10 @@
 'use strict';
 
-const { stripQueryFromURL } = require('../../tools/http');
+const errors = require('../../errors');
 
 const throwForStatus = resp => {
   if (resp.status > 300) {
-    const cleanURL = stripQueryFromURL(resp.request.url);
-    const message = `Got ${resp.status} calling ${resp.request.method} ${cleanURL}, expected 2xx.`;
-    throw new Error(message);
+    throw new errors.ResponseError(resp);
   }
 
   return resp;

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -165,7 +165,13 @@ const createLambdaHandler = appRawOrPath => {
       // the default behavior with callbacks anyway, but don't want
       // to rely on that.
       logger(logMsg, logData).then(() => {
-        if (!constants.IS_TESTING && err) {
+        // Check for `.message` in case someone did `throw "My Error"`
+        if (
+          !constants.IS_TESTING &&
+          err &&
+          !err.doNotContextify &&
+          err.message
+        ) {
           err.message += `\n\nConsole logs:\n${logBuffer
             .map(s => `  ${s.message}`)
             .join('')}`;

--- a/packages/core/src/tools/http.js
+++ b/packages/core/src/tools/http.js
@@ -1,5 +1,3 @@
-const { URL } = require('url');
-
 const _ = require('lodash');
 const fetch = require('node-fetch');
 
@@ -99,18 +97,11 @@ const parseDictHeader = s => {
 const unheader = h =>
   h instanceof fetch.Headers && _.isFunction(h.toJSON) ? h.toJSON() : h;
 
-const stripQueryFromURL = url => {
-  // Strip off querystring for any sensitive data
-  const u = new URL(url);
-  return u.origin + u.pathname;
-};
-
 module.exports = {
   FORM_TYPE,
   JSON_TYPE,
   JSON_TYPE_UTF8,
   getContentType,
   parseDictHeader,
-  stripQueryFromURL,
   unheader
 };

--- a/packages/core/src/tools/promise.js
+++ b/packages/core/src/tools/promise.js
@@ -23,7 +23,7 @@ const enrichErrorMessage = (err, frameStack) => {
 
 // Because reject callbacks stack, we have to skip errors we've already seen.
 const contextifyOnce = (err, attachErrorTrace, frameStack) => {
-  if (!err || err.isContextified) {
+  if (!err || err.doNotContextify || err.isContextified) {
     return err;
   }
 

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -4,6 +4,7 @@ const should = require('should');
 const createApp = require('../src/create-app');
 const createInput = require('../src/tools/create-input');
 const dataTools = require('../src/tools/data');
+const errors = require('../src/errors');
 const appDefinition = require('./userapp');
 
 describe('create-app', () => {
@@ -130,12 +131,15 @@ describe('create-app', () => {
         done('expected an error');
       })
       .catch(err => {
-        should(err.message).startWith(
-          'Got 403 calling GET https://httpbin.org/status/403, expected 2xx.\nWhat happened:\n  Starting GET request to https://httpbin.org/status/403\n  Received 403 code from https://httpbin.org/status/403 after '
+        should(err).instanceOf(errors.ResponseError);
+        err.name.should.eql('ResponseError');
+        const response = JSON.parse(err.message);
+        should(response.status).equal(403);
+        should(response.request.url).equal('https://httpbin.org/status/403');
+        should(response.headers['content-type']).equal(
+          'text/html; charset=utf-8'
         );
-        should(err.message).endWith(
-          'ms\n  Received content ""\n  Got 403 calling GET https://httpbin.org/status/403, expected 2xx.'
-        );
+        should(response.content).equal('');
         done();
       })
       .catch(done);
@@ -149,12 +153,15 @@ describe('create-app', () => {
         done('expected an error');
       })
       .catch(err => {
-        should(err.message).startWith(
-          'Got 403 calling GET https://httpbin.org/status/403, expected 2xx.\nWhat happened:\n  Starting GET request to https://httpbin.org/status/403\n  Received 403 code from https://httpbin.org/status/403 after '
+        should(err).instanceOf(errors.ResponseError);
+        err.name.should.eql('ResponseError');
+        const response = JSON.parse(err.message);
+        should(response.status).equal(403);
+        should(response.request.url).equal('https://httpbin.org/status/403');
+        should(response.headers['content-type']).equal(
+          'text/html; charset=utf-8'
         );
-        should(err.message).endWith(
-          'ms\n  Received content ""\n  Got 403 calling GET https://httpbin.org/status/403, expected 2xx.'
-        );
+        should(response.content).equal('');
         done();
       })
       .catch(done);
@@ -361,7 +368,10 @@ describe('create-app', () => {
           done('expected an error, got success');
         })
         .catch(error => {
-          error.name.should.eql('RefreshAuthError');
+          should(error).instanceOf(errors.ResponseError);
+          error.name.should.eql('ResponseError');
+          const response = JSON.parse(error.message);
+          should(response.status).equal(401);
           done();
         });
     });
@@ -395,7 +405,10 @@ describe('create-app', () => {
           done('expected an error, got success');
         })
         .catch(error => {
-          error.name.should.eql('RefreshAuthError');
+          should(error).instanceOf(errors.ResponseError);
+          error.name.should.eql('ResponseError');
+          const response = JSON.parse(error.message);
+          should(response.status).equal(401);
           done();
         });
     });
@@ -427,7 +440,10 @@ describe('create-app', () => {
           done('expected an error, got success');
         })
         .catch(error => {
-          error.name.should.eql('RefreshAuthError');
+          should(error).instanceOf(errors.ResponseError);
+          error.name.should.eql('ResponseError');
+          const response = JSON.parse(error.message);
+          should(response.status).equal(401);
           done();
         });
     });

--- a/packages/core/test/errors.js
+++ b/packages/core/test/errors.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const errors = require('../src/errors');
+const createAppRequestClient = require('../src/tools/create-app-request-client');
+const createInput = require('../src/tools/create-input');
+
+describe('errors', () => {
+  it('should name errors', () => {
+    const error = new errors.CheckError('Check Mate!');
+
+    error.should.instanceOf(errors.CheckError);
+    error.name.should.eql('CheckError');
+    error.message.should.eql('Check Mate!');
+  });
+
+  describe('AppError', () => {
+    it('should stringify arguments', () => {
+      const error = new errors.Error('My Message', 'MyCode', 400);
+
+      error.should.instanceOf(errors.Error);
+      error.name.should.eql('AppError');
+      error.message.should.eql(
+        '{"message":"My Message","code":"MyCode","status":400}'
+      );
+    });
+  });
+
+  describe('ResponseError', () => {
+    it('should stringify arguments', async () => {
+      const testLogger = () => Promise.resolve({});
+      const input = createInput({}, {}, testLogger);
+      const request = createAppRequestClient(input);
+
+      const response = await request({ url: 'https://httpbin.org/status/400' });
+      const error = new errors.ResponseError(response);
+
+      error.should.instanceOf(errors.ResponseError);
+      error.name.should.eql('ResponseError');
+      error.message.should.eql(
+        '{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"https://httpbin.org/status/400"}}'
+      );
+    });
+  });
+});

--- a/packages/legacy-scripting-runner/exceptions.js
+++ b/packages/legacy-scripting-runner/exceptions.js
@@ -3,6 +3,20 @@
 const _ = require('lodash');
 const util = require('util');
 
+class AppError extends Error {
+  constructor(message, code, status) {
+    super(
+      JSON.stringify({
+        message,
+        code,
+        status
+      })
+    );
+    this.name = 'AppError';
+    this.contextify = false;
+  }
+}
+
 // Make some of the errors we'll use!
 const createError = name => {
   const NewError = function(message) {
@@ -29,11 +43,13 @@ const cliErrors = _.reduce(
     error[name] = createError(name);
     return error;
   },
-  {}
+  {
+    Error: AppError
+  }
 );
 
 const exceptions = {
-  ErrorException: Error,
+  ErrorException: cliErrors.Error,
   HaltedException: cliErrors.HaltedError,
   StopRequestException: cliErrors.StopRequestError,
   ExpiredAuthException: cliErrors.ExpiredAuthError,


### PR DESCRIPTION
This adds `z.errors.Error` (`AppError`) and `z.errors.ResponseError` and uses the latter in `throwForStatus` and `throwForStaleAuth`.

- **JIRA:** `SXP-1286` [Create new Node z.errors classes](https://zapierorg.atlassian.net/browse/SXP-1286) and `SXP-1294` [Use new Node z.errors in throwForStatus](https://zapierorg.atlassian.net/browse/SXP-1294)
- **Spec:** https://github.com/zapier/sandbox-integration-errors/issues/6

The `z.error.Error` class is for developers to use instead of `Error` and takes an optional second `code` (string) and third `status` (number) argument. All arguments are `JSON.stringify`-ed as the message of the error. 

In [Python-land](https://github.com/zapier/zapier/blob/e03c532d97e4e647f44038eb5a35ce4b30de2b48/web/backend/zapier/developer_cli/api_base.py#L1114-L1126) we `json.loads` the message and raise the Python `AppError` class, which takes the same arguments. The code and status get retained in our error logs and task and editor states so that the frontend can show relevant troubleshooting docs for the code and/or status.

The `z.error.ResponseError` class is primarily for internal use and used in `throwForStatus` and `throwForStaleAuth`. It takes the `response` and `JSON.stringify`s what we need in [Python-land](https://github.com/zapier/zapier/blob/e03c532d97e4e647f44038eb5a35ce4b30de2b48/web/backend/zapier/developer_cli/api_base.py#L1129) to rebuild the response as a Python `requests.Response` and use our existing v1/v2 tooling to extract an error message, code and status from the response, and then raise `AppError`.

# Testing

- Includes updated and new tests.
- Use https://zapier.com/developer/public-invite/97300/9d0a334481cf89c39060d0b72e21c836/ to invite yourself to the publication of https://github.com/zapier/zapier-platform-example-app-errors to test with different errors.
- Or re-test the steps in the shared Zap at: https://zapier.com/app/editor/82925946 that uses the above app. Keep an eye on the network requests to `.. events` for the event `rendererdError` and look for the `errorCode` and `errorStatus` properties.

    ![](https://zappy.zapier.com/9bac16106d15154b31275e6fd1349628.png)

# Notes

- I use a `doNotContextify` flag to opt out the new classes for appending `What happened:` and `Console logs:` to their (`JSON.stringify`-ed) `message`.
  - To be honest, I don't like that we append to errors their messages at all and wonder why we need this and if, [like suggested here](https://github.com/zapier/zapier/blob/e03c532d97e4e647f44038eb5a35ce4b30de2b48/web/backend/zapier/developer_cli/api_base.py#L1082-L1099), getting them the step UUID and letting them search the existing bundle and request logs in their monitor by that wouldn't get them the same if not more information. Think of Sentry for Zapier Platform, give the ID of an error and we show you what led to it.
    - We could also choose to always turn `message` into a JSON object so that we're able to pass along any context, in a more structured way then appending it to the error message.
- @eliangcs brought up that part of why `throwForStatus` didn't use the response body was that it may contain sensitive data. We talked about how this merely bring v3 on par with v1/v2, so any security concerns would apply to them as well and probably are best address in the Python error message/code extraction logic. For example, by making sure none of the authentication details are part of the extracted message.