### PR TITLE
feat(core,legacy-scripting-runner): allow GET requests to have body

### DIFF
--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -44,7 +44,7 @@ const coerceBody = req => {
   const contentType = getContentType(req.headers || {});
 
   // No need for body on get
-  if (req.method === 'GET') {
+  if (req.method === 'GET' && !req.allowGetBody) {
     delete req.body;
   }
 

--- a/packages/core/src/tools/fetch.js
+++ b/packages/core/src/tools/fetch.js
@@ -1,6 +1,60 @@
 'use strict';
 
-// hacky "clone" for fetch so we don't pollute the global library
-const fetch = require('node-fetch').bind({});
-fetch.Promise = require('./promise');
-module.exports = fetch;
+const fetch = require('node-fetch');
+
+// XXX: PatchedRequest is to get past node-fetch's check that forbids GET requests
+// from having a body here:
+// https://github.com/node-fetch/node-fetch/blob/v2.6.0/src/request.js#L75-L78
+class PatchedRequest extends fetch.Request {
+  constructor(url, opts) {
+    const origMethod = (opts.method || 'GET').toUpperCase();
+
+    const isGetWithBody =
+      (origMethod === 'GET' || origMethod === 'HEAD') && opts.body;
+    let newOpts = opts;
+    if (isGetWithBody) {
+      // Temporary remove body to fool fetch.Request constructor
+      newOpts = { ...opts, body: null };
+    }
+
+    super(url, newOpts);
+
+    this._isGetWithBody = isGetWithBody;
+
+    if (isGetWithBody) {
+      // Restore the body. The body is stored internally using a Symbol key. We
+      // can't just do this[Symbol('Body internals')] as the symbol is internal.
+      // We need to use Object.getOwnPropertySymbols() to get all the keys and
+      // find the one that holds the body.
+      const keys = Object.getOwnPropertySymbols(this);
+      for (const k of keys) {
+        if (this[k].body !== undefined) {
+          this[k].body = Buffer.from(String(opts.body));
+          break;
+        }
+      }
+    }
+  }
+
+  get body() {
+    if (this._isGetWithBody && !this._bodyCalled) {
+      // This assumes node-fetch's check that disallows a GET request to have a
+      // body happens on the first time it calls this.body. Might not work if
+      // node-fetch breaks the assumption.
+      this._bodyCalled = true;
+      return null;
+    }
+    return super.body;
+  }
+}
+
+const newFetch = (url, opts) => {
+  const request = new PatchedRequest(url, opts);
+  // fetch actually accepts a Request object as an argument. It'll clone the
+  // request internally, that's why the PatchedRequest.body hack works.
+  return fetch(request);
+};
+
+newFetch.Promise = require('./promise');
+
+module.exports = newFetch;

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -372,6 +372,35 @@ describe('request client', () => {
     });
   });
 
+  it('should delete GET body by default', async () => {
+    const request = createAppRequestClient(input);
+    const response = await request({
+      // Use postman-echo because httpbin doesn't echo GET body
+      method: 'GET',
+      url: 'https://postman-echo.com/get',
+      body: {
+        name: 'Darth Vader'
+      }
+    });
+    response.status.should.eql(200);
+    response.json.args.should.deepEqual({});
+  });
+
+  it('should allow GET with body', async () => {
+    const request = createAppRequestClient(input);
+    const response = await request({
+      // Use postman-echo because httpbin doesn't echo GET body
+      method: 'GET',
+      url: 'https://postman-echo.com/get',
+      body: {
+        name: 'Darth Vader'
+      },
+      allowGetBody: true
+    });
+    response.status.should.eql(200);
+    response.json.args.should.deepEqual({ name: 'Darth Vader' });
+  });
+
   describe('adds query params', () => {
     it('should replace remaining curly params with empty string by default', () => {
       const request = createAppRequestClient(input);

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -670,6 +670,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       }
 
       request.headers = cleanHeaders(request.headers);
+      request.allowGetBody = true;
 
       const response = await zcli.request(request);
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -262,6 +262,16 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_GET_with_body: function(bundle) {
+        // Use postman-echo because httpbin doesn't echo a GET request's body
+        bundle.request.url = 'https://postman-echo.com/get';
+        bundle.request.method = 'GET';
+        bundle.request.data = JSON.stringify({
+          name: 'Luke Skywalker'
+        });
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -807,6 +807,30 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, GET with body', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_GET_with_body',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then(output => {
+        const echoed = output.results[0];
+        should.equal(echoed.args.name, 'Luke Skywalker');
+      });
+    });
+
     it('KEY_post_poll, jQuery utils', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Adds a hidden option `allowGetBody` to `z.request()`. When `allowGetBody` is true, `z.request` won't delete the body for the GET request. This is to add support for WB's ability to send GET requests with a body.

This has to be done with a nasty hack because node-fetch explicitly [forbids](https://github.com/node-fetch/node-fetch/blob/v2.6.0/src/request.js#L75-L78) us to send a GET request with a body (see also https://github.com/whatwg/fetch/issues/551). Not an ideal solution, but it gets the job done.