### PR TITLE
BREAKING CHANGE(core): `throwForStatus()` only when status between 400 and 600

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ example-apps/*/yarn.lock
 example-apps/*/package-lock.json
 
 boilerplate/build
+
+.vscode

--- a/docs/index.html
+++ b/docs/index.html
@@ -3316,8 +3316,6 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>, customHttpOptions)
     .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> {
-      response.throwForStatus();
-
       <span class="hljs-keyword">const</span> recipes = response.json;
       <span class="hljs-comment">// do any custom processing of recipes here...</span>
 
@@ -3475,7 +3473,7 @@ zapier env 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt; 300 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p>
+      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3553,8 +3551,8 @@ zapier env 1.0.0
 <li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
-<li><code>throwForStatus()</code>: Throw error if final <code>response.status &gt; 300</code>. Will throw <code>z.error.RefreshAuthError</code> if 401.</li>
 <li><code>skipThrowForStatus</code>: don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
+<li><code>throwForStatus()</code>: Throw error if 400 &lt;= <code>status</code> &lt; 600.</li>
 <li><code>request</code>: The original request options object (see above).</li>
 </ul>
     </div>
@@ -3950,7 +3948,7 @@ have incomprehensible messages for end users, or possibly go uncaught.</p><p>Zap
 <code>afterResponse</code> middleware (<a href="#using-http-middleware">docs</a>), which provides a hook for
 processing all responses from HTTP calls. Second is <code>response.throwForStatus()</code>
 (<a href="#http-response-object">docs</a>), which throws an error if the response status indicates
-an error (status &gt; 300). We automatically call this method before returning the
+an error (status &gt;= 400). We automatically call this method before returning the
 response, unless you set <code>skipThrowForStatus</code> on the request or response object. The
 last tool is the collection of errors in <code>z.errors</code> (<a href="#zerrors">docs</a>), which control
 the behavior of Zaps when various kinds of errors occur.</p>

--- a/example-apps/github/index.js
+++ b/example-apps/github/index.js
@@ -3,17 +3,6 @@ const issueCreate = require('./creates/issue');
 const issueTrigger = require('./triggers/issue');
 const authentication = require('./authentication');
 
-const handleHTTPError = (response, z) => {
-  if (response.status >= 400) {
-    throw new z.errors.Error(
-      `Unexpected status code ${response.status}`,
-      'StatusError',
-      response.status
-    );
-  }
-  return response;
-};
-
 const App = {
   // This is just shorthand to reference the installed dependencies you have. Zapier will
   // need to know these before we can upload
@@ -24,7 +13,7 @@ const App = {
   // beforeRequest & afterResponse are optional hooks into the provided HTTP client
   beforeRequest: [],
 
-  afterResponse: [handleHTTPError],
+  afterResponse: [],
 
   // If you want to define optional resources to simplify creation of triggers, searches, creates - do that here!
   resources: {},

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -996,7 +996,7 @@ The second argument for middleware is the `z` object, but it does *not* include 
 
 #### Error Response Handling
 
-Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code > 300 that should not be treated as an error.
+Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code >= 400 that should not be treated as an error.
 
 For developers using v9.x and below, it's your responsibility to throw an exception for an error response. That means you should call `response.throwForStatus()` or throw an error yourself, likely following the `z.request` call.
 
@@ -1052,8 +1052,8 @@ The response object returned by `z.request([url], options)` supports the followi
 * `body`: A stream available only if you provide `options.raw = true`.
 * `headers`: Response headers object. The header keys are all lower case.
 * `getHeader(key)`: Retrieve response header, case insensitive: `response.getHeader('My-Header')`
-* `throwForStatus()`: Throw error if final `response.status > 300`. Will throw `z.error.RefreshAuthError` if 401.
 * `skipThrowForStatus`: don't call `throwForStatus()` before resolving the request with this response.
+* `throwForStatus()`: Throw error if 400 <= `status` < 600.
 * `request`: The original request options object (see above).
 
 ```js
@@ -1225,7 +1225,7 @@ Zapier provides a couple of tools to help with error handling. First is the
 `afterResponse` middleware ([docs](#using-http-middleware)), which provides a hook for
 processing all responses from HTTP calls. Second is `response.throwForStatus()`
 ([docs](#http-response-object)), which throws an error if the response status indicates
-an error (status > 300). We automatically call this method before returning the
+an error (status >= 400). We automatically call this method before returning the
 response, unless you set `skipThrowForStatus` on the request or response object. The
 last tool is the collection of errors in `z.errors` ([docs](#zerrors)), which control
 the behavior of Zaps when various kinds of errors occur.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1923,8 +1923,6 @@ const listExample = (z, bundle) => {
   return z
     .request('https://example.com/api/v2/recipes.json', customHttpOptions)
     .then(response => {
-      response.throwForStatus();
-
       const recipes = response.json;
       // do any custom processing of recipes here...
 
@@ -2039,7 +2037,7 @@ The second argument for middleware is the `z` object, but it does *not* include 
 
 #### Error Response Handling
 
-Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code > 300 that should not be treated as an error.
+Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code >= 400 that should not be treated as an error.
 
 For developers using v9.x and below, it's your responsibility to throw an exception for an error response. That means you should call `response.throwForStatus()` or throw an error yourself, likely following the `z.request` call.
 
@@ -2095,8 +2093,8 @@ The response object returned by `z.request([url], options)` supports the followi
 * `body`: A stream available only if you provide `options.raw = true`.
 * `headers`: Response headers object. The header keys are all lower case.
 * `getHeader(key)`: Retrieve response header, case insensitive: `response.getHeader('My-Header')`
-* `throwForStatus()`: Throw error if final `response.status > 300`. Will throw `z.error.RefreshAuthError` if 401.
 * `skipThrowForStatus`: don't call `throwForStatus()` before resolving the request with this response.
+* `throwForStatus()`: Throw error if 400 <= `status` < 600.
 * `request`: The original request options object (see above).
 
 ```js
@@ -2364,7 +2362,7 @@ Zapier provides a couple of tools to help with error handling. First is the
 `afterResponse` middleware ([docs](#using-http-middleware)), which provides a hook for
 processing all responses from HTTP calls. Second is `response.throwForStatus()`
 ([docs](#http-response-object)), which throws an error if the response status indicates
-an error (status > 300). We automatically call this method before returning the
+an error (status >= 400). We automatically call this method before returning the
 response, unless you set `skipThrowForStatus` on the request or response object. The
 last tool is the collection of errors in `z.errors` ([docs](#zerrors)), which control
 the behavior of Zaps when various kinds of errors occur.

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3316,8 +3316,6 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>, customHttpOptions)
     .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> {
-      response.throwForStatus();
-
       <span class="hljs-keyword">const</span> recipes = response.json;
       <span class="hljs-comment">// do any custom processing of recipes here...</span>
 
@@ -3475,7 +3473,7 @@ zapier env 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt; 300 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p>
+      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3553,8 +3551,8 @@ zapier env 1.0.0
 <li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
-<li><code>throwForStatus()</code>: Throw error if final <code>response.status &gt; 300</code>. Will throw <code>z.error.RefreshAuthError</code> if 401.</li>
 <li><code>skipThrowForStatus</code>: don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
+<li><code>throwForStatus()</code>: Throw error if 400 &lt;= <code>status</code> &lt; 600.</li>
 <li><code>request</code>: The original request options object (see above).</li>
 </ul>
     </div>
@@ -3950,7 +3948,7 @@ have incomprehensible messages for end users, or possibly go uncaught.</p><p>Zap
 <code>afterResponse</code> middleware (<a href="#using-http-middleware">docs</a>), which provides a hook for
 processing all responses from HTTP calls. Second is <code>response.throwForStatus()</code>
 (<a href="#http-response-object">docs</a>), which throws an error if the response status indicates
-an error (status &gt; 300). We automatically call this method before returning the
+an error (status &gt;= 400). We automatically call this method before returning the
 response, unless you set <code>skipThrowForStatus</code> on the request or response object. The
 last tool is the collection of errors in <code>z.errors</code> (<a href="#zerrors">docs</a>), which control
 the behavior of Zaps when various kinds of errors occur.</p>

--- a/packages/cli/snippets/manual-request.js
+++ b/packages/cli/snippets/manual-request.js
@@ -8,8 +8,6 @@ const listExample = (z, bundle) => {
   return z
     .request('https://example.com/api/v2/recipes.json', customHttpOptions)
     .then(response => {
-      response.throwForStatus();
-
       const recipes = response.json;
       // do any custom processing of recipes here...
 

--- a/packages/core/src/http-middlewares/after/throw-for-status.js
+++ b/packages/core/src/http-middlewares/after/throw-for-status.js
@@ -3,7 +3,11 @@
 const errors = require('../../errors');
 
 const throwForStatus = response => {
-  if (!response.skipThrowForStatus && response.status > 300) {
+  if (
+    !response.skipThrowForStatus &&
+    response.status >= 400 &&
+    response.status < 600
+  ) {
     throw new errors.ResponseError(response);
   }
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -932,7 +932,7 @@ Key | Required | Type | Description
 `auth` | no | oneOf(`array`[`string`], [/FlatObjectSchema](#flatobjectschema)) | An object holding the auth parameters for OAuth1 request signing, like `{oauth_token: 'abcd', oauth_token_secret: '1234'}`. Or an array reserved (i.e. not implemented yet) to hold the username and password for Basic Auth. Like `['AzureDiamond', 'hunter2']`.
 `removeMissingValuesFrom` | no | `object` | Should missing values be sent? (empty strings, `null`, and `undefined` only — `[]`, `{}`, and `false` will still be sent). Allowed fields are `params` and `body`. The default is `false`, ex: ```removeMissingValuesFrom: { params: false, body: false }```
 `serializeValueForCurlies` | no | [/FunctionSchema](#functionschema) | A function to customize how to serialize a value for curlies `{{var}}` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.
-`skipThrowForStatus` | no | `boolean` | If `true`, don't throw an exception for response status > 300 automatically before resolving with the response. Defaults to `false`.
+`skipThrowForStatus` | no | `boolean` | If `true`, don't throw an exception for response 400 <= status < 600 automatically before resolving with the response. Defaults to `false`.
 
 -----
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -402,7 +402,7 @@
           "$ref": "/FunctionSchema"
         },
         "skipThrowForStatus": {
-          "description": "If `true`, don't throw an exception for response status > 300 automatically before resolving with the response. Defaults to `false`.",
+          "description": "If `true`, don't throw an exception for response 400 <= status < 600 automatically before resolving with the response. Defaults to `false`.",
           "type": "boolean",
           "default": false
         }

--- a/packages/schema/lib/schemas/RequestSchema.js
+++ b/packages/schema/lib/schemas/RequestSchema.js
@@ -83,7 +83,7 @@ module.exports = makeSchema(
       },
       skipThrowForStatus: {
         description:
-          "If `true`, don't throw an exception for response status > 300 automatically before resolving with the response. Defaults to `false`.",
+          "If `true`, don't throw an exception for response 400 <= status < 600 automatically before resolving with the response. Defaults to `false`.",
         type: 'boolean',
         default: false
       }


### PR DESCRIPTION
- JIRA: `SXP-1622` [v3 like v1/2 should only throw for >= 400 and < 600](https://zapierorg.atlassian.net/browse/SXP-1622)
- Discussion: https://github.com/zapier/sandbox-integration-errors/issues/2#issuecomment-610691775

Includes tests, which we didn't have for `throwForStatus`.