### PR TITLE
fix(legacy-scripting-runner): reliably resolve array curlies from other triggers/actions/searches

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -671,6 +671,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
       request.headers = cleanHeaders(request.headers);
       request.allowGetBody = true;
+      request.serializeValueForCurlies = serializeValueForCurlies;
 
       const response = await zcli.request(request);
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -786,6 +786,16 @@ describe('Integration Test', () => {
         'movie_post_poll_make_array',
         'movie_post_poll'
       );
+
+      // appDef will be injected to `input` as `input._zapier.app` by
+      // createInput(). core has an injectInput beforeRequest middleware that
+      // inject `input` to the request object. When core does prepareRequest,
+      // it's going to replace every curlies in req.input._zapier.app. So apart
+      // from the request options passed into z.request, we also need to make
+      // sure array curlies from another trigger/action don't break either.
+      appDef.legacy.triggers.recipe.operation.url =
+        'https://example.com?things={{bundle.inputData.things}}';
+
       const compiledApp = schemaTools.prepareApp(appDef);
       const app = createApp(appDefWithAuth);
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Following up on #190, there's still a case we need to handle for the `cannot reliably interpolate objects or arrays into a string` error. See the test for details.