### PR TITLE
docs(core) Use `response.json` where possible

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1315,7 +1315,7 @@ zapier convert 1234 my-app 1.0.1
       <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;The username/password you supplied is invalid&apos;</span>);
     }
     <span class="hljs-keyword">return</span> {
-      <span class="hljs-attr">sessionKey</span>: z.JSON.parse(response.content).sessionKey
+      <span class="hljs-attr">sessionKey</span>: response.json.sessionKey
     };
   });
 };
@@ -2215,7 +2215,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
         <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id
       }
     })
-    .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> z.JSON.parse(response.content));
+    .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> response.json);
 };
 
 </code></pre>
@@ -2493,7 +2493,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeOutputFields = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> response = z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
   <span class="hljs-comment">// json is like [{&quot;key&quot;:&quot;field_1&quot;,&quot;label&quot;:&quot;Label for Custom Field&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content));
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -3322,7 +3322,7 @@ zapier env 1.0.0
     .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> {
       response.throwForStatus();
 
-      <span class="hljs-keyword">const</span> recipes = z.JSON.parse(response.content);
+      <span class="hljs-keyword">const</span> recipes = response.json;
       <span class="hljs-comment">// do any custom processing of recipes here...</span>
 
       <span class="hljs-keyword">return</span> recipes;
@@ -3447,15 +3447,10 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> response;
 };
 
-<span class="hljs-keyword">const</span> autoParseJson = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
-  response.json = z.JSON.parse(response.content);
-  <span class="hljs-keyword">return</span> response;
-};
-
 <span class="hljs-keyword">const</span> App = {
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">beforeRequest</span>: [addHeader],
-  <span class="hljs-attr">afterResponse</span>: [mustBe200, autoParseJson]
+  <span class="hljs-attr">afterResponse</span>: [mustBe200]
   <span class="hljs-comment">// ...</span>
 };
 
@@ -3557,8 +3552,8 @@ zapier env 1.0.0
   response.request; <span class="hljs-comment">// original request options</span>
   response.throwForStatus();
   <span class="hljs-comment">// if options.raw === false (default)...</span>
+  response.json; <span class="hljs-comment">// identical to:</span>
   <span class="hljs-built_in">JSON</span>.parse(response.content);
-  response.json;
   <span class="hljs-comment">// if options.raw === true...</span>
   response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
   response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
@@ -3595,13 +3590,13 @@ zapier env 1.0.0
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> getExtraDataFunction = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> url = <span class="hljs-string">`https://example.com/movies/<span class="hljs-subst">${bundle.inputData.id}</span>.json`</span>;
-  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content));
+  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
 };
 
 <span class="hljs-keyword">const</span> movieList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/movies.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content))
+    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
     .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
       <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
         <span class="hljs-comment">// so maybe /movies.json is thin content but</span>
@@ -3730,7 +3725,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 <span class="hljs-keyword">const</span> pdfList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/pdfs.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content))
+    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
     .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
       <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
         <span class="hljs-comment">// lazily convert a secret_download_url to a stashed url</span>
@@ -4924,7 +4919,7 @@ npm run zapier-push
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
-<span class="hljs-keyword">let</span> items = z.JSON.parse(response.content).items;
+<span class="hljs-keyword">let</span> items = response.json.items;
 items.forEach(<span class="hljs-function"><span class="hljs-params">item</span> =&gt;</span> {
   item.id = item.contactId;
 })

--- a/example-apps/babel/src/resources/recipe.js
+++ b/example-apps/babel/src/resources/recipe.js
@@ -4,7 +4,7 @@ const getRecipe = async (z, bundle) => {
   const response = await z.request({
     url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
   });
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 const listRecipes = async (z, bundle) => {
@@ -14,7 +14,7 @@ const listRecipes = async (z, bundle) => {
       style: bundle.inputData.style
     }
   });
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 const createRecipe = async (z, bundle) => {
@@ -30,7 +30,7 @@ const createRecipe = async (z, bundle) => {
       'content-type': 'application/json'
     }
   });
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 const searchRecipe = async (z, bundle) => {
@@ -40,7 +40,7 @@ const searchRecipe = async (z, bundle) => {
       nameSearch: bundle.inputData.name
     }
   });
