### PR TITLE
feat(legacy-scripting-runner): support for unbounded curlies

### DIFF
--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -262,14 +262,6 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
-      movie_pre_poll_array_curlies: function(bundle) {
-        // TODO: devs won't ever write {{bundle.inputData.things}} in the
-        // scripting as bundle.inputData is of CLI world. We'll change it to
-        // {{things}} once we add support for "original" curlies (PDE-1467).
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/get?things={{bundle.inputData.things}}';
-        return bundle.request;
-      },
-
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];
@@ -1173,7 +1165,8 @@ const App = {
     scriptingSource: legacyScriptingSource,
 
     subscribeUrl: 'https://httpbin.zapier-tooling.com/post',
-    unsubscribeUrl: 'https://httpbin.zapier-tooling.com/delete',
+    unsubscribeUrl:
+      'https://httpbin.zapier-tooling.com/delete?sub_id={{subscription_id}}',
 
     authentication: {
       oauth2Config: {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Addresses [PDE-1467](https://zapierorg.atlassian.net/browse/PDE-1467).

When converting a WB app, we replace "unbounded" curlies `{{var}}` in URLs with "bounded" curlies, which are either:

- `{{bundle.authData.var}}`
- `{{bundle.inputData.var}}`
- `{{process.env.var}}`

Which one to use is decided based on the field definition. That is, if `var` is in auth fields, then we replace `var` with `bundle.authData.var`.

The idea was to be explicit about variable referencing. But unfortunately, being explicit requires some guessing and is not always reliable. This PR adds support for unbounded curlies, so `{{var}}` in URLs will be still `{{var}}`. legacy-scripting-runner will do the implicit variable referencing as WB does.

Existing converted apps that are still using bounded curlies like `{{bundle.inputData.var}}` will continue to work. The change is backward compatible.

This PR works with https://github.com/zapier/zapier/pull/38762.