### PR TITLE
feat(core,schema,legacy-scripting-runner): allow to "reliably interpolate arrays or objects to a string"

### DIFF
--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -126,7 +126,11 @@ const prepareRequest = function(req) {
 
   // replace {{curlies}} in the request
   if (req.replace) {
-    const bank = createBundleBank(input._zapier.app, input._zapier.event);
+    const bank = createBundleBank(
+      input._zapier.app,
+      input._zapier.event,
+      req.serializeValueForCurlies
+    );
     req = recurseReplaceBank(req, bank);
   }
 

--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -106,7 +106,7 @@ const finalizeBundle = pipe(
 );
 
 // Takes a raw app and bundle and composes a bank of {{key}}->val
-const createBundleBank = (appRaw, event = {}) => {
+const createBundleBank = (appRaw, event = {}, serializeFunc = x => x) => {
   const bank = {
     bundle: finalizeBundle(event.bundle),
     process: {
@@ -116,8 +116,9 @@ const createBundleBank = (appRaw, event = {}) => {
 
   const options = { preserve: { 'bundle.inputData': true } };
   const flattenedBank = flattenPaths(bank, options);
-  return Object.keys(flattenedBank).reduce((coll, key) => {
-    coll[`{{${key}}}`] = flattenedBank[key];
+
+  return Object.entries(flattenedBank).reduce((coll, [key, value]) => {
+    coll[`{{${key}}}`] = serializeFunc(value);
     return coll;
   }, {});
 };

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -630,6 +630,16 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       }
 
       request.headers = cleanHeaders(request.headers);
+      request.serializeValueForCurlies = value => {
+        if (Array.isArray(value)) {
+          return value.join(',');
+        } else if (_.isPlainObject(value)) {
+          // Not sure if anyone would ever expect a '[object Object]',
+          // but who knows?
+          return value.toString();
+        }
+        return value;
+      };
 
       const response = await zcli.request(request);
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -262,6 +262,14 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_array_curlies: function(bundle) {
+        // TODO: devs won't ever write {{bundle.inputData.things}} in the
+        // scripting as bundle.inputData is of CLI world. We'll change it to
+        // {{things}} once we add support for "original" curlies (PDE-1467).
+        bundle.request.url = 'https://httpbin.zapier-tooling.com/get?things={{bundle.inputData.things}}';
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -756,6 +756,37 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, array curlies', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_array_curlies',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.inputData = {
+        things: ['eyedrops', 'cyclops', 'ipod']
+      };
+      return app(input).then(output => {
+        const req = output.results[0];
+        req.args.should.deepEqual({
+          things: ['eyedrops,cyclops,ipod']
+        });
+        req.url.should.equal(
+          'https://httpbin.zapier-tooling.com/get?things=eyedrops%2Ccyclops%2Cipod'
+        );
+      });
+    });
+
     it('KEY_post_poll, jQuery utils', () => {
       const input = createTestInput(
         compiledApp,

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -931,7 +931,7 @@ Key | Required | Type | Description
 `headers` | no | [/FlatObjectSchema](#flatobjectschema) | The HTTP headers for the request.
 `auth` | no | oneOf(`array`[`string`], [/FlatObjectSchema](#flatobjectschema)) | An object holding the auth parameters for OAuth1 request signing, like `{oauth_token: 'abcd', oauth_token_secret: '1234'}`. Or an array reserved (i.e. not implemented yet) to hold the username and password for Basic Auth. Like `['AzureDiamond', 'hunter2']`.
 `removeMissingValuesFrom` | no | `object` | Should missing values be sent? (empty strings, `null`, and `undefined` only — `[]`, `{}`, and `false` will still be sent). Allowed fields are `params` and `body`. The default is `false`, ex: ```removeMissingValuesFrom: { params: false, body: false }```
-`serializeValueForCurlies` | no | [/FunctionSchema](#functionschema) | A function to customize how to serialize a value for curlies `{{var}}`` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.
+`serializeValueForCurlies` | no | [/FunctionSchema](#functionschema) | A function to customize how to serialize a value for curlies `{{var}}` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.
 
 -----
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -931,6 +931,7 @@ Key | Required | Type | Description
 `headers` | no | [/FlatObjectSchema](#flatobjectschema) | The HTTP headers for the request.
 `auth` | no | oneOf(`array`[`string`], [/FlatObjectSchema](#flatobjectschema)) | An object holding the auth parameters for OAuth1 request signing, like `{oauth_token: 'abcd', oauth_token_secret: '1234'}`. Or an array reserved (i.e. not implemented yet) to hold the username and password for Basic Auth. Like `['AzureDiamond', 'hunter2']`.
 `removeMissingValuesFrom` | no | `object` | Should missing values be sent? (empty strings, `null`, and `undefined` only — `[]`, `{}`, and `false` will still be sent). Allowed fields are `params` and `body`. The default is `false`, ex: ```removeMissingValuesFrom: { params: false, body: false }```
+`serializeValueForCurlies` | no | [/FunctionSchema](#functionschema) | A function to customize how to serialize a value for curlies `{{var}}`` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.
 
 -----
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -398,7 +398,7 @@
           "additionalProperties": false
         },
         "serializeValueForCurlies": {
-          "description": "A function to customize how to serialize a value for curlies `{{var}}`` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.",
+          "description": "A function to customize how to serialize a value for curlies `{{var}}` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.",
           "$ref": "/FunctionSchema"
         }
       },

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -396,6 +396,10 @@
             }
           },
           "additionalProperties": false
+        },
+        "serializeValueForCurlies": {
+          "description": "A function to customize how to serialize a value for curlies `{{var}}`` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.",
+          "$ref": "/FunctionSchema"
         }
       },
       "additionalProperties": false

--- a/packages/schema/lib/schemas/RequestSchema.js
+++ b/packages/schema/lib/schemas/RequestSchema.js
@@ -84,5 +84,5 @@ module.exports = makeSchema(
     },
     additionalProperties: false
   },
-  [FlatObjectSchema]
+  [FlatObjectSchema, FunctionSchema]
 );

--- a/packages/schema/lib/schemas/RequestSchema.js
+++ b/packages/schema/lib/schemas/RequestSchema.js
@@ -3,6 +3,7 @@
 const makeSchema = require('../utils/makeSchema');
 
 const FlatObjectSchema = require('./FlatObjectSchema');
+const FunctionSchema = require('./FunctionSchema');
 
 module.exports = makeSchema(
   {
@@ -74,6 +75,11 @@ module.exports = makeSchema(
           }
         },
         additionalProperties: false
+      },
+      serializeValueForCurlies: {
+        description:
+          'A function to customize how to serialize a value for curlies `{{var}}`` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.',
+        $ref: FunctionSchema.id
       }
     },
     additionalProperties: false

--- a/packages/schema/lib/schemas/RequestSchema.js
+++ b/packages/schema/lib/schemas/RequestSchema.js
@@ -78,7 +78,7 @@ module.exports = makeSchema(
       },
       serializeValueForCurlies: {
         description:
-          'A function to customize how to serialize a value for curlies `{{var}}`` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.',
+          'A function to customize how to serialize a value for curlies `{{var}}` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.',
         $ref: FunctionSchema.id
       }
     },


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Addresses [PDE-1468](https://zapierorg.atlassian.net/browse/PDE-1468).

A common error of a converted app is:

"Cannot reliably interpolate objects or arrays into a string"

This is because the app uses curlies in their polling/action URL and the variable in the curlies is an array, such as `https://example.com?param={{an_array_variable}}`. Web Builder would replace `{{an_array_variable}}` with a comma-separated string such as `a,b,c`. But in VB, since core 8.0.0 with this breaking change (https://github.com/zapier/zapier-platform-core/pull/139), that syntax is no longer supported and would raise an error.

We've been advising partners to adjust code on their side. But there are just too many of them for us to handle it efficiently. I think to fix it, we can add an optional option `serializeValueForCurlies` to the `RequestSchema`. When specified, `serializeValueForCurlies` is a function that transforms an unknown type of a value to a string. The usage would be like:

```js
const response = await z.request({
  url: 'https://httpbin.zapier-tooling.com/get?{{bundle.inputData.anArray}}',
  serializeValueForCurlies: value => {
    if (Array.isArray(value)) {
      return value.join(',');
    }
    return value;
  }
});
```

Then the `prepareRequest` middleware in the core will invoke this function to serialize values in the bank before it replaces curlies. legacy-scripting-runner can also use this feature to serialize arrays or objects like we used to do prior to core 8.0.0.