-  const matchingRecipes = z.JSON.parse(response.content);
+  const matchingRecipes = response.json;
 
   // Only return the first matching recipe
   if (matchingRecipes && matchingRecipes.length) {

--- a/example-apps/create/creates/recipe.js
+++ b/example-apps/create/creates/recipe.js
@@ -49,7 +49,7 @@ module.exports = {
         }
       });
 
-      return promise.then(response => JSON.parse(response.content));
+      return promise.then(response => response.json);
     },
 
     // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example

--- a/example-apps/dynamic-dropdown/triggers/people.js
+++ b/example-apps/dynamic-dropdown/triggers/people.js
@@ -10,7 +10,7 @@ const fetchList = (z, bundle) => {
   //   we're going to omit that part. Thus, this trigger only "see" the people
   //   in their first page of results
   return z.request(request).then(response => {
-    let peopleArray = JSON.parse(response.content).results;
+    let peopleArray = response.json.results;
     if (bundle.inputData.species) {
       // The Zap's setup has requested a specific species of person.
       // Since the API/endpoint can't perform the filtering, we'll perform it

--- a/example-apps/dynamic-dropdown/triggers/species.js
+++ b/example-apps/dynamic-dropdown/triggers/species.js
@@ -13,7 +13,7 @@ const fetchList = (z, bundle) => {
   }
 
   return z.request(request).then(response => {
-    const speciesArray = JSON.parse(response.content).results;
+    const speciesArray = response.json.results;
     speciesArray.forEach(species => {
       // copy the "url" field into an "id" field
       species.id = generateID(species.url);

--- a/example-apps/files/triggers/newFile.js
+++ b/example-apps/files/triggers/newFile.js
@@ -13,7 +13,7 @@ const listFiles = (z, bundle) => {
       url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/files'
     })
     .then(response => {
-      const files = JSON.parse(response.content);
+      const files = response.json;
 
       // Make it possible to get the actual file contents if necessary (no need to make the request now)
       return files.map(file => {

--- a/example-apps/github/creates/issue.js
+++ b/example-apps/github/creates/issue.js
@@ -9,7 +9,7 @@ const createIssue = (z, bundle) => {
       body: bundle.inputData.body
     }
   });
-  return responsePromise.then(response => JSON.parse(response.content));
+  return responsePromise.then(response => response.json);
 };
 
 module.exports = {

--- a/example-apps/github/triggers/issue.js
+++ b/example-apps/github/triggers/issue.js
@@ -11,7 +11,7 @@ const triggerIssue = (z, bundle) => {
       direction: 'desc'
     }
   });
-  return responsePromise.then(response => JSON.parse(response.content));
+  return responsePromise.then(response => response.json);
 };
 
 module.exports = {

--- a/example-apps/github/triggers/repo.js
+++ b/example-apps/github/triggers/repo.js
@@ -4,7 +4,7 @@ const triggerRepo = (z, bundle) => {
   const responsePromise = z.request({
     url: 'https://api.github.com/user/repos?per_page=100'
   });
-  return responsePromise.then(response => JSON.parse(response.content));
+  return responsePromise.then(response => response.json);
 };
 
 module.exports = {

--- a/example-apps/oauth1-trello/triggers/board.js
+++ b/example-apps/oauth1-trello/triggers/board.js
@@ -2,7 +2,7 @@
 const triggerBoard = async (z, bundle) => {
   const url = 'https://trello.com/1/members/me/boards';
   const response = await z.request(url);
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 module.exports = {

--- a/example-apps/oauth1-tumblr/triggers/like.js
+++ b/example-apps/oauth1-tumblr/triggers/like.js
@@ -1,7 +1,7 @@
 const perform = async (z, bundle) => {
   const url = 'https://api.tumblr.com/v2/user/likes';
   const response = await z.request(url);
-  const result = z.JSON.parse(response.content);
+  const result = response.json;
   return result.response.liked_posts || [];
 };
 

--- a/example-apps/oauth2/authentication.js
+++ b/example-apps/oauth2/authentication.js
@@ -24,7 +24,7 @@ const getAccessToken = (z, bundle) => {
       );
     }
 
-    const result = JSON.parse(response.content);
+    const result = response.json;
     return {
       access_token: result.access_token,
       refresh_token: result.refresh_token
@@ -57,7 +57,7 @@ const refreshAccessToken = (z, bundle) => {
       );
     }
 
-    const result = JSON.parse(response.content);
+    const result = response.json;
     return {
       access_token: result.access_token
     };
@@ -82,7 +82,7 @@ const testAuth = (z /*, bundle */) => {
         response.status
       );
     }
-    return z.JSON.parse(response.content);
+    return response.json;
   });
 };
 

--- a/example-apps/onedrive/authentication.js
+++ b/example-apps/onedrive/authentication.js
@@ -58,7 +58,7 @@ const getAccessToken = (z, bundle) => {
       )
     }
 
-    const result = z.JSON.parse(response.content)
+    const result = response.json
     return {
       access_token: result.access_token,
       refresh_token: result.refresh_token,
@@ -100,7 +100,7 @@ const refreshAccessToken = (z, bundle) => {
       )
     }
 
-    const result = z.JSON.parse(response.content)
+    const result = response.json
     return {
       access_token: result.access_token,
       refresh_token: result.refresh_token,
@@ -126,7 +126,7 @@ const testAuth = (z) => {
         response.status
       )
     }
-    return z.JSON.parse(response.content)
+    return response.json
   })
 }
 

--- a/example-apps/onedrive/resources/base-item.js
+++ b/example-apps/onedrive/resources/base-item.js
@@ -121,7 +121,7 @@ const handleCreateWithSession = (
         )
       }
 
