### PR TITLE
docs(legacy-scripting-runner): add changelog

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,0 +1,23 @@
+## 3.5.0
+
+- :tada: Add support for unbounded curlies ([#194](https://github.com/zapier/zapier-platform/pull/194))
+
+## 3.4.0
+
+- :tada: Allow to "reliably interpolate arrays or objects to a string" ([#190](https://github.com/zapier/zapier-platform/pull/190))
+
+## 3.3.3
+
+- :bug: Run post method first before throwing error for response status ([#183](https://github.com/zapier/zapier-platform/pull/183))
+
+## 3.3.2
+
+- :bug: Fix missing `console.log` ([#182](https://github.com/zapier/zapier-platform/pull/182))
+
+## 3.3.1
+
+- :bug: Add full jQuery support ([#181](https://github.com/zapier/zapier-platform/pull/181))
+
+## 3.3.0
+
+- :tada: Log converted bundles ([#177](https://github.com/zapier/zapier-platform/pull/177))


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Adds changelog for legacy-scripting-runner. Didn't go way back to the beginning because I'm not sure if that will be useful. We can trace back further if we want to.