### PR TITLE
fix(cli): Allow for different changelog version formats

### DIFF
--- a/packages/cli/src/tests/utils/changelog.js
+++ b/packages/cli/src/tests/utils/changelog.js
@@ -13,7 +13,7 @@ describe('changelog utils', () => {
       appDir = makeTempDir();
       fs.writeFileSync(
         path.join(appDir, 'CHANGELOG.md'),
-        '## 2.0.0\n\n' +
+        '## new and improved version! (v2.0.0)\n\n' +
           '* Fix some bugs.\n' +
           '* Major docs fixes.\n\n' +
           '## 1.0.0\n\n' +
@@ -42,5 +42,10 @@ describe('changelog utils', () => {
         .then(log => {
           log.should.eql('');
         }));
+
+    it('should not fail when versions follow "different" formatting', () =>
+      changelog.getVersionChangelog('2.0.0', appDir).then(log => {
+        log.should.eql('* Fix some bugs.\n* Major docs fixes.');
+      }));
   });
 });

--- a/packages/cli/src/utils/changelog.js
+++ b/packages/cli/src/utils/changelog.js
@@ -9,9 +9,8 @@ const getChangelogFromMarkdown = (version, markdown) => {
     .replace(/\r/g, '\n')
     .split('\n');
 
-  let startingLine = _.findIndex(
-    lines,
-    line => line.indexOf(`## ${version}`) === 0
+  let startingLine = _.findIndex(lines, line =>
+    RegExp(`## .*${version}`).test(line)
   );
 
   if (startingLine === -1) {


### PR DESCRIPTION
https://keepachangelog.com/en/1.0.0/ uses a format like so:

but our changelog utils only handled

So this commit just loosens up the restrictions a bit. :)

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
