### PR TITLE
improvement(cli): Compress zip files more

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -15,6 +15,10 @@ const ignore = require('ignore');
 const gitIgnore = require('parse-gitignore');
 const semver = require('semver');
 
+const {
+  constants: { Z_BEST_COMPRESSION }
+} = require('zlib');
+
 const constants = require('../constants');
 
 const {
@@ -170,7 +174,7 @@ const writeZipFromPaths = (dir, zipPath, paths) => {
   return new Promise((resolve, reject) => {
     const output = fs.createWriteStream(zipPath);
     const zip = archiver('zip', {
-      store: true // Sets the compression method to STORE.
+      zlib: { level: Z_BEST_COMPRESSION }
     });
 
     // listen for all archive data to be written


### PR DESCRIPTION
Adds some compression when creating `build.zip`. 

Using an app w/ `lodash` and `moment` as dependencies, the zip size went from `1.6M` -> `409K`, so that's promising!

I also tested with an app pushed to prod - everything worked normally. I didn't notice any difference in the app build time. 

Test suite was the exact same speed. 