-      const uploadUrl = z.JSON.parse(response.content).uploadUrl
+      const uploadUrl = response.json.uploadUrl
 
       // This should work fine for files up to 60MB (https://dev.onedrive.com/items/upload_large_files.htm#upload-fragments)
 

--- a/example-apps/onedrive/utils.js
+++ b/example-apps/onedrive/utils.js
@@ -12,7 +12,7 @@ const parseResponse = (z, type, response) => {
   let results = []
 
   if (response.status >= 200 && response.status < 300) {
-    results = JSON.parse(response.content)
+    results = response.json
 
     // OneDrive puts the contents of lists inside .value property
     if (!_.isArray(results) && _.isArray(results.value)) {

--- a/example-apps/resource/resources/recipe.js
+++ b/example-apps/resource/resources/recipe.js
@@ -5,7 +5,7 @@ const getRecipe = (z, bundle) => {
     .request({
       url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
     })
-    .then(response => JSON.parse(response.content));
+    .then(response => response.json);
 };
 
 const listRecipes = (z, bundle) => {
@@ -16,7 +16,7 @@ const listRecipes = (z, bundle) => {
         style: bundle.inputData.style
       }
     })
-    .then(response => JSON.parse(response.content));
+    .then(response => response.json);
 };
 
 const createRecipe = (z, bundle) => {
@@ -33,9 +33,7 @@ const createRecipe = (z, bundle) => {
     }
   };
 
-  return z
-    .request(requestOptions)
-    .then(response => JSON.parse(response.content));
+  return z.request(requestOptions).then(response => response.json);
 };
 
 const searchRecipe = (z, bundle) => {
@@ -47,7 +45,7 @@ const searchRecipe = (z, bundle) => {
       }
     })
     .then(response => {
-      const matchingRecipes = JSON.parse(response.content);
+      const matchingRecipes = response.json;
 
       // Only return the first matching recipe
       if (matchingRecipes && matchingRecipes.length) {

--- a/example-apps/rest-hooks/triggers/recipe.js
+++ b/example-apps/rest-hooks/triggers/recipe.js
@@ -17,7 +17,7 @@ const subscribeHook = (z, bundle) => {
   };
 
   // You may return a promise or a normal data structure from any perform method.
-  return z.request(options).then(response => JSON.parse(response.content));
+  return z.request(options).then(response => response.json);
 };
 
 const unsubscribeHook = (z, bundle) => {
@@ -33,7 +33,7 @@ const unsubscribeHook = (z, bundle) => {
   };
 
   // You may return a promise or a normal data structure from any perform method.
-  return z.request(options).then(response => JSON.parse(response.content));
+  return z.request(options).then(response => response.json);
 };
 
 const getRecipe = (z, bundle) => {
@@ -60,7 +60,7 @@ const getFallbackRealRecipe = (z, bundle) => {
     }
   };
 
-  return z.request(options).then(response => JSON.parse(response.content));
+  return z.request(options).then(response => response.json);
 };
 
 // We recommend writing your triggers separate like this and rolling them

--- a/example-apps/search-or-create/creates/recipe.js
+++ b/example-apps/search-or-create/creates/recipe.js
@@ -7,7 +7,7 @@ const createRecipe = (z, bundle) => {
       name: bundle.inputData.name
     }
   });
-  return responsePromise.then(response => z.JSON.parse(response.content));
+  return responsePromise.then(response => response.json);
 };
 
 module.exports = {

--- a/example-apps/search-or-create/searches/recipe.js
+++ b/example-apps/search-or-create/searches/recipe.js
@@ -6,7 +6,7 @@ const searchRecipe = (z, bundle) => {
       name: bundle.inputData.name
     }
   });
-  return responsePromise.then(response => z.JSON.parse(response.content));
+  return responsePromise.then(response => response.json);
 };
 
 module.exports = {

--- a/example-apps/search/searches/recipe.js
+++ b/example-apps/search/searches/recipe.js
@@ -34,9 +34,7 @@ module.exports = {
         }
       };
 
-      return z
-        .request(url, options)
-        .then(response => JSON.parse(response.content));
+      return z.request(url, options).then(response => response.json);
     },
 
     // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example

--- a/example-apps/session-auth/authentication.js
+++ b/example-apps/session-auth/authentication.js
@@ -38,7 +38,7 @@ const getSessionKey = (z, bundle) => {
         response.status
       );
     }
-    const json = JSON.parse(response.content);
+    const json = response.json;
     return {
       sessionKey: json.sessionKey || 'secret'
     };

--- a/example-apps/trigger/triggers/recipe.js
+++ b/example-apps/trigger/triggers/recipe.js
@@ -15,9 +15,7 @@ const listRecipes = (z, bundle) => {
   };
 
   // You may return a promise or a normal data structure from any perform method.
-  return z
-    .request(requestOptions)
-    .then(response => z.JSON.parse(response.content));
+  return z.request(requestOptions).then(response => response.json);
 };
 
 // We recommend writing your triggers separate like this and rolling them

--- a/example-apps/typescript/src/resources/recipe.ts
+++ b/example-apps/typescript/src/resources/recipe.ts
@@ -8,7 +8,7 @@ const getRecipe = async (z: ZObject, bundle: Bundle<{ id: string }>) => {
   const response = await z.request({
     url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
   });
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 const listRecipes = async (z: ZObject, bundle: Bundle<{ style?: string }>) => {
@@ -18,7 +18,7 @@ const listRecipes = async (z: ZObject, bundle: Bundle<{ style?: string }>) => {
       style: bundle.inputData.style
     }
   });
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 const createRecipe = async (
@@ -42,7 +42,7 @@ const createRecipe = async (
       'content-type': 'application/json'
     }
   });
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 const searchRecipe = async (z: ZObject, bundle: Bundle) => {
@@ -52,7 +52,7 @@ const searchRecipe = async (z: ZObject, bundle: Bundle) => {
       nameSearch: bundle.inputData.name
     }
   });
-  const matchingRecipes = z.JSON.parse(response.content);
+  const matchingRecipes = response.json as {}[];
 
   // Only return the first matching recipe
   if (matchingRecipes && matchingRecipes.length) {

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1059,8 +1059,8 @@ z.request({
   response.request; // original request options
   response.throwForStatus();
   // if options.raw === false (default)...
+  response.json; // identical to:
   JSON.parse(response.content);
-  response.json;
   // if options.raw === true...
   response.buffer().then(buf => buf.toString());
   response.text().then(content => content);
@@ -1625,7 +1625,7 @@ For deduplication to work, we need to be able to identify and use a unique field
 
 ```js
 // ...
-let items = z.JSON.parse(response.content).items;
+let items = response.json.items;
 items.forEach(item => {
   item.id = item.contactId;
 })

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -566,7 +566,7 @@ const getSessionKey = (z, bundle) => {
       throw new Error('The username/password you supplied is invalid');
     }
     return {
-      sessionKey: z.JSON.parse(response.content).sessionKey
+      sessionKey: response.json.sessionKey
     };
   });
 };
@@ -1277,7 +1277,7 @@ perform: () => {
         spreadsheet_id: bundle.inputData.spreadsheet_id
       }
     })
-    .then(response => z.JSON.parse(response.content));
+    .then(response => response.json);
 };
 
 ```
@@ -1497,7 +1497,7 @@ To define an Output Field for a nested field use `{{parent}}__{{key}}`. For chil
 const recipeOutputFields = (z, bundle) => {
   const response = z.request('https://example.com/api/v2/fields.json');
   // json is like [{"key":"field_1","label":"Label for Custom Field"}]
-  return response.then(res => z.JSON.parse(res.content));
+  return response.then(res => res.json);
 };
 
 const App = {
@@ -1934,7 +1934,7 @@ const listExample = (z, bundle) => {
     .then(response => {
       response.throwForStatus();
 
-      const recipes = z.JSON.parse(response.content);
+      const recipes = response.json;
       // do any custom processing of recipes here...
 
       return recipes;
@@ -2030,15 +2030,10 @@ const mustBe200 = (response, z, bundle) => {
   return response;
 };
 
-const autoParseJson = (response, z, bundle) => {
-  response.json = z.JSON.parse(response.content);
-  return response;
-};
-
 const App = {
   // ...
   beforeRequest: [addHeader],
-  afterResponse: [mustBe200, autoParseJson]
+  afterResponse: [mustBe200]
   // ...
 };
 
@@ -2115,8 +2110,8 @@ z.request({
   response.request; // original request options
   response.throwForStatus();
   // if options.raw === false (default)...
+  response.json; // identical to:
   JSON.parse(response.content);
-  response.json;
   // if options.raw === true...
   response.buffer().then(buf => buf.toString());
   response.text().then(content => content);
@@ -2147,13 +2142,13 @@ Here is an example that pulls in extra data for a movie:
 ```js
 const getExtraDataFunction = (z, bundle) => {
   const url = `https://example.com/movies/${bundle.inputData.id}.json`;
-  return z.request(url).then(res => z.JSON.parse(res.content));
+  return z.request(url).then(res => res.json);
 };
 
 const movieList = (z, bundle) => {
   return z
     .request('https://example.com/movies.json')
-    .then(res => z.JSON.parse(res.content))
+    .then(res => res.json)
     .then(results => {
       return results.map(result => {
         // so maybe /movies.json is thin content but
@@ -2251,7 +2246,7 @@ const stashPDFfunction = (z, bundle) => {
 const pdfList = (z, bundle) => {
   return z
     .request('https://example.com/pdfs.json')
-    .then(res => z.JSON.parse(res.content))
+    .then(res => res.json)
     .then(results => {
       return results.map(result => {
         // lazily convert a secret_download_url to a stashed url
@@ -3029,7 +3024,7 @@ For deduplication to work, we need to be able to identify and use a unique field
 
 ```js
 // ...
-let items = z.JSON.parse(response.content).items;
+let items = response.json.items;
 items.forEach(item => {
   item.id = item.contactId;
 })

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1315,7 +1315,7 @@ zapier convert 1234 my-app 1.0.1
       <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;The username/password you supplied is invalid&apos;</span>);
     }
     <span class="hljs-keyword">return</span> {
-      <span class="hljs-attr">sessionKey</span>: z.JSON.parse(response.content).sessionKey
+      <span class="hljs-attr">sessionKey</span>: response.json.sessionKey
     };
   });
 };
@@ -2215,7 +2215,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
         <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id
       }
     })
-    .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> z.JSON.parse(response.content));
+    .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> response.json);
 };
 
 </code></pre>
@@ -2493,7 +2493,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeOutputFields = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> response = z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
   <span class="hljs-comment">// json is like [{&quot;key&quot;:&quot;field_1&quot;,&quot;label&quot;:&quot;Label for Custom Field&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content));
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -3322,7 +3322,7 @@ zapier env 1.0.0
     .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> {
       response.throwForStatus();
 
-      <span class="hljs-keyword">const</span> recipes = z.JSON.parse(response.content);
+      <span class="hljs-keyword">const</span> recipes = response.json;
       <span class="hljs-comment">// do any custom processing of recipes here...</span>
 
       <span class="hljs-keyword">return</span> recipes;
@@ -3447,15 +3447,10 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> response;
 };
 
-<span class="hljs-keyword">const</span> autoParseJson = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
-  response.json = z.JSON.parse(response.content);
-  <span class="hljs-keyword">return</span> response;
-};
-
 <span class="hljs-keyword">const</span> App = {
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">beforeRequest</span>: [addHeader],
-  <span class="hljs-attr">afterResponse</span>: [mustBe200, autoParseJson]
+  <span class="hljs-attr">afterResponse</span>: [mustBe200]
   <span class="hljs-comment">// ...</span>
 };
 
@@ -3557,8 +3552,8 @@ zapier env 1.0.0
   response.request; <span class="hljs-comment">// original request options</span>
   response.throwForStatus();
   <span class="hljs-comment">// if options.raw === false (default)...</span>
+  response.json; <span class="hljs-comment">// identical to:</span>
   <span class="hljs-built_in">JSON</span>.parse(response.content);
-  response.json;
   <span class="hljs-comment">// if options.raw === true...</span>
   response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
   response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
@@ -3595,13 +3590,13 @@ zapier env 1.0.0
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> getExtraDataFunction = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> url = <span class="hljs-string">`https://example.com/movies/<span class="hljs-subst">${bundle.inputData.id}</span>.json`</span>;
-  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content));
+  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
 };
 
 <span class="hljs-keyword">const</span> movieList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/movies.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content))
+    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
     .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
       <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
         <span class="hljs-comment">// so maybe /movies.json is thin content but</span>
@@ -3730,7 +3725,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 <span class="hljs-keyword">const</span> pdfList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/pdfs.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> z.JSON.parse(res.content))
+    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
     .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
       <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
         <span class="hljs-comment">// lazily convert a secret_download_url to a stashed url</span>
@@ -4924,7 +4919,7 @@ npm run zapier-push
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
-<span class="hljs-keyword">let</span> items = z.JSON.parse(response.content).items;
+<span class="hljs-keyword">let</span> items = response.json.items;
 items.forEach(<span class="hljs-function"><span class="hljs-params">item</span> =&gt;</span> {
   item.id = item.contactId;
 })

--- a/packages/cli/scaffold/create.template.js
+++ b/packages/cli/scaffold/create.template.js
@@ -11,7 +11,7 @@ const perform = async (z, bundle) => {
   });
   response.throwForStatus();
   // this should return a single object
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 module.exports = {

--- a/packages/cli/scaffold/resource.template.js
+++ b/packages/cli/scaffold/resource.template.js
@@ -7,7 +7,7 @@ const performList = async (z, bundle) => {
     }
   });
   response.throwForStatus()
-  return z.JSON.parse(response.content)
+  return response.json
 };
 
 // find a particular <%= LOWER_NOUN %> by name (or other search criteria)
@@ -19,7 +19,7 @@ const performSearch = async (z, bundle) => {
     }
   });
   response.throwForStatus()
-  return z.JSON.parse(response.content)
+  return response.json
 };
 
 // creates a new <%= LOWER_NOUN %>
@@ -32,7 +32,7 @@ const performCreate = async (z, bundle) => {
     }
   });
   response.throwForStatus()
-  return z.JSON.parse(response.content)
+  return response.json
 };
 
 module.exports = {

--- a/packages/cli/scaffold/search.template.js
+++ b/packages/cli/scaffold/search.template.js
@@ -8,7 +8,7 @@ const perform = async (z, bundle) => {
   });
   response.throwForStatus();
   // this should return an array of objects (but only the first will be used)
-  return z.JSON.parse(response.content)
+  return response.json
 };
 
 module.exports = {

--- a/packages/cli/scaffold/trigger.template.js
+++ b/packages/cli/scaffold/trigger.template.js
@@ -8,7 +8,7 @@ const perform = async (z, bundle) => {
   });
   response.throwForStatus();
   // this should return an array of objects
-  return z.JSON.parse(response.content);
+  return response.json;
 };
 
 module.exports = {

--- a/packages/cli/snippets/dehydration.js
+++ b/packages/cli/snippets/dehydration.js
@@ -1,12 +1,12 @@
 const getExtraDataFunction = (z, bundle) => {
   const url = `https://example.com/movies/${bundle.inputData.id}.json`;
-  return z.request(url).then(res => z.JSON.parse(res.content));
+  return z.request(url).then(res => res.json);
 };
 
 const movieList = (z, bundle) => {
   return z
     .request('https://example.com/movies.json')
-    .then(res => z.JSON.parse(res.content))
+    .then(res => res.json)
     .then(results => {
       return results.map(result => {
         // so maybe /movies.json is thin content but

--- a/packages/cli/snippets/dynamic-dropdowns-five.js
+++ b/packages/cli/snippets/dynamic-dropdowns-five.js
@@ -5,5 +5,5 @@ perform: () => {
         spreadsheet_id: bundle.inputData.spreadsheet_id
       }
     })
-    .then(response => z.JSON.parse(response.content));
+    .then(response => response.json);
 };

--- a/packages/cli/snippets/manual-request.js
+++ b/packages/cli/snippets/manual-request.js
@@ -10,7 +10,7 @@ const listExample = (z, bundle) => {
     .then(response => {
       response.throwForStatus();
 
-      const recipes = z.JSON.parse(response.content);
+      const recipes = response.json;
       // do any custom processing of recipes here...
 
       return recipes;

--- a/packages/cli/snippets/middleware.js
+++ b/packages/cli/snippets/middleware.js
@@ -16,14 +16,9 @@ const mustBe200 = (response, z, bundle) => {
   return response;
 };
 
-const autoParseJson = (response, z, bundle) => {
-  response.json = z.JSON.parse(response.content);
-  return response;
-};
-
 const App = {
   // ...
   beforeRequest: [addHeader],
-  afterResponse: [mustBe200, autoParseJson]
+  afterResponse: [mustBe200]
   // ...
 };

--- a/packages/cli/snippets/output-fields.js
+++ b/packages/cli/snippets/output-fields.js
@@ -1,7 +1,7 @@
 const recipeOutputFields = (z, bundle) => {
   const response = z.request('https://example.com/api/v2/fields.json');
   // json is like [{"key":"field_1","label":"Label for Custom Field"}]
-  return response.then(res => z.JSON.parse(res.content));
+  return response.then(res => res.json);
 };
 
 const App = {

--- a/packages/cli/snippets/session-auth.js
+++ b/packages/cli/snippets/session-auth.js
@@ -13,7 +13,7 @@ const getSessionKey = (z, bundle) => {
       throw new Error('The username/password you supplied is invalid');
     }
     return {
-      sessionKey: z.JSON.parse(response.content).sessionKey
+      sessionKey: response.json.sessionKey
     };
   });
 };

--- a/packages/cli/snippets/stash-file.js
+++ b/packages/cli/snippets/stash-file.js
@@ -11,7 +11,7 @@ const stashPDFfunction = (z, bundle) => {
 const pdfList = (z, bundle) => {
   return z
     .request('https://example.com/pdfs.json')
-    .then(res => z.JSON.parse(res.content))
+    .then(res => res.json)
     .then(results => {
       return results.map(result => {
         // lazily convert a secret_download_url to a stashed url

--- a/packages/cli/src/tests/utils/convert.js
+++ b/packages/cli/src/tests/utils/convert.js
@@ -81,11 +81,11 @@ const visualAppDefinition = {
           },
           {
             source:
-              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    response.throwForStatus();\n    const results = z.JSON.parse(response.content);\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n"
+              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    response.throwForStatus();\n    const results = response.json;\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n"
           },
           {
             source:
-              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    response.throwForStatus();\n    const results = z.JSON.parse(response.content);\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n"
+              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    response.throwForStatus();\n    const results = response.json;\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n"
           },
           {
             required: false,
@@ -208,7 +208,7 @@ const visualAppDefinition = {
       operation: {
         perform: {
           source:
-            "const options = {\n  url: 'https://jsonplaceholder.typicode.com/posts',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n    '_limit': '3'\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    response.throwForStatus();\n    const results = z.JSON.parse(response.content);\n\n    // You can do any parsing you need for results here before returning them\n\n    return results;\n  });"
+            "const options = {\n  url: 'https://jsonplaceholder.typicode.com/posts',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n    '_limit': '3'\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    response.throwForStatus();\n    const results = response.json;\n\n    // You can do any parsing you need for results here before returning them\n\n    return results;\n  });"
         }
       },
       noun: 'Code',

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -127,7 +127,7 @@ const RequestFunc = {
     operation: {
       perform: (z /* , bundle */) => {
         return z.request({ url: '{{process.env.BASE_URL}}/get' }).then(resp => {
-          const result = JSON.parse(resp.content);
+          const result = resp.json;
           result.id = 123;
           return [result];
         });
@@ -147,7 +147,7 @@ const RequestSugar = {
     operation: {
       perform: (z /* , bundle */) => {
         return z.request('https://httpbin.org/get').then(resp => {
-          return JSON.parse(resp.content);
+          return resp.json;
         });
       }
     }
@@ -412,7 +412,7 @@ const ExecuteRequestAsFunc = {
       perform: (z, bundle) => {
         const req = _.defaults({}, bundle.inputData.options);
         return z.request(req).then(resp => {
-          return bundle.inputData.returnValue || JSON.parse(resp.content);
+          return bundle.inputData.returnValue || resp.json;
         });
       },
       inputFields: [
@@ -516,7 +516,7 @@ const changeStatusOnErrorResponses = response => {
     return response;
   }
 
-  const data = JSON.parse(response.content);
+  const data = response.json;
   const error = data.args.error;
   if (response.status === 200 && error) {
     response.status = 500;


### PR DESCRIPTION
I originally included some of these in #193 but figured it was better done in a separate PR.

AFAIK unless you set `raw:true` you can use `response.json` instead of `z.JSON.parse(response.content)` so I guess we want to promote that more simple shortcut as much as we can.