### PR TITLE
BREAKING CHANGE(core): Introduce response.data with support for form-urlencoded and custom parsing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1321,7 +1321,7 @@ zapier convert 1234 my-app 1.0.1
       <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;The username/password you supplied is invalid&apos;</span>);
     }
     <span class="hljs-keyword">return</span> {
-      <span class="hljs-attr">sessionKey</span>: response.json.sessionKey,
+      <span class="hljs-attr">sessionKey</span>: response.data.sessionKey,
     };
   });
 };
@@ -1972,7 +1972,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeFields = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> response = z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
   <span class="hljs-comment">// json is is [{&quot;key&quot;:&quot;field_1&quot;},{&quot;key&quot;:&quot;field_2&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -1987,19 +1987,19 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;title&apos;</span>,
             <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Title of Recipe&apos;</span>,
-            <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Name your recipe!&apos;</span>
+            <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Name your recipe!&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;style&apos;</span>,
             <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
-            <span class="hljs-attr">choices</span>: { <span class="hljs-attr">mexican</span>: <span class="hljs-string">&apos;Mexican&apos;</span>, <span class="hljs-attr">italian</span>: <span class="hljs-string">&apos;Italian&apos;</span> }
+            <span class="hljs-attr">choices</span>: { <span class="hljs-attr">mexican</span>: <span class="hljs-string">&apos;Mexican&apos;</span>, <span class="hljs-attr">italian</span>: <span class="hljs-string">&apos;Italian&apos;</span> },
           },
-          recipeFields <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
+          recipeFields, <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
         ],
-        <span class="hljs-attr">perform</span>: <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {}
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {},
+      },
+    },
+  },
 };
 
 </code></pre>
@@ -2208,10 +2208,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/api/v2/projects.json&apos;</span>, {
       <span class="hljs-attr">params</span>: {
-        <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id
-      }
+        <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id,
+      },
     })
-    .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> response.json);
+    .then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
 };
 
 </code></pre>
@@ -2489,7 +2489,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeOutputFields = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> response = z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
   <span class="hljs-comment">// json is like [{&quot;key&quot;:&quot;field_1&quot;,&quot;label&quot;:&quot;Label for Custom Field&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -2504,67 +2504,67 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
           <span class="hljs-attr">title</span>: <span class="hljs-string">&apos;Pancake&apos;</span>,
           <span class="hljs-attr">author</span>: {
             <span class="hljs-attr">id</span>: <span class="hljs-number">1</span>,
-            <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Amy&apos;</span>
+            <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Amy&apos;</span>,
           },
           <span class="hljs-attr">ingredients</span>: [
             {
               <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Egg&apos;</span>,
-              <span class="hljs-attr">amount</span>: <span class="hljs-number">1</span>
+              <span class="hljs-attr">amount</span>: <span class="hljs-number">1</span>,
             },
             {
               <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Milk&apos;</span>,
               <span class="hljs-attr">amount</span>: <span class="hljs-number">60</span>,
-              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>
+              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>,
             },
             {
               <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Flour&apos;</span>,
               <span class="hljs-attr">amount</span>: <span class="hljs-number">30</span>,
-              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>
-            }
-          ]
+              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>,
+            },
+          ],
         },
         <span class="hljs-comment">// an array of objects is the simplest way</span>
         <span class="hljs-attr">outputFields</span>: [
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;id&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Recipe ID&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;title&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Recipe Title&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;author__id&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Author User ID&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;author__name&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Author Name&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;ingredients[]name&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Ingredient Name&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;ingredients[]amount&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Ingredient Amount&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;number&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;number&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;ingredients[]unit&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Ingredient Unit&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
-          recipeOutputFields <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
-        ]
-      }
-    }
-  }
+          recipeOutputFields, <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
+        ],
+      },
+    },
+  },
 };
 
 </code></pre>
@@ -2939,7 +2939,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     },
   };
 
-  <span class="hljs-keyword">return</span> z.request(options).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.json);
+  <span class="hljs-keyword">return</span> z.request(options).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
 };
 
 <span class="hljs-built_in">module</span>.exports = {
@@ -3174,14 +3174,14 @@ zapier env 1.0.0
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> listExample = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> httpOptions = {
     <span class="hljs-attr">headers</span>: {
-      <span class="hljs-string">&apos;my-header&apos;</span>: process.env.MY_SECRET_VALUE
-    }
+      <span class="hljs-string">&apos;my-header&apos;</span>: process.env.MY_SECRET_VALUE,
+    },
   };
   <span class="hljs-keyword">const</span> response = z.request(
     <span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>,
     httpOptions
   );
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -3191,10 +3191,10 @@ zapier env 1.0.0
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;{{process.env.MY_NOUN}}&apos;</span>,
       <span class="hljs-attr">operation</span>: {
         <span class="hljs-comment">// ...</span>
-        <span class="hljs-attr">perform</span>: listExample
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: listExample,
+      },
+    },
+  },
 };
 
 </code></pre>
@@ -3316,7 +3316,7 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>, customHttpOptions)
     .then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> {
-      <span class="hljs-keyword">const</span> recipes = response.json;
+      <span class="hljs-keyword">const</span> recipes = response.data;
       <span class="hljs-comment">// do any custom processing of recipes here...</span>
 
       <span class="hljs-keyword">return</span> recipes;
@@ -3435,17 +3435,22 @@ zapier env 1.0.0
   }
 
   <span class="hljs-comment">// Throw an error that `throwForStatus` wouldn&apos;t throw (correctly) for.</span>
-  <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.json.success === <span class="hljs-literal">false</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.json.message, response.json.code);
+  <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.data.message, response.data.code);
   }
+};
 
+<span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
+  <span class="hljs-comment">// Parse content that is not JSON</span>
+  <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
+  response.data = xml.parse(response.content);
   <span class="hljs-keyword">return</span> response;
 };
 
 <span class="hljs-keyword">const</span> App = {
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">beforeRequest</span>: [addHeader],
-  <span class="hljs-attr">afterResponse</span>: [handleErrors],
+  <span class="hljs-attr">afterResponse</span>: [parseXML, handleErrors],
   <span class="hljs-comment">// ...</span>
 };
 
@@ -3547,7 +3552,9 @@ zapier env 1.0.0
       <p>The response object returned by <code>z.request([url], options)</code> supports the following fields and methods:</p><ul>
 <li><code>status</code>: The response status code, i.e. <code>200</code>, <code>404</code>, etc.</li>
 <li><code>content</code>: The response content as a String. For Buffer, try <code>options.raw = true</code>.</li>
-<li><code>json</code>: The response content as an object (or <code>undefined</code>). If <code>options.raw = true</code> - is a promise.</li>
+<li><code>data</code>: The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
+<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated: Use <code>data</code> instead.</li>
+<li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise).</li>
 <li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
@@ -3566,14 +3573,16 @@ zapier env 1.0.0
   response.getHeader(<span class="hljs-string">&apos;content-type&apos;</span>);
   response.request; <span class="hljs-comment">// original request options</span>
   response.throwForStatus();
-  <span class="hljs-comment">// if options.raw === false (default)...</span>
-  response.json; <span class="hljs-comment">// identical to:</span>
-  <span class="hljs-built_in">JSON</span>.parse(response.content);
-  <span class="hljs-comment">// if options.raw === true...</span>
-  response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
-  response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
-  response.json().then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> json);
-  response.body.pipe(otherStream);
+  <span class="hljs-keyword">if</span> (options.raw === <span class="hljs-literal">false</span>) { <span class="hljs-comment">// (default)</span>
+    response.data; <span class="hljs-comment">// same as...</span>
+    <span class="hljs-built_in">JSON</span>.parse(response.content); <span class="hljs-comment">// or...</span>
+    querystring.parse(response.content);
+  } <span class="hljs-keyword">else</span> {
+    response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
+    response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
+    response.json().then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> json);
+    response.body.pipe(otherStream);
+  }
 });
 </code></pre>
     </div>
@@ -3605,19 +3614,19 @@ zapier env 1.0.0
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> getExtraDataFunction = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> url = <span class="hljs-string">`https://example.com/movies/<span class="hljs-subst">${bundle.inputData.id}</span>.json`</span>;
-  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> movieList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/movies.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
-    .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
-      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
+    .then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data)
+    .then(<span class="hljs-function">(<span class="hljs-params">results</span>) =&gt;</span> {
+      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function">(<span class="hljs-params">result</span>) =&gt;</span> {
         <span class="hljs-comment">// so maybe /movies.json is thin content but</span>
         <span class="hljs-comment">// /movies/:id.json has more details we want...</span>
         result.moreData = z.dehydrate(getExtraDataFunction, {
-          <span class="hljs-attr">id</span>: result.id
+          <span class="hljs-attr">id</span>: result.id,
         });
         <span class="hljs-keyword">return</span> result;
       });
@@ -3631,7 +3640,7 @@ zapier env 1.0.0
   <span class="hljs-comment">// don&apos;t forget to register hydrators here!</span>
   <span class="hljs-comment">// it can be imported from any module</span>
   <span class="hljs-attr">hydrators</span>: {
-    <span class="hljs-attr">getExtraData</span>: getExtraDataFunction
+    <span class="hljs-attr">getExtraData</span>: getExtraDataFunction,
   },
 
   <span class="hljs-attr">triggers</span>: {
@@ -3639,13 +3648,13 @@ zapier env 1.0.0
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;Movie&apos;</span>,
       <span class="hljs-attr">display</span>: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New Movie&apos;</span>,
-        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new Movie is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new Movie is added.&apos;</span>,
       },
       <span class="hljs-attr">operation</span>: {
-        <span class="hljs-attr">perform</span>: movieList
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: movieList,
+      },
+    },
+  },
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
@@ -3731,7 +3740,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
   <span class="hljs-comment">// use standard auth to request the file</span>
   <span class="hljs-keyword">const</span> filePromise = z.request({
     <span class="hljs-attr">url</span>: bundle.inputData.downloadUrl,
-    <span class="hljs-attr">raw</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">raw</span>: <span class="hljs-literal">true</span>,
   });
   <span class="hljs-comment">// and swap it for a stashed URL</span>
   <span class="hljs-keyword">return</span> z.stashFile(filePromise);
@@ -3740,13 +3749,13 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 <span class="hljs-keyword">const</span> pdfList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/pdfs.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
-    .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
-      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
+    .then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data)
+    .then(<span class="hljs-function">(<span class="hljs-params">results</span>) =&gt;</span> {
+      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function">(<span class="hljs-params">result</span>) =&gt;</span> {
         <span class="hljs-comment">// lazily convert a secret_download_url to a stashed url</span>
         <span class="hljs-comment">// zapier won&apos;t do this until we need it</span>
         result.file = z.dehydrateFile(stashPDFfunction, {
-          <span class="hljs-attr">downloadUrl</span>: result.secret_download_url
+          <span class="hljs-attr">downloadUrl</span>: result.secret_download_url,
         });
         <span class="hljs-keyword">delete</span> result.secret_download_url;
         <span class="hljs-keyword">return</span> result;
@@ -3759,7 +3768,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
   <span class="hljs-attr">platformVersion</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;zapier-platform-core&apos;</span>).version,
 
   <span class="hljs-attr">hydrators</span>: {
-    <span class="hljs-attr">stashPDF</span>: stashPDFfunction
+    <span class="hljs-attr">stashPDF</span>: stashPDFfunction,
   },
 
   <span class="hljs-attr">triggers</span>: {
@@ -3767,13 +3776,13 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;PDF&apos;</span>,
       <span class="hljs-attr">display</span>: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New PDF&apos;</span>,
-        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new PDF is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new PDF is added.&apos;</span>,
       },
       <span class="hljs-attr">operation</span>: {
-        <span class="hljs-attr">perform</span>: pdfList
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: pdfList,
+      },
+    },
+  },
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
@@ -4647,7 +4656,7 @@ npm run zapier-push
 <li><a href="https://github.com/jhuckaby/pixl-xml">pixl-xml</a></li>
 <li><a href="https://github.com/Leonidas-from-XIV/node-xml2js">xml2js</a></li>
 <li><a href="https://github.com/NaturalIntelligence/fast-xml-parser">fast-xml-parser</a></li>
-</ul>
+</ul><p>For <a href="shorthand-http-requests">shorthand requests</a>, use an <code>afterResponse</code> <a href="using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed XML:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> xml = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;pixl-xml&apos;</span>);
@@ -4656,10 +4665,10 @@ npm run zapier-push
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">afterResponse</span>: [
     <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
-      response.xml = xml.parse(response.content);
+      response.data = xml.parse(response.content);
       <span class="hljs-keyword">return</span> response;
-    }
-  ]
+    },
+  ],
   <span class="hljs-comment">// ...</span>
 };
 
@@ -4687,8 +4696,8 @@ npm run zapier-push
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://jsonplaceholder.typicode.com/posts&apos;</span>,
     <span class="hljs-attr">params</span>: {
       <span class="hljs-attr">_start</span>: start,
-      <span class="hljs-attr">_limit</span>: limit
-    }
+      <span class="hljs-attr">_limit</span>: limit,
+    },
   });
 };
 
@@ -4707,9 +4716,9 @@ npm run zapier-push
     i += <span class="hljs-number">1</span>;
   }
 
-  <span class="hljs-keyword">return</span> <span class="hljs-built_in">Promise</span>.all(promises).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> {
+  <span class="hljs-keyword">return</span> <span class="hljs-built_in">Promise</span>.all(promises).then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> {
     <span class="hljs-comment">// res is an array of responses</span>
-    <span class="hljs-keyword">const</span> results = res.map(<span class="hljs-function"><span class="hljs-params">r</span> =&gt;</span> r.json); <span class="hljs-comment">// array of arrays of js objects</span>
+    <span class="hljs-keyword">const</span> results = res.map(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.data); <span class="hljs-comment">// array of arrays of js objects</span>
     <span class="hljs-keyword">return</span> <span class="hljs-built_in">Array</span>.prototype.concat.apply([], results); <span class="hljs-comment">// flatten array</span>
   });
 };
@@ -4720,13 +4729,13 @@ npm run zapier-push
 
   <span class="hljs-attr">display</span>: {
     <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Get Paging&apos;</span>,
-    <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers on a new paging.&apos;</span>
+    <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers on a new paging.&apos;</span>,
   },
 
   <span class="hljs-attr">operation</span>: {
     <span class="hljs-attr">inputFields</span>: [],
-    <span class="hljs-attr">perform</span>: performPaging
-  }
+    <span class="hljs-attr">perform</span>: performPaging,
+  },
 };
 
 </code></pre>
@@ -4751,11 +4760,11 @@ npm run zapier-push
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://jsonplaceholder.typicode.com/posts&apos;</span>,
     <span class="hljs-attr">params</span>: {
       <span class="hljs-attr">_start</span>: start,
-      <span class="hljs-attr">_limit</span>: limit
-    }
+      <span class="hljs-attr">_limit</span>: limit,
+    },
   });
 
-  <span class="hljs-keyword">let</span> results = response.json;
+  <span class="hljs-keyword">let</span> results = response.data;
 
   <span class="hljs-comment">// keep paging until the last item was created over two hours ago</span>
   <span class="hljs-comment">// then we know we almost certainly haven&apos;t missed anything and can let</span>
@@ -4768,11 +4777,11 @@ npm run zapier-push
       <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://jsonplaceholder.typicode.com/posts&apos;</span>,
       <span class="hljs-attr">params</span>: {
         <span class="hljs-attr">_start</span>: start,
-        <span class="hljs-attr">_limit</span>: limit
-      }
+        <span class="hljs-attr">_limit</span>: limit,
+      },
     });
 
-    results = results.concat(response.json);
+    results = results.concat(response.data);
   }
 
   <span class="hljs-keyword">return</span> results;
@@ -4827,7 +4836,7 @@ npm run zapier-push
       <span class="hljs-attr">offset</span>: <span class="hljs-number">100</span> * bundle.meta.page
     }
   });
-  <span class="hljs-keyword">return</span> promise.then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.json);
+  <span class="hljs-keyword">return</span> promise.then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
 };
 </code></pre>
     </div>
@@ -4937,7 +4946,7 @@ npm run zapier-push
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
-<span class="hljs-keyword">let</span> items = response.json.items;
+<span class="hljs-keyword">let</span> items = response.data.items;
 items.forEach(<span class="hljs-function"><span class="hljs-params">item</span> =&gt;</span> {
   item.id = item.contactId;
 })

--- a/example-apps/babel/src/resources/recipe.js
+++ b/example-apps/babel/src/resources/recipe.js
@@ -2,19 +2,19 @@ const _sharedBaseUrl = 'https://auth-json-server.zapier-staging.com';
 
 const getRecipe = async (z, bundle) => {
   const response = await z.request({
-    url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
+    url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`,
   });
-  return response.json;
+  return response.data;
 };
 
 const listRecipes = async (z, bundle) => {
   const response = await z.request({
     url: _sharedBaseUrl + '/recipes',
     params: {
-      style: bundle.inputData.style
-    }
+      style: bundle.inputData.style,
+    },
   });
-  return response.json;
+  return response.data;
 };
 
 const createRecipe = async (z, bundle) => {
@@ -24,23 +24,23 @@ const createRecipe = async (z, bundle) => {
     body: {
       name: bundle.inputData.name,
       directions: bundle.inputData.directions,
-      authorId: bundle.inputData.authorId
+      authorId: bundle.inputData.authorId,
     },
     headers: {
-      'content-type': 'application/json'
-    }
+      'content-type': 'application/json',
+    },
   });
-  return response.json;
+  return response.data;
 };
 
 const searchRecipe = async (z, bundle) => {
   const response = await z.request({
     url: _sharedBaseUrl + '/recipes',
     params: {
-      nameSearch: bundle.inputData.name
-    }
+      nameSearch: bundle.inputData.name,
+    },
   });
-  const matchingRecipes = response.json;
+  const matchingRecipes = response.data;
 
   // Only return the first matching recipe
   if (matchingRecipes && matchingRecipes.length) {
@@ -56,7 +56,7 @@ const sample = {
   name: 'Best Spagetti Ever',
   authorId: 1,
   directions: '1. Boil Noodles\n2.Serve with sauce',
-  style: 'italian'
+  style: 'italian',
 };
 
 // This file exports a Recipe resource. The definition below contains all of the keys available,
@@ -70,31 +70,31 @@ const Recipe = {
   get: {
     display: {
       label: 'Get Recipe',
-      description: 'Gets a recipe.'
+      description: 'Gets a recipe.',
     },
     operation: {
       inputFields: [{ key: 'id', required: true }],
       perform: getRecipe,
-      sample
-    }
+      sample,
+    },
   },
   // The list method on this resource becomes a Trigger on the app. Zapier will use polling to watch for new records
   list: {
     display: {
       label: 'New Recipe',
-      description: 'Trigger when a new recipe is added.'
+      description: 'Trigger when a new recipe is added.',
     },
     operation: {
       inputFields: [
         {
           key: 'style',
           type: 'string',
-          helpText: 'Explain what style of cuisine this is.'
-        }
+          helpText: 'Explain what style of cuisine this is.',
+        },
       ],
       perform: listRecipes,
-      sample
-    }
+      sample,
+    },
   },
   // If your app supports webhooks, you can define a hook method instead of a list method.
   // Zapier will turn this into a webhook Trigger on the app.
@@ -105,7 +105,7 @@ const Recipe = {
   create: {
     display: {
       label: 'Create Recipe',
-      description: 'Creates a new recipe.'
+      description: 'Creates a new recipe.',
     },
     operation: {
       inputFields: [
@@ -114,36 +114,36 @@ const Recipe = {
           key: 'directions',
           required: true,
           type: 'text',
-          helpText: 'Explain how should one make the recipe, step by step.'
+          helpText: 'Explain how should one make the recipe, step by step.',
         },
         {
           key: 'authorId',
           required: true,
           type: 'integer',
-          label: 'Author ID'
+          label: 'Author ID',
         },
         {
           key: 'style',
           required: false,
           type: 'string',
-          helpText: 'Explain what style of cuisine this is.'
-        }
+          helpText: 'Explain what style of cuisine this is.',
+        },
       ],
       perform: createRecipe,
-      sample
-    }
+      sample,
+    },
   },
 
   search: {
     display: {
       label: 'Find Recipe',
-      description: 'Finds an existing recipe by name.'
+      description: 'Finds an existing recipe by name.',
     },
     operation: {
       inputFields: [{ key: 'name', required: true, type: 'string' }],
       perform: searchRecipe,
-      sample
-    }
+      sample,
+    },
   },
 
   // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
@@ -161,8 +161,8 @@ const Recipe = {
     { key: 'name', label: 'Name' },
     { key: 'directions', label: 'Directions' },
     { key: 'authorId', label: 'Author ID' },
-    { key: 'style', label: 'Style' }
-  ]
+    { key: 'style', label: 'Style' },
+  ],
 };
 
 export default Recipe;

--- a/example-apps/create/creates/recipe.js
+++ b/example-apps/create/creates/recipe.js
@@ -8,7 +8,7 @@ module.exports = {
   noun: 'Recipe',
   display: {
     label: 'Create Recipe',
-    description: 'Creates a new recipe.'
+    description: 'Creates a new recipe.',
   },
 
   // `operation` is where the business logic goes.
@@ -19,15 +19,15 @@ module.exports = {
         key: 'directions',
         required: true,
         type: 'text',
-        helpText: 'Explain how should one make the recipe, step by step.'
+        helpText: 'Explain how should one make the recipe, step by step.',
       },
       { key: 'authorId', required: true, type: 'integer', label: 'Author ID' },
       {
         key: 'style',
         required: false,
         type: 'string',
-        helpText: 'Explain what style of cuisine this is.'
-      }
+        helpText: 'Explain what style of cuisine this is.',
+      },
     ],
     perform: (z, bundle) => {
       const promise = z.request({
@@ -37,7 +37,7 @@ module.exports = {
           name: bundle.inputData.name,
           directions: bundle.inputData.directions,
           authorId: bundle.inputData.authorId,
-          style: bundle.inputData.style
+          style: bundle.inputData.style,
         },
         headers: {
           'content-type': 'application/json',
@@ -45,11 +45,11 @@ module.exports = {
           // This is NOT how you normally do authentication. This is just to demo how to write a create here.
           // Refer to this doc to set up authentication:
           // https://zapier.github.io/zapier-platform-cli/#authentication
-          'X-API-Key': 'secret'
-        }
+          'X-API-Key': 'secret',
+        },
       });
 
-      return promise.then(response => response.json);
+      return promise.then((response) => response.data);
     },
 
     // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
@@ -61,7 +61,7 @@ module.exports = {
       name: 'Best Spagetti Ever',
       authorId: 1,
       directions: '1. Boil Noodles\n2.Serve with sauce',
-      style: 'italian'
+      style: 'italian',
     },
 
     // If the resource can have fields that are custom on a per-user basis, define a function to fetch the custom
@@ -74,7 +74,7 @@ module.exports = {
       { key: 'name', label: 'Name' },
       { key: 'directions', label: 'Directions' },
       { key: 'authorId', label: 'Author ID' },
-      { key: 'style', label: 'Style' }
-    ]
-  }
+      { key: 'style', label: 'Style' },
+    ],
+  },
 };

--- a/example-apps/digest-auth/test/digest.js
+++ b/example-apps/digest-auth/test/digest.js
@@ -19,8 +19,8 @@ describe('digest auth app', () => {
 
     return appTester(App.authentication.test, bundle).then((response) => {
       response.status.should.eql(200);
-      response.json.authenticated.should.be.true();
-      response.json.user.should.eql('myuser');
+      response.data.authenticated.should.be.true();
+      response.data.user.should.eql('myuser');
     });
   });
 

--- a/example-apps/dynamic-dropdown/triggers/people.js
+++ b/example-apps/dynamic-dropdown/triggers/people.js
@@ -3,26 +3,26 @@ const { generateID } = require('../utils');
 // fetches a list of records from the endpoint
 const fetchList = (z, bundle) => {
   const request = {
-    url: 'https://swapi.co/api/people/'
+    url: 'https://swapi.co/api/people/',
   };
 
   // ideally, we should poll through all the pages of results, but in this example
   //   we're going to omit that part. Thus, this trigger only "see" the people
   //   in their first page of results
-  return z.request(request).then(response => {
-    let peopleArray = response.json.results;
+  return z.request(request).then((response) => {
+    let peopleArray = response.data.results;
     if (bundle.inputData.species) {
       // The Zap's setup has requested a specific species of person.
       // Since the API/endpoint can't perform the filtering, we'll perform it
       //   here, within the integration, and return the matching objects/records
       //   back to Zapier.
-      peopleArray = peopleArray.filter(person => {
+      peopleArray = peopleArray.filter((person) => {
         const speciesID = generateID(person.species[0]);
         return speciesID === String(bundle.inputData.species);
       });
     }
 
-    peopleArray.forEach(person => {
+    peopleArray.forEach((person) => {
       // copy the "url" field into an "id" field
       person.id = generateID(person.url);
     });
@@ -36,7 +36,7 @@ module.exports = {
   noun: 'person',
   display: {
     label: 'New Person',
-    description: 'Triggers when a new person is added.'
+    description: 'Triggers when a new person is added.',
   },
 
   operation: {
@@ -46,7 +46,7 @@ module.exports = {
         type: 'string',
         helpText: 'Species of person',
         dynamic: 'species.id.name',
-        altersDynamicFields: true
+        altersDynamicFields: true,
       },
       (z, bundle) => {
         if (!bundle.inputData.species) {
@@ -57,16 +57,16 @@ module.exports = {
             key: 'foo1',
             label: 'Favorite Number',
             required: false,
-            type: 'number'
+            type: 'number',
           },
           {
             key: 'foo2',
             label: 'Favorite Color',
             required: false,
-            type: 'string'
-          }
+            type: 'string',
+          },
         ];
-      }
+      },
     ],
     perform: fetchList,
     sample: {
@@ -80,7 +80,7 @@ module.exports = {
       mass: '77',
       skin_color: 'Fair',
       created: '2014-12-09T13:50:51.644000Z',
-      edited: '2014-12-10T13:52:43.172000Z'
-    }
-  }
+      edited: '2014-12-10T13:52:43.172000Z',
+    },
+  },
 };

--- a/example-apps/dynamic-dropdown/triggers/species.js
+++ b/example-apps/dynamic-dropdown/triggers/species.js
@@ -4,7 +4,7 @@ const generateID = require('../utils').generateID;
 const fetchList = (z, bundle) => {
   const request = {
     url: 'https://swapi.co/api/species/',
-    params: {}
+    params: {},
   };
 
   // this API returns things in "pages" of results
@@ -12,9 +12,9 @@ const fetchList = (z, bundle) => {
     request.params.page = 1 + bundle.meta.page;
   }
 
-  return z.request(request).then(response => {
-    const speciesArray = response.json.results;
-    speciesArray.forEach(species => {
+  return z.request(request).then((response) => {
+    const speciesArray = response.data.results;
+    speciesArray.forEach((species) => {
       // copy the "url" field into an "id" field
       species.id = generateID(species.url);
     });
@@ -29,7 +29,7 @@ module.exports = {
     label: 'List of Species',
     description:
       'This is a hidden trigger, and is used in a Dynamic Dropdown within this app',
-    hidden: true
+    hidden: true,
   },
 
   operation: {
@@ -37,6 +37,6 @@ module.exports = {
     perform: fetchList,
     // the folowing is a "hint" to the Zap Editor that this trigger returns data "in pages", and
     //   that the UI should display an option to "load next page" to the human.
-    canPaginate: true
-  }
+    canPaginate: true,
+  },
 };

--- a/example-apps/files/creates/uploadFile.js
+++ b/example-apps/files/creates/uploadFile.js
@@ -21,16 +21,16 @@ const uploadFile = (z, bundle) => {
     .request({
       url: 'https://1i94uigjze.execute-api.us-east-1.amazonaws.com/api/upload',
       method: 'POST',
-      body: formData
+      body: formData,
     })
-    .then(response => {
-      const file = response.json;
+    .then((response) => {
+      const file = response.data;
 
       // Make it possible to use the actual uploaded (or online converted)
       // file in a subsequent action. No need to download it now, so again
       // dehydrating like in ../triggers/newFile.js
       file.file = z.dehydrateFile(hydrators.downloadFile, {
-        fileId: file.id
+        fileId: file.id,
       });
 
       return file;
@@ -42,7 +42,7 @@ module.exports = {
   noun: 'File',
   display: {
     label: 'Upload File',
-    description: 'Uploads a file.'
+    description: 'Uploads a file.',
   },
   operation: {
     inputFields: [
@@ -51,23 +51,23 @@ module.exports = {
         required: false,
         type: 'string',
         label: 'Name',
-        helpText: 'If not defined, the Filename will be copied here.'
+        helpText: 'If not defined, the Filename will be copied here.',
       },
       { key: 'filename', required: true, type: 'string', label: 'Filename' },
-      { key: 'file', required: true, type: 'file', label: 'File' }
+      { key: 'file', required: true, type: 'file', label: 'File' },
     ],
     perform: uploadFile,
     sample: {
       id: 1,
       name: 'Example PDF',
       file: 'SAMPLE FILE',
-      filename: 'example.pdf'
+      filename: 'example.pdf',
     },
     outputFields: [
       { key: 'id', type: 'integer', label: 'ID' },
       { key: 'name', type: 'string', label: 'Name' },
       { key: 'filename', type: 'string', label: 'Filename' },
-      { key: 'file', type: 'file', label: 'File' }
-    ]
-  }
+      { key: 'file', type: 'file', label: 'File' },
+    ],
+  },
 };

--- a/example-apps/files/triggers/newFile.js
+++ b/example-apps/files/triggers/newFile.js
@@ -10,15 +10,15 @@ const listFiles = (z, bundle) => {
   // You may return a promise or a normal data structure from any perform method.
   return z
     .request({
-      url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/files'
+      url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/files',
     })
-    .then(response => {
-      const files = response.json;
+    .then((response) => {
+      const files = response.data;
 
       // Make it possible to get the actual file contents if necessary (no need to make the request now)
-      return files.map(file => {
+      return files.map((file) => {
         file.file = z.dehydrateFile(hydrators.downloadFile, {
-          fileId: file.id
+          fileId: file.id,
         });
 
         return file;
@@ -36,7 +36,7 @@ module.exports = {
   noun: 'File',
   display: {
     label: 'New File',
-    description: 'Trigger when a new file is added.'
+    description: 'Trigger when a new file is added.',
   },
 
   // `operation` is where the business logic goes.
@@ -47,14 +47,14 @@ module.exports = {
       id: 1,
       name: 'Example PDF',
       file: 'SAMPLE FILE',
-      filename: 'example.pdf'
+      filename: 'example.pdf',
     },
 
     outputFields: [
       { key: 'id', type: 'integer', label: 'ID' },
       { key: 'name', type: 'string', label: 'Name' },
       { key: 'filename', type: 'string', label: 'Filename' },
-      { key: 'file', type: 'file', label: 'File' }
-    ]
-  }
+      { key: 'file', type: 'file', label: 'File' },
+    ],
+  },
 };

--- a/example-apps/github/creates/issue.js
+++ b/example-apps/github/creates/issue.js
@@ -6,10 +6,10 @@ const createIssue = (z, bundle) => {
     url: `https://api.github.com/repos/${bundle.inputData.repo}/issues`,
     body: {
       title: bundle.inputData.title,
-      body: bundle.inputData.body
-    }
+      body: bundle.inputData.body,
+    },
   });
-  return responsePromise.then(response => response.json);
+  return responsePromise.then((response) => response.data);
 };
 
 module.exports = {
@@ -18,7 +18,7 @@ module.exports = {
 
   display: {
     label: 'Create Issue',
-    description: 'Creates a issue.'
+    description: 'Creates a issue.',
   },
 
   operation: {
@@ -27,12 +27,12 @@ module.exports = {
         key: 'repo',
         label: 'Repo',
         required: true,
-        dynamic: 'repo.full_name.full_name'
+        dynamic: 'repo.full_name.full_name',
       },
       { key: 'title', label: 'Title', required: true },
-      { key: 'body', label: 'Body', required: false }
+      { key: 'body', label: 'Body', required: false },
     ],
     perform: createIssue,
-    sample: sample
-  }
+    sample: sample,
+  },
 };

--- a/example-apps/github/triggers/issue.js
+++ b/example-apps/github/triggers/issue.js
@@ -8,10 +8,10 @@ const triggerIssue = (z, bundle) => {
       filter: bundle.inputData.filter,
       state: bundle.inputData.state,
       sort: 'updated',
-      direction: 'desc'
-    }
+      direction: 'desc',
+    },
   });
-  return responsePromise.then(response => response.json);
+  return responsePromise.then((response) => response.data);
 };
 
 module.exports = {
@@ -20,7 +20,7 @@ module.exports = {
 
   display: {
     label: 'Get Issue',
-    description: 'Triggers on a new issue.'
+    description: 'Triggers on a new issue.',
   },
 
   operation: {
@@ -29,7 +29,7 @@ module.exports = {
         key: 'repo',
         label: 'Repo',
         required: true,
-        dynamic: 'repo.full_name.full_name'
+        dynamic: 'repo.full_name.full_name',
       },
       {
         key: 'filter',
@@ -40,20 +40,20 @@ module.exports = {
           created: 'created',
           mentioned: 'mentioned',
           subscribed: 'subscribed',
-          all: 'all'
+          all: 'all',
         },
-        helpText: 'Default is "assigned"'
+        helpText: 'Default is "assigned"',
       },
       {
         key: 'state',
         required: false,
         label: 'State',
         choices: { open: 'open', closed: 'closed', all: 'all' },
-        helpText: 'Default is "open"'
-      }
+        helpText: 'Default is "open"',
+      },
     ],
     perform: triggerIssue,
 
-    sample: sample
-  }
+    sample: sample,
+  },
 };

--- a/example-apps/github/triggers/repo.js
+++ b/example-apps/github/triggers/repo.js
@@ -2,9 +2,9 @@ const sample = require('../samples/sample_repo_list');
 
 const triggerRepo = (z, bundle) => {
   const responsePromise = z.request({
-    url: 'https://api.github.com/user/repos?per_page=100'
+    url: 'https://api.github.com/user/repos?per_page=100',
   });
-  return responsePromise.then(response => response.json);
+  return responsePromise.then((response) => response.data);
 };
 
 module.exports = {
@@ -15,12 +15,12 @@ module.exports = {
     label: 'Get Repo',
     hidden: true,
     description:
-      "The only purpose of this trigger is to populate the dropdown list of repos in the UI, thus, it's hidden."
+      "The only purpose of this trigger is to populate the dropdown list of repos in the UI, thus, it's hidden.",
   },
 
   operation: {
     inputFields: [],
     perform: triggerRepo,
-    sample: sample
-  }
+    sample: sample,
+  },
 };

--- a/example-apps/middleware/index.js
+++ b/example-apps/middleware/index.js
@@ -22,8 +22,8 @@ const handleErrors = (response, z) => {
   }
 
   // Throw an error that `throwForStatus` wouldn't throw (correctly) for.
-  else if (response.status === 200 && response.json.success === false) {
-    throw new z.errors.Error(response.json.message, response.json.code);
+  else if (response.status === 200 && response.data.success === false) {
+    throw new z.errors.Error(response.data.message, response.data.code);
   }
 
   return response;

--- a/example-apps/oauth1-trello/authentication.js
+++ b/example-apps/oauth1-trello/authentication.js
@@ -1,5 +1,3 @@
-const querystring = require('querystring');
-
 const _ = require('lodash');
 
 const REQUEST_TOKEN_URL = 'https://trello.com/1/OAuthGetRequestToken';
@@ -17,7 +15,7 @@ const getRequestToken = async (z, bundle) => {
       oauth_callback: bundle.inputData.redirect_uri,
     },
   });
-  return querystring.parse(response.content);
+  return response.data;
 };
 
 const getAccessToken = async (z, bundle) => {
@@ -32,7 +30,7 @@ const getAccessToken = async (z, bundle) => {
       oauth_verifier: bundle.inputData.oauth_verifier,
     },
   });
-  return querystring.parse(response.content);
+  return response.data;
 };
 
 const config = {

--- a/example-apps/oauth1-trello/triggers/board.js
+++ b/example-apps/oauth1-trello/triggers/board.js
@@ -2,7 +2,7 @@
 const triggerBoard = async (z, bundle) => {
   const url = 'https://trello.com/1/members/me/boards';
   const response = await z.request(url);
-  return response.json;
+  return response.data;
 };
 
 module.exports = {
@@ -11,7 +11,7 @@ module.exports = {
 
   display: {
     label: 'Get Board',
-    description: 'Triggers on a new board.'
+    description: 'Triggers on a new board.',
   },
 
   operation: {
@@ -30,75 +30,75 @@ module.exports = {
           perBoard: {
             status: 'ok',
             disableAt: 34200,
-            warnAt: 32400
-          }
+            warnAt: 32400,
+          },
         },
         boards: {
           totalMembersPerBoard: {
             status: 'ok',
             disableAt: 1520,
-            warnAt: 1440
-          }
+            warnAt: 1440,
+          },
         },
         cards: {
           openPerBoard: {
             status: 'ok',
             disableAt: 4750,
-            warnAt: 4500
+            warnAt: 4500,
           },
           totalPerBoard: {
             status: 'ok',
             disableAt: 1900000,
-            warnAt: 1800000
-          }
+            warnAt: 1800000,
+          },
         },
         checklists: {
           perBoard: {
             status: 'ok',
             disableAt: 1900000,
-            warnAt: 1800000
-          }
+            warnAt: 1800000,
+          },
         },
         customFields: {
           perBoard: {
             status: 'ok',
             disableAt: 48,
-            warnAt: 45
-          }
+            warnAt: 45,
+          },
         },
         labels: {
           perBoard: {
             status: 'ok',
             disableAt: 950,
-            warnAt: 900
-          }
+            warnAt: 900,
+          },
         },
         lists: {
           openPerBoard: {
             status: 'ok',
             disableAt: 475,
-            warnAt: 450
+            warnAt: 450,
           },
           totalPerBoard: {
             status: 'ok',
             disableAt: 2850,
-            warnAt: 2700
-          }
-        }
+            warnAt: 2700,
+          },
+        },
       },
       memberships: [
         {
           id: '5612e4fb1b25c15e8737234b',
           idMember: '53baf533e697a982248cd73f',
           memberType: 'admin',
-          unconfirmed: false
+          unconfirmed: false,
         },
         {
           id: '5925e4fc63096260c349cbd4',
           idMember: '53cd82cd7ed746db278c4f32',
           memberType: 'normal',
-          unconfirmed: false
-        }
+          unconfirmed: false,
+        },
       ],
       pinned: false,
       starred: false,
@@ -120,62 +120,62 @@ module.exports = {
             width: 140,
             height: 100,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/140x100/5afcd242d52da7ad4827966d8c896c00/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/140x100/5afcd242d52da7ad4827966d8c896c00/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 256,
             height: 192,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/256x192/d297510e553abc340fb0de3570445f03/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/256x192/d297510e553abc340fb0de3570445f03/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 480,
             height: 480,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/480x480/08b5996b0a87a0f3dd80af488d99194a/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/480x480/08b5996b0a87a0f3dd80af488d99194a/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 960,
             height: 960,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/960x960/7cb60ad23bdee1ca45a7c5e4e0c07968/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/960x960/7cb60ad23bdee1ca45a7c5e4e0c07968/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 1024,
             height: 1024,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1024x1024/dca79e47ce10cd2c985dc4ba61abd9cc/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1024x1024/dca79e47ce10cd2c985dc4ba61abd9cc/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 2048,
             height: 2048,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2048x2048/b5a88d70569d9ded2af259e8d332c346/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2048x2048/b5a88d70569d9ded2af259e8d332c346/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 1280,
             height: 1280,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1280x1280/c9ae077543d6c41ea2d48d84fdc12484/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1280x1280/c9ae077543d6c41ea2d48d84fdc12484/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 1920,
             height: 1920,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1920x1920/cc85a9a12195863a1ff2193b5bb3a651/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/1920x1920/cc85a9a12195863a1ff2193b5bb3a651/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 2560,
             height: 1600,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1600/de59d9e742f2de51d4284c6fd7c07f5d/photo-1495571758719-6ec1e876d6ae.jpg'
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1600/de59d9e742f2de51d4284c6fd7c07f5d/photo-1495571758719-6ec1e876d6ae.jpg',
           },
           {
             width: 2560,
             height: 1707,
             url:
-              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1707/f3c8b6101072d80565d9b6368f05b19d/photo-1495571758719-6ec1e876d6ae'
-          }
+              'https://trello-backgrounds.s3.amazonaws.com/SharedBackground/2560x1707/f3c8b6101072d80565d9b6368f05b19d/photo-1495571758719-6ec1e876d6ae',
+          },
         ],
         backgroundTile: false,
         backgroundBrightness: 'light',
@@ -184,7 +184,7 @@ module.exports = {
         canBePublic: false,
         canBeOrg: false,
         canBePrivate: false,
-        canInvite: true
+        canInvite: true,
       },
       invitations: [],
       shortLink: 'HbTEX5hb',
@@ -199,14 +199,14 @@ module.exports = {
         sky: '',
         lime: '',
         pink: '',
-        black: ''
+        black: '',
       },
       powerUps: [],
       dateLastActivity: '2016-01-07T21:24:47.855Z',
       dateLastView: '2018-03-12T14:15:20.234Z',
       shortUrl: 'https://trello.com/b/HbTEX5hb',
       idTags: [],
-      datePluginDisable: null
-    }
-  }
+      datePluginDisable: null,
+    },
+  },
 };

--- a/example-apps/oauth1-tumblr/triggers/like.js
+++ b/example-apps/oauth1-tumblr/triggers/like.js
@@ -1,7 +1,7 @@
 const perform = async (z, bundle) => {
   const url = 'https://api.tumblr.com/v2/user/likes';
   const response = await z.request(url);
-  const result = response.json;
+  const result = response.data;
   return result.response.liked_posts || [];
 };
 
@@ -11,7 +11,7 @@ module.exports = {
 
   display: {
     label: 'New Like',
-    description: 'Triggers when you like a post.'
+    description: 'Triggers when you like a post.',
   },
 
   operation: {
@@ -29,7 +29,7 @@ module.exports = {
       tags: ['tumblrize', 'milky dog', 'mini comic'],
       note_count: 14,
       title: 'Milky Dog',
-      body: '<p>Example body.</p>'
-    }
-  }
+      body: '<p>Example body.</p>',
+    },
+  },
 };

--- a/example-apps/oauth1-twitter/authentication.js
+++ b/example-apps/oauth1-twitter/authentication.js
@@ -1,5 +1,3 @@
-const querystring = require('querystring');
-
 const _ = require('lodash');
 
 const REQUEST_TOKEN_URL = 'https://api.twitter.com/oauth/request_token';
@@ -18,7 +16,7 @@ const getRequestToken = async (z, bundle) => {
       oauth_version: '1.0', // Twitter says this should be 1.0
     },
   });
-  return querystring.parse(response.content);
+  return response.data;
 };
 
 const getAccessToken = async (z, bundle) => {
@@ -33,7 +31,7 @@ const getAccessToken = async (z, bundle) => {
       oauth_verifier: bundle.inputData.oauth_verifier,
     },
   });
-  return querystring.parse(response.content);
+  return response.data;
 };
 
 const config = {

--- a/example-apps/oauth2/authentication.js
+++ b/example-apps/oauth2/authentication.js
@@ -16,8 +16,8 @@ const getAccessToken = (z, bundle) => {
 
   // Needs to return at minimum, `access_token`, and if your app also does refresh, then `refresh_token` too
   return promise.then((response) => ({
-    access_token: response.json.access_token,
-    refresh_token: response.json.refresh_token,
+    access_token: response.data.access_token,
+    refresh_token: response.data.refresh_token,
   }));
 };
 
@@ -38,7 +38,7 @@ const refreshAccessToken = (z, bundle) => {
   // Needs to return `access_token`. If the refresh token stays constant, can skip it. If it changes, can
   // return it here to update the user's auth on Zapier.
   return promise.then((response) => ({
-    access_token: response.json.access_token,
+    access_token: response.data.access_token,
   }));
 };
 
@@ -52,7 +52,7 @@ const testAuth = (z /*, bundle */) => {
 
   // This method can return any truthy value to indicate the credentials are valid.
   // Raise an error to show
-  return promise.then((response) => response.json);
+  return promise.then((response) => response.data);
 };
 
 module.exports = {

--- a/example-apps/onedrive/authentication.js
+++ b/example-apps/onedrive/authentication.js
@@ -50,9 +50,9 @@ const getAccessToken = (z, bundle) => {
   })
 
   return promise.then((response) => ({
-    access_token: response.json.access_token,
-    refresh_token: response.json.refresh_token,
-    id_token: response.json.id_token,
+    access_token: response.data.access_token,
+    refresh_token: response.data.refresh_token,
+    id_token: response.data.id_token,
   }))
 }
 
@@ -81,9 +81,9 @@ const refreshAccessToken = (z, bundle) => {
   })
 
   return promise.then((response) => ({
-    access_token: response.json.access_token,
-    refresh_token: response.json.refresh_token,
-    id_token: response.json.id_token,
+    access_token: response.data.access_token,
+    refresh_token: response.data.refresh_token,
+    id_token: response.data.id_token,
   }))
 }
 
@@ -96,7 +96,7 @@ const testAuth = (z) => {
     url: 'https://graph.microsoft.com/v1.0/me',
   })
 
-  return promise.then((response) => response.json)
+  return promise.then((response) => response.data)
 }
 
 module.exports = {

--- a/example-apps/onedrive/resources/base-item.js
+++ b/example-apps/onedrive/resources/base-item.js
@@ -113,7 +113,7 @@ const handleCreateWithSession = (
       },
     })
     .then((response) => {
-      const uploadUrl = response.json.uploadUrl
+      const uploadUrl = response.data.uploadUrl
 
       // This should work fine for files up to 60MB (https://dev.onedrive.com/items/upload_large_files.htm#upload-fragments)
 

--- a/example-apps/onedrive/utils.js
+++ b/example-apps/onedrive/utils.js
@@ -12,7 +12,7 @@ const parseResponse = (z, type, response) => {
   let results = []
 
   if (response.status >= 200 && response.status < 300) {
-    results = response.json
+    results = response.data
 
     // OneDrive puts the contents of lists inside .value property
     if (!_.isArray(results) && _.isArray(results.value)) {
@@ -57,7 +57,7 @@ const extractParentsFromPath = (path) => {
       id: (i + 1) * -1,
       name: name === '' ? '/' : name,
       _path: parts.join('/') + (name === '' ? name : `/${name}`),
-      folder: {}
+      folder: {},
     }
 
     results.push(result)
@@ -102,7 +102,7 @@ const getFileDetailsFromRequest = (url) =>
       filename: '',
       size: 0,
       content: '',
-      contentType: ''
+      contentType: '',
     }
 
     fetch(url)
@@ -135,5 +135,5 @@ module.exports = {
   extractParentsFromPath,
   cleanupPaths,
   getFileDetailsFromRequest,
-  getStringByteSize
+  getStringByteSize,
 }

--- a/example-apps/resource/resources/recipe.js
+++ b/example-apps/resource/resources/recipe.js
@@ -3,9 +3,9 @@ const _sharedBaseUrl = 'https://auth-json-server.zapier-staging.com';
 const getRecipe = (z, bundle) => {
   return z
     .request({
-      url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
+      url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`,
     })
-    .then(response => response.json);
+    .then((response) => response.data);
 };
 
 const listRecipes = (z, bundle) => {
@@ -13,10 +13,10 @@ const listRecipes = (z, bundle) => {
     .request({
       url: _sharedBaseUrl + '/recipes',
       params: {
-        style: bundle.inputData.style
-      }
+        style: bundle.inputData.style,
+      },
     })
-    .then(response => response.json);
+    .then((response) => response.data);
 };
 
 const createRecipe = (z, bundle) => {
@@ -26,14 +26,14 @@ const createRecipe = (z, bundle) => {
     body: {
       name: bundle.inputData.name,
       directions: bundle.inputData.directions,
-      authorId: bundle.inputData.authorId
+      authorId: bundle.inputData.authorId,
     },
     headers: {
-      'content-type': 'application/json'
-    }
+      'content-type': 'application/json',
+    },
   };
 
-  return z.request(requestOptions).then(response => response.json);
+  return z.request(requestOptions).then((response) => response.data);
 };
 
 const searchRecipe = (z, bundle) => {
@@ -41,11 +41,11 @@ const searchRecipe = (z, bundle) => {
     .request({
       url: _sharedBaseUrl + '/recipes',
       params: {
-        nameSearch: bundle.inputData.name
-      }
+        nameSearch: bundle.inputData.name,
+      },
     })
-    .then(response => {
-      const matchingRecipes = response.json;
+    .then((response) => {
+      const matchingRecipes = response.data;
 
       // Only return the first matching recipe
       if (matchingRecipes && matchingRecipes.length) {
@@ -62,7 +62,7 @@ const sample = {
   name: 'Best Spagetti Ever',
   authorId: 1,
   directions: '1. Boil Noodles\n2.Serve with sauce',
-  style: 'italian'
+  style: 'italian',
 };
 
 // This file exports a Recipe resource. The definition below contains all of the keys available,
@@ -76,31 +76,31 @@ module.exports = {
   get: {
     display: {
       label: 'Get Recipe',
-      description: 'Gets a recipe.'
+      description: 'Gets a recipe.',
     },
     operation: {
       inputFields: [{ key: 'id', required: true }],
       perform: getRecipe,
-      sample: sample
-    }
+      sample: sample,
+    },
   },
   // The list method on this resource becomes a Trigger on the app. Zapier will use polling to watch for new records
   list: {
     display: {
       label: 'New Recipe',
-      description: 'Trigger when a new recipe is added.'
+      description: 'Trigger when a new recipe is added.',
     },
     operation: {
       inputFields: [
         {
           key: 'style',
           type: 'string',
-          helpText: 'Explain what style of cuisine this is.'
-        }
+          helpText: 'Explain what style of cuisine this is.',
+        },
       ],
       perform: listRecipes,
-      sample: sample
-    }
+      sample: sample,
+    },
   },
   // If your app supports webhooks, you can define a hook method instead of a list method.
   // Zapier will turn this into a webhook Trigger on the app.
@@ -112,7 +112,7 @@ module.exports = {
   create: {
     display: {
       label: 'Create Recipe',
-      description: 'Creates a new recipe.'
+      description: 'Creates a new recipe.',
     },
     operation: {
       inputFields: [
@@ -121,36 +121,36 @@ module.exports = {
           key: 'directions',
           required: true,
           type: 'text',
-          helpText: 'Explain how should one make the recipe, step by step.'
+          helpText: 'Explain how should one make the recipe, step by step.',
         },
         {
           key: 'authorId',
           required: true,
           type: 'integer',
-          label: 'Author ID'
+          label: 'Author ID',
         },
         {
           key: 'style',
           required: false,
           type: 'string',
-          helpText: 'Explain what style of cuisine this is.'
-        }
+          helpText: 'Explain what style of cuisine this is.',
+        },
       ],
       perform: createRecipe,
-      sample: sample
-    }
+      sample: sample,
+    },
   },
   // The search method on this resource becomes a Search on this app
   search: {
     display: {
       label: 'Find Recipe',
-      description: 'Finds an existing recipe by name.'
+      description: 'Finds an existing recipe by name.',
     },
     operation: {
       inputFields: [{ key: 'name', required: true, type: 'string' }],
       perform: searchRecipe,
-      sample: sample
-    }
+      sample: sample,
+    },
   },
 
   // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
@@ -168,6 +168,6 @@ module.exports = {
     { key: 'name', label: 'Name' },
     { key: 'directions', label: 'Directions' },
     { key: 'authorId', label: 'Author ID' },
-    { key: 'style', label: 'Style' }
-  ]
+    { key: 'style', label: 'Style' },
+  ],
 };

--- a/example-apps/rest-hooks/triggers/recipe.js
+++ b/example-apps/rest-hooks/triggers/recipe.js
@@ -5,7 +5,7 @@ const subscribeHook = (z, bundle) => {
   // bundle.targetUrl has the Hook URL this app should call when a recipe is created.
   const data = {
     url: bundle.targetUrl,
-    style: bundle.inputData.style
+    style: bundle.inputData.style,
   };
 
   // You can build requests and our client will helpfully inject all the variables
@@ -13,11 +13,11 @@ const subscribeHook = (z, bundle) => {
   const options = {
     url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks',
     method: 'POST',
-    body: data
+    body: data,
   };
 
   // You may return a promise or a normal data structure from any perform method.
-  return z.request(options).then(response => response.json);
+  return z.request(options).then((response) => response.data);
 };
 
 const unsubscribeHook = (z, bundle) => {
@@ -29,11 +29,11 @@ const unsubscribeHook = (z, bundle) => {
   // you need to complete. You can also register middleware to control this.
   const options = {
     url: `https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks/${hookId}`,
-    method: 'DELETE'
+    method: 'DELETE',
   };
 
   // You may return a promise or a normal data structure from any perform method.
-  return z.request(options).then(response => response.json);
+  return z.request(options).then((response) => response.data);
 };
 
 const getRecipe = (z, bundle) => {
@@ -45,7 +45,7 @@ const getRecipe = (z, bundle) => {
     directions: bundle.cleanedRequest.directions,
     style: bundle.cleanedRequest.style,
     authorId: bundle.cleanedRequest.authorId,
-    createdAt: bundle.cleanedRequest.createdAt
+    createdAt: bundle.cleanedRequest.createdAt,
   };
 
   return [recipe];
@@ -56,11 +56,11 @@ const getFallbackRealRecipe = (z, bundle) => {
   const options = {
     url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/recipes/',
     params: {
-      style: bundle.inputData.style
-    }
+      style: bundle.inputData.style,
+    },
   };
 
-  return z.request(options).then(response => response.json);
+  return z.request(options).then((response) => response.data);
 };
 
 // We recommend writing your triggers separate like this and rolling them
@@ -73,7 +73,7 @@ module.exports = {
   noun: 'Recipe',
   display: {
     label: 'New Recipe',
-    description: 'Trigger when a new recipe is added.'
+    description: 'Trigger when a new recipe is added.',
   },
 
   // `operation` is where the business logic goes.
@@ -84,8 +84,8 @@ module.exports = {
       {
         key: 'style',
         type: 'string',
-        helpText: 'Which styles of cuisine this should trigger on.'
-      }
+        helpText: 'Which styles of cuisine this should trigger on.',
+      },
     ],
 
     type: 'hook',
@@ -105,7 +105,7 @@ module.exports = {
       name: 'Best Spagetti Ever',
       authorId: 1,
       directions: '1. Boil Noodles\n2.Serve with sauce',
-      style: 'italian'
+      style: 'italian',
     },
 
     // If the resource can have fields that are custom on a per-user basis, define a function to fetch the custom
@@ -118,7 +118,7 @@ module.exports = {
       { key: 'name', label: 'Name' },
       { key: 'directions', label: 'Directions' },
       { key: 'authorId', label: 'Author ID' },
-      { key: 'style', label: 'Style' }
-    ]
-  }
+      { key: 'style', label: 'Style' },
+    ],
+  },
 };

--- a/example-apps/search-or-create/creates/recipe.js
+++ b/example-apps/search-or-create/creates/recipe.js
@@ -4,10 +4,10 @@ const createRecipe = (z, bundle) => {
     method: 'POST',
     url: 'https://jsonplaceholder.typicode.com/posts',
     body: {
-      name: bundle.inputData.name
-    }
+      name: bundle.inputData.name,
+    },
   });
-  return responsePromise.then(response => response.json);
+  return responsePromise.then((response) => response.data);
 };
 
 module.exports = {
@@ -16,21 +16,24 @@ module.exports = {
 
   display: {
     label: 'Create Recipe',
-    description: 'Creates a recipe.'
+    description: 'Creates a recipe.',
   },
 
   operation: {
     inputFields: [
       { key: 'name', required: true },
-      { key: 'favorite', required: true }
+      { key: 'favorite', required: true },
     ],
     perform: createRecipe,
 
     sample: {
       id: 1,
-      name: 'Test'
+      name: 'Test',
     },
 
-    outputFields: [{ key: 'id', label: 'ID' }, { key: 'name', label: 'Name' }]
-  }
+    outputFields: [
+      { key: 'id', label: 'ID' },
+      { key: 'name', label: 'Name' },
+    ],
+  },
 };

--- a/example-apps/search-or-create/searches/recipe.js
+++ b/example-apps/search-or-create/searches/recipe.js
@@ -3,10 +3,10 @@ const searchRecipe = (z, bundle) => {
   const responsePromise = z.request({
     url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
-      name: bundle.inputData.name
-    }
+      name: bundle.inputData.name,
+    },
   });
-  return responsePromise.then(response => response.json);
+  return responsePromise.then((response) => response.data);
 };
 
 module.exports = {
@@ -15,7 +15,7 @@ module.exports = {
 
   display: {
     label: 'Find a Recipe',
-    description: 'Finds a recipe.'
+    description: 'Finds a recipe.',
   },
 
   operation: {
@@ -23,16 +23,19 @@ module.exports = {
       {
         key: 'name',
         required: true,
-        helpText: 'Find the Recipe with this name.'
-      }
+        helpText: 'Find the Recipe with this name.',
+      },
     ],
     perform: searchRecipe,
 
     sample: {
       id: 1,
-      name: 'Test'
+      name: 'Test',
     },
 
-    outputFields: [{ key: 'id', label: 'ID' }, { key: 'name', label: 'Name' }]
-  }
+    outputFields: [
+      { key: 'id', label: 'ID' },
+      { key: 'name', label: 'Name' },
+    ],
+  },
 };

--- a/example-apps/search/searches/recipe.js
+++ b/example-apps/search/searches/recipe.js
@@ -6,7 +6,7 @@ module.exports = {
   noun: 'Recipe',
   display: {
     label: 'Find a Recipe',
-    description: 'Search for recipe by cuisine style.'
+    description: 'Search for recipe by cuisine style.',
   },
 
   // `operation` is where we make the call to your API to do the search
@@ -19,8 +19,8 @@ module.exports = {
         type: 'string',
         label: 'Style',
         helpText:
-          'Cuisine style to limit to the search to (i.e. mediterranean or italian).'
-      }
+          'Cuisine style to limit to the search to (i.e. mediterranean or italian).',
+      },
     ],
 
     perform: (z, bundle) => {
@@ -30,11 +30,11 @@ module.exports = {
       // a search URL will depend on how your API works.
       const options = {
         params: {
-          style: bundle.inputData.style
-        }
+          style: bundle.inputData.style,
+        },
       };
 
-      return z.request(url, options).then(response => response.json);
+      return z.request(url, options).then((response) => response.data);
     },
 
     // In cases where Zapier needs to show an example record to the user, but we are unable to get a live example
@@ -46,7 +46,7 @@ module.exports = {
       name: 'Best Spagetti Ever',
       authorId: 1,
       directions: '1. Boil Noodles\n2.Serve with sauce',
-      style: 'italian'
+      style: 'italian',
     },
 
     // If the resource can have fields that are custom on a per-user basis, define a function to fetch the custom
@@ -59,7 +59,7 @@ module.exports = {
       { key: 'name', label: 'Name' },
       { key: 'directions', label: 'Directions' },
       { key: 'authorId', label: 'Author ID' },
-      { key: 'style', label: 'Style' }
-    ]
-  }
+      { key: 'style', label: 'Style' },
+    ],
+  },
 };

--- a/example-apps/session-auth/authentication.js
+++ b/example-apps/session-auth/authentication.js
@@ -17,7 +17,7 @@ const getSessionKey = (z, bundle) => {
   });
 
   return promise.then((response) => ({
-    sessionKey: response.json.sessionKey || 'secret',
+    sessionKey: response.data.sessionKey || 'secret',
   }));
 };
 

--- a/example-apps/trigger/triggers/recipe.js
+++ b/example-apps/trigger/triggers/recipe.js
@@ -11,11 +11,11 @@ const listRecipes = (z, bundle) => {
   // you need to complete. You can also register middleware to control this.
   const requestOptions = {
     url: 'https://auth-json-server.zapier-staging.com/recipes',
-    params: params
+    params: params,
   };
 
   // You may return a promise or a normal data structure from any perform method.
-  return z.request(requestOptions).then(response => response.json);
+  return z.request(requestOptions).then((response) => response.data);
 };
 
 // We recommend writing your triggers separate like this and rolling them
@@ -28,7 +28,7 @@ module.exports = {
   noun: 'Recipe',
   display: {
     label: 'New Recipe',
-    description: 'Triggers when a new recipe is added.'
+    description: 'Triggers when a new recipe is added.',
   },
 
   // `operation` is where the business logic goes.
@@ -39,8 +39,8 @@ module.exports = {
       {
         key: 'style',
         type: 'string',
-        helpText: 'Which styles of cuisine this should trigger on.'
-      }
+        helpText: 'Which styles of cuisine this should trigger on.',
+      },
     ],
 
     perform: listRecipes,
@@ -54,7 +54,7 @@ module.exports = {
       name: 'Best Spagetti Ever',
       authorId: 1,
       directions: '1. Boil Noodles\n2.Serve with sauce',
-      style: 'italian'
+      style: 'italian',
     },
 
     // If the resource can have fields that are custom on a per-user basis, define a function to fetch the custom
@@ -71,7 +71,7 @@ module.exports = {
       { key: 'name', label: 'Name' },
       { key: 'directions', label: 'Directions' },
       { key: 'authorId', label: 'Author ID' },
-      { key: 'style', label: 'Style' }
-    ]
-  }
+      { key: 'style', label: 'Style' },
+    ],
+  },
 };

--- a/example-apps/typescript/src/resources/recipe.ts
+++ b/example-apps/typescript/src/resources/recipe.ts
@@ -8,7 +8,7 @@ const getRecipe = async (z: ZObject, bundle: Bundle<{ id: string }>) => {
   const response = await z.request({
     url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
   });
-  return response.json;
+  return response.data;
 };
 
 const listRecipes = async (z: ZObject, bundle: Bundle<{ style?: string }>) => {
@@ -18,7 +18,7 @@ const listRecipes = async (z: ZObject, bundle: Bundle<{ style?: string }>) => {
       style: bundle.inputData.style
     }
   });
-  return response.json;
+  return response.data;
 };
 
 const createRecipe = async (
@@ -42,7 +42,7 @@ const createRecipe = async (
       'content-type': 'application/json'
     }
   });
-  return response.json;
+  return response.data;
 };
 
 const searchRecipe = async (z: ZObject, bundle: Bundle) => {
@@ -52,7 +52,7 @@ const searchRecipe = async (z: ZObject, bundle: Bundle) => {
       nameSearch: bundle.inputData.name
     }
   });
-  const matchingRecipes = response.json as {}[];
+  const matchingRecipes = response.data as {}[];
 
   // Only return the first matching recipe
   if (matchingRecipes && matchingRecipes.length) {

--- a/examples/restHooks.js
+++ b/examples/restHooks.js
@@ -3,18 +3,18 @@ const subscribeHook = async (z, bundle) => {
   // the rest of the data can be anything you want, such an event type or other configuration data
   const data = {
     url: bundle.targetUrl,
-    style: bundle.inputData.style
+    style: bundle.inputData.style,
   };
 
   const options = {
     url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks',
     method: 'POST',
-    body: data
+    body: data,
   };
 
   // data returned from this object will be available in `performUnsubscribe` as `bundle.subscribeData`
   const response = await z.request(options);
-  return response.json;
+  return response.data;
 };
 
 const unsubscribeHook = async (z, bundle) => {
@@ -23,12 +23,12 @@ const unsubscribeHook = async (z, bundle) => {
 
   const options = {
     url: `https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks/${hookId}`,
-    method: 'DELETE'
+    method: 'DELETE',
   };
 
   // You may return a promise or a normal data structure from any perform method.
   const response = await z.request(options);
-  return response.json;
+  return response.data;
 };
 
 // this function runs when a hook is recieved on a live zap (or if testing with a hook)
@@ -41,7 +41,7 @@ const getRecipe = (z, bundle) => {
     directions: bundle.cleanedRequest.directions,
     style: bundle.cleanedRequest.style,
     authorId: bundle.cleanedRequest.authorId,
-    createdAt: bundle.cleanedRequest.createdAt
+    createdAt: bundle.cleanedRequest.createdAt,
   };
 
   // trigger methods must return arrays
@@ -54,13 +54,13 @@ const getFallbackRealRecipe = async (z, bundle) => {
   const options = {
     url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/recipes/',
     params: {
-      style: bundle.inputData.style
-    }
+      style: bundle.inputData.style,
+    },
   };
 
   const response = await z.request(options);
 
-  return response.json;
+  return response.data;
 };
 
 module.exports = {
@@ -71,7 +71,7 @@ module.exports = {
   noun: 'Recipe',
   display: {
     label: 'New Recipe',
-    description: 'Trigger when a new recipe is added.'
+    description: 'Trigger when a new recipe is added.',
   },
 
   // `operation` is where the business logic goes.
@@ -82,8 +82,8 @@ module.exports = {
       {
         key: 'style',
         type: 'string',
-        helpText: 'Which styles of cuisine this should trigger on.'
-      }
+        helpText: 'Which styles of cuisine this should trigger on.',
+      },
     ],
 
     type: 'hook',
@@ -103,7 +103,7 @@ module.exports = {
       name: 'Best Spagetti Ever',
       authorId: 1,
       directions: '1. Boil Noodles\n2.Serve with sauce',
-      style: 'italian'
+      style: 'italian',
     },
 
     // If the item can have fields with custom names (such as a spreadsheet or form app might)
@@ -118,7 +118,7 @@ module.exports = {
       { key: 'name', label: 'Name' },
       { key: 'directions', label: 'Directions' },
       { key: 'authorId', label: 'Author ID' },
-      { key: 'style', label: 'Style' }
-    ]
-  }
+      { key: 'style', label: 'Style' },
+    ],
+  },
 };

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1321,7 +1321,7 @@ zapier convert 1234 my-app 1.0.1
       <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;The username/password you supplied is invalid&apos;</span>);
     }
     <span class="hljs-keyword">return</span> {
-      <span class="hljs-attr">sessionKey</span>: response.json.sessionKey,
+      <span class="hljs-attr">sessionKey</span>: response.data.sessionKey,
     };
   });
 };
@@ -1972,7 +1972,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeFields = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> response = z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
   <span class="hljs-comment">// json is is [{&quot;key&quot;:&quot;field_1&quot;},{&quot;key&quot;:&quot;field_2&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -1987,19 +1987,19 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;title&apos;</span>,
             <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Title of Recipe&apos;</span>,
-            <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Name your recipe!&apos;</span>
+            <span class="hljs-attr">helpText</span>: <span class="hljs-string">&apos;Name your recipe!&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;style&apos;</span>,
             <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>,
-            <span class="hljs-attr">choices</span>: { <span class="hljs-attr">mexican</span>: <span class="hljs-string">&apos;Mexican&apos;</span>, <span class="hljs-attr">italian</span>: <span class="hljs-string">&apos;Italian&apos;</span> }
+            <span class="hljs-attr">choices</span>: { <span class="hljs-attr">mexican</span>: <span class="hljs-string">&apos;Mexican&apos;</span>, <span class="hljs-attr">italian</span>: <span class="hljs-string">&apos;Italian&apos;</span> },
           },
-          recipeFields <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
+          recipeFields, <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
         ],
-        <span class="hljs-attr">perform</span>: <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {}
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {},
+      },
+    },
+  },
 };
 
 </code></pre>
@@ -2208,10 +2208,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/api/v2/projects.json&apos;</span>, {
       <span class="hljs-attr">params</span>: {
-        <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id
-      }
+        <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id,
+      },
     })
-    .then(<span class="hljs-function"><span class="hljs-params">response</span> =&gt;</span> response.json);
+    .then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
 };
 
 </code></pre>
@@ -2489,7 +2489,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeOutputFields = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> response = z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
   <span class="hljs-comment">// json is like [{&quot;key&quot;:&quot;field_1&quot;,&quot;label&quot;:&quot;Label for Custom Field&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -2504,67 +2504,67 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
           <span class="hljs-attr">title</span>: <span class="hljs-string">&apos;Pancake&apos;</span>,
           <span class="hljs-attr">author</span>: {
             <span class="hljs-attr">id</span>: <span class="hljs-number">1</span>,
-            <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Amy&apos;</span>
+            <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Amy&apos;</span>,
           },
           <span class="hljs-attr">ingredients</span>: [
             {
               <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Egg&apos;</span>,
-              <span class="hljs-attr">amount</span>: <span class="hljs-number">1</span>
+              <span class="hljs-attr">amount</span>: <span class="hljs-number">1</span>,
             },
             {
               <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Milk&apos;</span>,
               <span class="hljs-attr">amount</span>: <span class="hljs-number">60</span>,
-              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>
+              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>,
             },
             {
               <span class="hljs-attr">name</span>: <span class="hljs-string">&apos;Flour&apos;</span>,
               <span class="hljs-attr">amount</span>: <span class="hljs-number">30</span>,
-              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>
-            }
-          ]
+              <span class="hljs-attr">unit</span>: <span class="hljs-string">&apos;g&apos;</span>,
+            },
+          ],
         },
         <span class="hljs-comment">// an array of objects is the simplest way</span>
         <span class="hljs-attr">outputFields</span>: [
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;id&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Recipe ID&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;title&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Recipe Title&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;author__id&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Author User ID&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;integer&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;author__name&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Author Name&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;ingredients[]name&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Ingredient Name&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;ingredients[]amount&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Ingredient Amount&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;number&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;number&apos;</span>,
           },
           {
             <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;ingredients[]unit&apos;</span>,
             <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Ingredient Unit&apos;</span>,
-            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>
+            <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>,
           },
-          recipeOutputFields <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
-        ]
-      }
-    }
-  }
+          recipeOutputFields, <span class="hljs-comment">// provide a function inline - we&apos;ll merge the results!</span>
+        ],
+      },
+    },
+  },
 };
 
 </code></pre>
@@ -2939,7 +2939,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     },
   };
 
-  <span class="hljs-keyword">return</span> z.request(options).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.json);
+  <span class="hljs-keyword">return</span> z.request(options).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
 };
 
 <span class="hljs-built_in">module</span>.exports = {
@@ -3174,14 +3174,14 @@ zapier env 1.0.0
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> listExample = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> httpOptions = {
     <span class="hljs-attr">headers</span>: {
-      <span class="hljs-string">&apos;my-header&apos;</span>: process.env.MY_SECRET_VALUE
-    }
+      <span class="hljs-string">&apos;my-header&apos;</span>: process.env.MY_SECRET_VALUE,
+    },
   };
   <span class="hljs-keyword">const</span> response = z.request(
     <span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>,
     httpOptions
   );
-  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> response.then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -3191,10 +3191,10 @@ zapier env 1.0.0
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;{{process.env.MY_NOUN}}&apos;</span>,
       <span class="hljs-attr">operation</span>: {
         <span class="hljs-comment">// ...</span>
-        <span class="hljs-attr">perform</span>: listExample
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: listExample,
+      },
+    },
+  },
 };
 
 </code></pre>
@@ -3316,7 +3316,7 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>, customHttpOptions)
     .then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> {
-      <span class="hljs-keyword">const</span> recipes = response.json;
+      <span class="hljs-keyword">const</span> recipes = response.data;
       <span class="hljs-comment">// do any custom processing of recipes here...</span>
 
       <span class="hljs-keyword">return</span> recipes;
@@ -3435,17 +3435,22 @@ zapier env 1.0.0
   }
 
   <span class="hljs-comment">// Throw an error that `throwForStatus` wouldn&apos;t throw (correctly) for.</span>
-  <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.json.success === <span class="hljs-literal">false</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.json.message, response.json.code);
+  <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.data.message, response.data.code);
   }
+};
 
+<span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
+  <span class="hljs-comment">// Parse content that is not JSON</span>
+  <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
+  response.data = xml.parse(response.content);
   <span class="hljs-keyword">return</span> response;
 };
 
 <span class="hljs-keyword">const</span> App = {
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">beforeRequest</span>: [addHeader],
-  <span class="hljs-attr">afterResponse</span>: [handleErrors],
+  <span class="hljs-attr">afterResponse</span>: [parseXML, handleErrors],
   <span class="hljs-comment">// ...</span>
 };
 
@@ -3547,7 +3552,9 @@ zapier env 1.0.0
       <p>The response object returned by <code>z.request([url], options)</code> supports the following fields and methods:</p><ul>
 <li><code>status</code>: The response status code, i.e. <code>200</code>, <code>404</code>, etc.</li>
 <li><code>content</code>: The response content as a String. For Buffer, try <code>options.raw = true</code>.</li>
-<li><code>json</code>: The response content as an object (or <code>undefined</code>). If <code>options.raw = true</code> - is a promise.</li>
+<li><code>data</code>: The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
+<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated: Use <code>data</code> instead.</li>
+<li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise).</li>
 <li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
@@ -3566,14 +3573,16 @@ zapier env 1.0.0
   response.getHeader(<span class="hljs-string">&apos;content-type&apos;</span>);
   response.request; <span class="hljs-comment">// original request options</span>
   response.throwForStatus();
-  <span class="hljs-comment">// if options.raw === false (default)...</span>
-  response.json; <span class="hljs-comment">// identical to:</span>
-  <span class="hljs-built_in">JSON</span>.parse(response.content);
-  <span class="hljs-comment">// if options.raw === true...</span>
-  response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
-  response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
-  response.json().then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> json);
-  response.body.pipe(otherStream);
+  <span class="hljs-keyword">if</span> (options.raw === <span class="hljs-literal">false</span>) { <span class="hljs-comment">// (default)</span>
+    response.data; <span class="hljs-comment">// same as...</span>
+    <span class="hljs-built_in">JSON</span>.parse(response.content); <span class="hljs-comment">// or...</span>
+    querystring.parse(response.content);
+  } <span class="hljs-keyword">else</span> {
+    response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
+    response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
+    response.json().then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> json);
+    response.body.pipe(otherStream);
+  }
 });
 </code></pre>
     </div>
@@ -3605,19 +3614,19 @@ zapier env 1.0.0
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> getExtraDataFunction = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">const</span> url = <span class="hljs-string">`https://example.com/movies/<span class="hljs-subst">${bundle.inputData.id}</span>.json`</span>;
-  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json);
+  <span class="hljs-keyword">return</span> z.request(url).then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data);
 };
 
 <span class="hljs-keyword">const</span> movieList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/movies.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
-    .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
-      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
+    .then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data)
+    .then(<span class="hljs-function">(<span class="hljs-params">results</span>) =&gt;</span> {
+      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function">(<span class="hljs-params">result</span>) =&gt;</span> {
         <span class="hljs-comment">// so maybe /movies.json is thin content but</span>
         <span class="hljs-comment">// /movies/:id.json has more details we want...</span>
         result.moreData = z.dehydrate(getExtraDataFunction, {
-          <span class="hljs-attr">id</span>: result.id
+          <span class="hljs-attr">id</span>: result.id,
         });
         <span class="hljs-keyword">return</span> result;
       });
@@ -3631,7 +3640,7 @@ zapier env 1.0.0
   <span class="hljs-comment">// don&apos;t forget to register hydrators here!</span>
   <span class="hljs-comment">// it can be imported from any module</span>
   <span class="hljs-attr">hydrators</span>: {
-    <span class="hljs-attr">getExtraData</span>: getExtraDataFunction
+    <span class="hljs-attr">getExtraData</span>: getExtraDataFunction,
   },
 
   <span class="hljs-attr">triggers</span>: {
@@ -3639,13 +3648,13 @@ zapier env 1.0.0
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;Movie&apos;</span>,
       <span class="hljs-attr">display</span>: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New Movie&apos;</span>,
-        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new Movie is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new Movie is added.&apos;</span>,
       },
       <span class="hljs-attr">operation</span>: {
-        <span class="hljs-attr">perform</span>: movieList
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: movieList,
+      },
+    },
+  },
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
@@ -3731,7 +3740,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
   <span class="hljs-comment">// use standard auth to request the file</span>
   <span class="hljs-keyword">const</span> filePromise = z.request({
     <span class="hljs-attr">url</span>: bundle.inputData.downloadUrl,
-    <span class="hljs-attr">raw</span>: <span class="hljs-literal">true</span>
+    <span class="hljs-attr">raw</span>: <span class="hljs-literal">true</span>,
   });
   <span class="hljs-comment">// and swap it for a stashed URL</span>
   <span class="hljs-keyword">return</span> z.stashFile(filePromise);
@@ -3740,13 +3749,13 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 <span class="hljs-keyword">const</span> pdfList = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
   <span class="hljs-keyword">return</span> z
     .request(<span class="hljs-string">&apos;https://example.com/pdfs.json&apos;</span>)
-    .then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> res.json)
-    .then(<span class="hljs-function"><span class="hljs-params">results</span> =&gt;</span> {
-      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function"><span class="hljs-params">result</span> =&gt;</span> {
+    .then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> res.data)
+    .then(<span class="hljs-function">(<span class="hljs-params">results</span>) =&gt;</span> {
+      <span class="hljs-keyword">return</span> results.map(<span class="hljs-function">(<span class="hljs-params">result</span>) =&gt;</span> {
         <span class="hljs-comment">// lazily convert a secret_download_url to a stashed url</span>
         <span class="hljs-comment">// zapier won&apos;t do this until we need it</span>
         result.file = z.dehydrateFile(stashPDFfunction, {
-          <span class="hljs-attr">downloadUrl</span>: result.secret_download_url
+          <span class="hljs-attr">downloadUrl</span>: result.secret_download_url,
         });
         <span class="hljs-keyword">delete</span> result.secret_download_url;
         <span class="hljs-keyword">return</span> result;
@@ -3759,7 +3768,7 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
   <span class="hljs-attr">platformVersion</span>: <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;zapier-platform-core&apos;</span>).version,
 
   <span class="hljs-attr">hydrators</span>: {
-    <span class="hljs-attr">stashPDF</span>: stashPDFfunction
+    <span class="hljs-attr">stashPDF</span>: stashPDFfunction,
   },
 
   <span class="hljs-attr">triggers</span>: {
@@ -3767,13 +3776,13 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
       <span class="hljs-attr">noun</span>: <span class="hljs-string">&apos;PDF&apos;</span>,
       <span class="hljs-attr">display</span>: {
         <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;New PDF&apos;</span>,
-        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new PDF is added.&apos;</span>
+        <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers when a new PDF is added.&apos;</span>,
       },
       <span class="hljs-attr">operation</span>: {
-        <span class="hljs-attr">perform</span>: pdfList
-      }
-    }
-  }
+        <span class="hljs-attr">perform</span>: pdfList,
+      },
+    },
+  },
 };
 
 <span class="hljs-built_in">module</span>.exports = App;
@@ -4647,7 +4656,7 @@ npm run zapier-push
 <li><a href="https://github.com/jhuckaby/pixl-xml">pixl-xml</a></li>
 <li><a href="https://github.com/Leonidas-from-XIV/node-xml2js">xml2js</a></li>
 <li><a href="https://github.com/NaturalIntelligence/fast-xml-parser">fast-xml-parser</a></li>
-</ul>
+</ul><p>For <a href="shorthand-http-requests">shorthand requests</a>, use an <code>afterResponse</code> <a href="using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed XML:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> xml = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;pixl-xml&apos;</span>);
@@ -4656,10 +4665,10 @@ npm run zapier-push
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">afterResponse</span>: [
     <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
-      response.xml = xml.parse(response.content);
+      response.data = xml.parse(response.content);
       <span class="hljs-keyword">return</span> response;
-    }
-  ]
+    },
+  ],
   <span class="hljs-comment">// ...</span>
 };
 
@@ -4687,8 +4696,8 @@ npm run zapier-push
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://jsonplaceholder.typicode.com/posts&apos;</span>,
     <span class="hljs-attr">params</span>: {
       <span class="hljs-attr">_start</span>: start,
-      <span class="hljs-attr">_limit</span>: limit
-    }
+      <span class="hljs-attr">_limit</span>: limit,
+    },
   });
 };
 
@@ -4707,9 +4716,9 @@ npm run zapier-push
     i += <span class="hljs-number">1</span>;
   }
 
-  <span class="hljs-keyword">return</span> <span class="hljs-built_in">Promise</span>.all(promises).then(<span class="hljs-function"><span class="hljs-params">res</span> =&gt;</span> {
+  <span class="hljs-keyword">return</span> <span class="hljs-built_in">Promise</span>.all(promises).then(<span class="hljs-function">(<span class="hljs-params">res</span>) =&gt;</span> {
     <span class="hljs-comment">// res is an array of responses</span>
-    <span class="hljs-keyword">const</span> results = res.map(<span class="hljs-function"><span class="hljs-params">r</span> =&gt;</span> r.json); <span class="hljs-comment">// array of arrays of js objects</span>
+    <span class="hljs-keyword">const</span> results = res.map(<span class="hljs-function">(<span class="hljs-params">r</span>) =&gt;</span> r.data); <span class="hljs-comment">// array of arrays of js objects</span>
     <span class="hljs-keyword">return</span> <span class="hljs-built_in">Array</span>.prototype.concat.apply([], results); <span class="hljs-comment">// flatten array</span>
   });
 };
@@ -4720,13 +4729,13 @@ npm run zapier-push
 
   <span class="hljs-attr">display</span>: {
     <span class="hljs-attr">label</span>: <span class="hljs-string">&apos;Get Paging&apos;</span>,
-    <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers on a new paging.&apos;</span>
+    <span class="hljs-attr">description</span>: <span class="hljs-string">&apos;Triggers on a new paging.&apos;</span>,
   },
 
   <span class="hljs-attr">operation</span>: {
     <span class="hljs-attr">inputFields</span>: [],
-    <span class="hljs-attr">perform</span>: performPaging
-  }
+    <span class="hljs-attr">perform</span>: performPaging,
+  },
 };
 
 </code></pre>
@@ -4751,11 +4760,11 @@ npm run zapier-push
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://jsonplaceholder.typicode.com/posts&apos;</span>,
     <span class="hljs-attr">params</span>: {
       <span class="hljs-attr">_start</span>: start,
-      <span class="hljs-attr">_limit</span>: limit
-    }
+      <span class="hljs-attr">_limit</span>: limit,
+    },
   });
 
-  <span class="hljs-keyword">let</span> results = response.json;
+  <span class="hljs-keyword">let</span> results = response.data;
 
   <span class="hljs-comment">// keep paging until the last item was created over two hours ago</span>
   <span class="hljs-comment">// then we know we almost certainly haven&apos;t missed anything and can let</span>
@@ -4768,11 +4777,11 @@ npm run zapier-push
       <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://jsonplaceholder.typicode.com/posts&apos;</span>,
       <span class="hljs-attr">params</span>: {
         <span class="hljs-attr">_start</span>: start,
-        <span class="hljs-attr">_limit</span>: limit
-      }
+        <span class="hljs-attr">_limit</span>: limit,
+      },
     });
 
-    results = results.concat(response.json);
+    results = results.concat(response.data);
   }
 
   <span class="hljs-keyword">return</span> results;
@@ -4827,7 +4836,7 @@ npm run zapier-push
       <span class="hljs-attr">offset</span>: <span class="hljs-number">100</span> * bundle.meta.page
     }
   });
-  <span class="hljs-keyword">return</span> promise.then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.json);
+  <span class="hljs-keyword">return</span> promise.then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
 };
 </code></pre>
     </div>
@@ -4937,7 +4946,7 @@ npm run zapier-push
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
-<span class="hljs-keyword">let</span> items = response.json.items;
+<span class="hljs-keyword">let</span> items = response.data.items;
 items.forEach(<span class="hljs-function"><span class="hljs-params">item</span> =&gt;</span> {
   item.id = item.contactId;
 })

--- a/packages/cli/scaffold/create.template.js
+++ b/packages/cli/scaffold/create.template.js
@@ -10,7 +10,7 @@ const perform = async (z, bundle) => {
     }
   });
   // this should return a single object
-  return response.json;
+  return response.data;
 };
 
 module.exports = {

--- a/packages/cli/scaffold/resource.template.js
+++ b/packages/cli/scaffold/resource.template.js
@@ -6,7 +6,7 @@ const performList = async (z, bundle) => {
       order_by: 'id desc'
     }
   });
-  return response.json
+  return response.data
 };
 
 // find a particular <%= LOWER_NOUN %> by name (or other search criteria)
@@ -17,7 +17,7 @@ const performSearch = async (z, bundle) => {
       name: bundle.inputData.name
     }
   });
-  return response.json
+  return response.data
 };
 
 // creates a new <%= LOWER_NOUN %>
@@ -29,7 +29,7 @@ const performCreate = async (z, bundle) => {
       name: bundle.inputData.name // json by default
     }
   });
-  return response.json
+  return response.data
 };
 
 module.exports = {

--- a/packages/cli/scaffold/search.template.js
+++ b/packages/cli/scaffold/search.template.js
@@ -7,7 +7,7 @@ const perform = async (z, bundle) => {
     }
   });
   // this should return an array of objects (but only the first will be used)
-  return response.json
+  return response.data
 };
 
 module.exports = {

--- a/packages/cli/scaffold/trigger.template.js
+++ b/packages/cli/scaffold/trigger.template.js
@@ -7,7 +7,7 @@ const perform = async (z, bundle) => {
     }
   });
   // this should return an array of objects
-  return response.json;
+  return response.data;
 };
 
 module.exports = {

--- a/packages/cli/snippets/async-polling.js
+++ b/packages/cli/snippets/async-polling.js
@@ -11,11 +11,11 @@ const asyncExample = async (z, bundle) => {
     url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
       _start: start,
-      _limit: limit
-    }
+      _limit: limit,
+    },
   });
 
-  let results = response.json;
+  let results = response.data;
 
   // keep paging until the last item was created over two hours ago
   // then we know we almost certainly haven't missed anything and can let
@@ -28,11 +28,11 @@ const asyncExample = async (z, bundle) => {
       url: 'https://jsonplaceholder.typicode.com/posts',
       params: {
         _start: start,
-        _limit: limit
-      }
+        _limit: limit,
+      },
     });
 
-    results = results.concat(response.json);
+    results = results.concat(response.data);
   }
 
   return results;

--- a/packages/cli/snippets/custom-fields.js
+++ b/packages/cli/snippets/custom-fields.js
@@ -1,7 +1,7 @@
 const recipeFields = (z, bundle) => {
   const response = z.request('https://example.com/api/v2/fields.json');
   // json is is [{"key":"field_1"},{"key":"field_2"}]
-  return response.then(res => res.json);
+  return response.then((res) => res.data);
 };
 
 const App = {
@@ -16,17 +16,17 @@ const App = {
             key: 'title',
             required: true,
             label: 'Title of Recipe',
-            helpText: 'Name your recipe!'
+            helpText: 'Name your recipe!',
           },
           {
             key: 'style',
             required: true,
-            choices: { mexican: 'Mexican', italian: 'Italian' }
+            choices: { mexican: 'Mexican', italian: 'Italian' },
           },
-          recipeFields // provide a function inline - we'll merge the results!
+          recipeFields, // provide a function inline - we'll merge the results!
         ],
-        perform: () => {}
-      }
-    }
-  }
+        perform: () => {},
+      },
+    },
+  },
 };

--- a/packages/cli/snippets/dehydration.js
+++ b/packages/cli/snippets/dehydration.js
@@ -1,18 +1,18 @@
 const getExtraDataFunction = (z, bundle) => {
   const url = `https://example.com/movies/${bundle.inputData.id}.json`;
-  return z.request(url).then(res => res.json);
+  return z.request(url).then((res) => res.data);
 };
 
 const movieList = (z, bundle) => {
   return z
     .request('https://example.com/movies.json')
-    .then(res => res.json)
-    .then(results => {
-      return results.map(result => {
+    .then((res) => res.data)
+    .then((results) => {
+      return results.map((result) => {
         // so maybe /movies.json is thin content but
         // /movies/:id.json has more details we want...
         result.moreData = z.dehydrate(getExtraDataFunction, {
-          id: result.id
+          id: result.id,
         });
         return result;
       });
@@ -26,7 +26,7 @@ const App = {
   // don't forget to register hydrators here!
   // it can be imported from any module
   hydrators: {
-    getExtraData: getExtraDataFunction
+    getExtraData: getExtraDataFunction,
   },
 
   triggers: {
@@ -34,13 +34,13 @@ const App = {
       noun: 'Movie',
       display: {
         label: 'New Movie',
-        description: 'Triggers when a new Movie is added.'
+        description: 'Triggers when a new Movie is added.',
       },
       operation: {
-        perform: movieList
-      }
-    }
-  }
+        perform: movieList,
+      },
+    },
+  },
 };
 
 module.exports = App;

--- a/packages/cli/snippets/dynamic-dropdowns-five.js
+++ b/packages/cli/snippets/dynamic-dropdowns-five.js
@@ -2,8 +2,8 @@ perform: () => {
   return z
     .request('https://example.com/api/v2/projects.json', {
       params: {
-        spreadsheet_id: bundle.inputData.spreadsheet_id
-      }
+        spreadsheet_id: bundle.inputData.spreadsheet_id,
+      },
     })
-    .then(response => response.json);
+    .then((response) => response.data);
 };

--- a/packages/cli/snippets/manual-request.js
+++ b/packages/cli/snippets/manual-request.js
@@ -8,7 +8,7 @@ const listExample = (z, bundle) => {
   return z
     .request('https://example.com/api/v2/recipes.json', customHttpOptions)
     .then((response) => {
-      const recipes = response.json;
+      const recipes = response.data;
       // do any custom processing of recipes here...
 
       return recipes;

--- a/packages/cli/snippets/middleware.js
+++ b/packages/cli/snippets/middleware.js
@@ -10,16 +10,21 @@ const handleErrors = (response, z) => {
   }
 
   // Throw an error that `throwForStatus` wouldn't throw (correctly) for.
-  else if (response.status === 200 && response.json.success === false) {
-    throw new z.errors.Error(response.json.message, response.json.code);
+  else if (response.status === 200 && response.data.success === false) {
+    throw new z.errors.Error(response.data.message, response.data.code);
   }
+};
 
+const parseXML = (response, z, bundle) => {
+  // Parse content that is not JSON
+  // eslint-disable-next-line no-undef
+  response.data = xml.parse(response.content);
   return response;
 };
 
 const App = {
   // ...
   beforeRequest: [addHeader],
-  afterResponse: [handleErrors],
+  afterResponse: [parseXML, handleErrors],
   // ...
 };

--- a/packages/cli/snippets/output-fields.js
+++ b/packages/cli/snippets/output-fields.js
@@ -1,7 +1,7 @@
 const recipeOutputFields = (z, bundle) => {
   const response = z.request('https://example.com/api/v2/fields.json');
   // json is like [{"key":"field_1","label":"Label for Custom Field"}]
-  return response.then(res => res.json);
+  return response.then((res) => res.data);
 };
 
 const App = {
@@ -16,65 +16,65 @@ const App = {
           title: 'Pancake',
           author: {
             id: 1,
-            name: 'Amy'
+            name: 'Amy',
           },
           ingredients: [
             {
               name: 'Egg',
-              amount: 1
+              amount: 1,
             },
             {
               name: 'Milk',
               amount: 60,
-              unit: 'g'
+              unit: 'g',
             },
             {
               name: 'Flour',
               amount: 30,
-              unit: 'g'
-            }
-          ]
+              unit: 'g',
+            },
+          ],
         },
         // an array of objects is the simplest way
         outputFields: [
           {
             key: 'id',
             label: 'Recipe ID',
-            type: 'integer'
+            type: 'integer',
           },
           {
             key: 'title',
             label: 'Recipe Title',
-            type: 'string'
+            type: 'string',
           },
           {
             key: 'author__id',
             label: 'Author User ID',
-            type: 'integer'
+            type: 'integer',
           },
           {
             key: 'author__name',
             label: 'Author Name',
-            type: 'string'
+            type: 'string',
           },
           {
             key: 'ingredients[]name',
             label: 'Ingredient Name',
-            type: 'string'
+            type: 'string',
           },
           {
             key: 'ingredients[]amount',
             label: 'Ingredient Amount',
-            type: 'number'
+            type: 'number',
           },
           {
             key: 'ingredients[]unit',
             label: 'Ingredient Unit',
-            type: 'string'
+            type: 'string',
           },
-          recipeOutputFields // provide a function inline - we'll merge the results!
-        ]
-      }
-    }
-  }
+          recipeOutputFields, // provide a function inline - we'll merge the results!
+        ],
+      },
+    },
+  },
 };

--- a/packages/cli/snippets/paging-poll.js
+++ b/packages/cli/snippets/paging-poll.js
@@ -4,8 +4,8 @@ const makeCall = (z, start, limit) => {
     url: 'https://jsonplaceholder.typicode.com/posts',
     params: {
       _start: start,
-      _limit: limit
-    }
+      _limit: limit,
+    },
   });
 };
 
@@ -24,9 +24,9 @@ const performPaging = (z, bundle) => {
     i += 1;
   }
 
-  return Promise.all(promises).then(res => {
+  return Promise.all(promises).then((res) => {
     // res is an array of responses
-    const results = res.map(r => r.json); // array of arrays of js objects
+    const results = res.map((r) => r.data); // array of arrays of js objects
     return Array.prototype.concat.apply([], results); // flatten array
   });
 };
@@ -37,11 +37,11 @@ module.exports = {
 
   display: {
     label: 'Get Paging',
-    description: 'Triggers on a new paging.'
+    description: 'Triggers on a new paging.',
   },
 
   operation: {
     inputFields: [],
-    perform: performPaging
-  }
+    perform: performPaging,
+  },
 };

--- a/packages/cli/snippets/process-env.js
+++ b/packages/cli/snippets/process-env.js
@@ -1,14 +1,14 @@
 const listExample = (z, bundle) => {
   const httpOptions = {
     headers: {
-      'my-header': process.env.MY_SECRET_VALUE
-    }
+      'my-header': process.env.MY_SECRET_VALUE,
+    },
   };
   const response = z.request(
     'https://example.com/api/v2/recipes.json',
     httpOptions
   );
-  return response.then(res => res.json);
+  return response.then((res) => res.data);
 };
 
 const App = {
@@ -18,8 +18,8 @@ const App = {
       noun: '{{process.env.MY_NOUN}}',
       operation: {
         // ...
-        perform: listExample
-      }
-    }
-  }
+        perform: listExample,
+      },
+    },
+  },
 };

--- a/packages/cli/snippets/session-auth.js
+++ b/packages/cli/snippets/session-auth.js
@@ -13,7 +13,7 @@ const getSessionKey = (z, bundle) => {
       throw new Error('The username/password you supplied is invalid');
     }
     return {
-      sessionKey: response.json.sessionKey,
+      sessionKey: response.data.sessionKey,
     };
   });
 };

--- a/packages/cli/snippets/stash-file.js
+++ b/packages/cli/snippets/stash-file.js
@@ -2,7 +2,7 @@ const stashPDFfunction = (z, bundle) => {
   // use standard auth to request the file
   const filePromise = z.request({
     url: bundle.inputData.downloadUrl,
-    raw: true
+    raw: true,
   });
   // and swap it for a stashed URL
   return z.stashFile(filePromise);
@@ -11,13 +11,13 @@ const stashPDFfunction = (z, bundle) => {
 const pdfList = (z, bundle) => {
   return z
     .request('https://example.com/pdfs.json')
-    .then(res => res.json)
-    .then(results => {
-      return results.map(result => {
+    .then((res) => res.data)
+    .then((results) => {
+      return results.map((result) => {
         // lazily convert a secret_download_url to a stashed url
         // zapier won't do this until we need it
         result.file = z.dehydrateFile(stashPDFfunction, {
-          downloadUrl: result.secret_download_url
+          downloadUrl: result.secret_download_url,
         });
         delete result.secret_download_url;
         return result;
@@ -30,7 +30,7 @@ const App = {
   platformVersion: require('zapier-platform-core').version,
 
   hydrators: {
-    stashPDF: stashPDFfunction
+    stashPDF: stashPDFfunction,
   },
 
   triggers: {
@@ -38,13 +38,13 @@ const App = {
       noun: 'PDF',
       display: {
         label: 'New PDF',
-        description: 'Triggers when a new PDF is added.'
+        description: 'Triggers when a new PDF is added.',
       },
       operation: {
-        perform: pdfList
-      }
-    }
-  }
+        perform: pdfList,
+      },
+    },
+  },
 };
 
 module.exports = App;

--- a/packages/cli/snippets/xml.js
+++ b/packages/cli/snippets/xml.js
@@ -4,9 +4,9 @@ const App = {
   // ...
   afterResponse: [
     (response, z, bundle) => {
-      response.xml = xml.parse(response.content);
+      response.data = xml.parse(response.content);
       return response;
-    }
-  ]
+    },
+  ],
   // ...
 };

--- a/packages/cli/src/generators/templates/authTests/custom.test.js
+++ b/packages/cli/src/generators/templates/authTests/custom.test.js
@@ -14,7 +14,7 @@ describe('custom auth', () => {
     };
 
     const response = await appTester(App.authentication.test, bundle);
-    expect(response.json).toHaveProperty('username');
+    expect(response.data).toHaveProperty('username');
   });
 
   it('fails on bad auth', async () => {

--- a/packages/cli/src/generators/templates/authTests/digest.test.js
+++ b/packages/cli/src/generators/templates/authTests/digest.test.js
@@ -18,8 +18,8 @@ describe('digest auth', () => {
     const response = await appTester(App.authentication.test, bundle);
 
     expect(response.status).toBe(200);
-    expect(response.json.authenticated).toBe(true);
-    expect(response.json.user).toBe('myuser');
+    expect(response.data.authenticated).toBe(true);
+    expect(response.data.user).toBe('myuser');
   });
 
   it('fails on bad auth', async () => {

--- a/packages/cli/src/generators/templates/authTests/oauth2.test.js
+++ b/packages/cli/src/generators/templates/authTests/oauth2.test.js
@@ -112,7 +112,7 @@ describe('oauth2 app', () => {
     };
 
     const response = await appTester(App.authentication.test, bundle);
-    expect(response.json).toHaveProperty('username');
-    expect(response.json.username).toBe('Bret');
+    expect(response.data).toHaveProperty('username');
+    expect(response.data.username).toBe('Bret');
   });
 });

--- a/packages/cli/src/generators/templates/dynamic-dropdown/triggers/people.js
+++ b/packages/cli/src/generators/templates/dynamic-dropdown/triggers/people.js
@@ -6,7 +6,7 @@ const perform = async (z, bundle) => {
   // example we're going to omit that part. Thus, this trigger only "see" the
   // people in their first page of results.
   const response = await z.request({ url: 'https://swapi.dev/api/people/' });
-  let peopleArray = response.json.results;
+  let peopleArray = response.data.results;
 
   if (bundle.inputData.species_id) {
     // The Zap's setup has requested a specific species of person. Since the

--- a/packages/cli/src/generators/templates/dynamic-dropdown/triggers/species.js
+++ b/packages/cli/src/generators/templates/dynamic-dropdown/triggers/species.js
@@ -13,7 +13,7 @@ const perform = async (z, bundle) => {
   }
 
   const response = await z.request(request);
-  const speciesArray = response.json.results;
+  const speciesArray = response.data.results;
   return speciesArray.map((species) => {
     species.id = extractID(species.url);
     return species;

--- a/packages/cli/src/generators/templates/files/creates/uploadFile_v10.js
+++ b/packages/cli/src/generators/templates/files/creates/uploadFile_v10.js
@@ -30,7 +30,7 @@ const perform = async (z, bundle) => {
     },
   });
 
-  return response.json;
+  return response.data;
 };
 
 module.exports = {

--- a/packages/cli/src/generators/templates/search-or-create/creates/recipe.js
+++ b/packages/cli/src/generators/templates/search-or-create/creates/recipe.js
@@ -6,7 +6,7 @@ const perform = async (z, bundle) => {
       name: bundle.inputData.name,
     },
   });
-  return response.json;
+  return response.data;
 };
 
 module.exports = {

--- a/packages/cli/src/generators/templates/search-or-create/searches/recipe.js
+++ b/packages/cli/src/generators/templates/search-or-create/searches/recipe.js
@@ -5,7 +5,7 @@ const perform = async (z, bundle) => {
       name: bundle.inputData.name,
     },
   });
-  return response.json;
+  return response.data;
 };
 
 module.exports = {

--- a/packages/cli/src/generators/templates/typescript/src/creates/movie.ts
+++ b/packages/cli/src/generators/templates/typescript/src/creates/movie.ts
@@ -14,7 +14,7 @@ const perform = async (
       year: bundle.inputData.year,
     },
   });
-  return response.json;
+  return response.data;
 };
 
 export default {

--- a/packages/cli/src/generators/templates/typescript/src/triggers/movie.ts
+++ b/packages/cli/src/generators/templates/typescript/src/triggers/movie.ts
@@ -4,7 +4,7 @@ const perform = async (z: ZObject, bundle: Bundle) => {
   const response = await z.request(
     'https://auth-json-server.zapier-staging.com/movies'
   );
-  return response.json;
+  return response.data;
 };
 
 export default {

--- a/packages/cli/src/tests/utils/convert.js
+++ b/packages/cli/src/tests/utils/convert.js
@@ -81,11 +81,11 @@ const visualAppDefinition = {
           },
           {
             source:
-              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.json;\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n",
+              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.data;\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n",
           },
           {
             source:
-              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.json;\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n",
+              "// Configure a request to an endpoint of your api that\n// returns custom field meta data for the authenticated\n// user.  Don't forget to congigure authentication!\n\nconst options = {\n  url: 'https://api.example.com/custom_field_meta_data',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.data;\n\n    // modify your api response to return an array of Field objects\n    // see https://zapier.github.io/zapier-platform-schema/build/schema.html#fieldschema\n    // for schema definition.\n\n    return results;\n  });\n",
           },
           {
             required: false,
@@ -208,7 +208,7 @@ const visualAppDefinition = {
       operation: {
         perform: {
           source:
-            "const options = {\n  url: 'https://jsonplaceholder.typicode.com/posts',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n    '_limit': '3'\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.json;\n\n    // You can do any parsing you need for results here before returning them\n\n    return results;\n  });",
+            "const options = {\n  url: 'https://jsonplaceholder.typicode.com/posts',\n  method: 'GET',\n  headers: {\n    'Accept': 'application/json'\n  },\n  params: {\n    '_limit': '3'\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.data;\n\n    // You can do any parsing you need for results here before returning them\n\n    return results;\n  });",
         },
       },
       noun: 'Code',

--- a/packages/cli/src/utils/auth-files-codegen.js
+++ b/packages/cli/src/utils/auth-files-codegen.js
@@ -20,7 +20,7 @@ const {
   throwSessionRefresh,
   variableAssignmentDeclaration,
   zRequest,
-  zResponseErr
+  zResponseErr,
 } = require('./codegen');
 
 const standardArgs = ['z', 'bundle'];
@@ -31,7 +31,7 @@ const afterMiddlewareArgs = [RESPONSE_VAR, ...standardArgs];
 const getOauthAccessTokenFuncName = 'getAccessToken';
 const refreshOath2AccessTokenFuncName = 'refreshAccessToken';
 
-const authJsonUrl = path =>
+const authJsonUrl = (path) =>
   `https://auth-json-server.zapier-staging.com/${path}`;
 
 const authFileExport = (
@@ -43,7 +43,7 @@ const authFileExport = (
     extraConfigProps = [],
     connectionLabel = strLiteral('{{json.username}}'),
     test = objProperty('test'),
-    authFields = []
+    authFields = [],
   } = {}
 ) => {
   return exportStatement(
@@ -63,7 +63,7 @@ const authFileExport = (
           ),
           test,
           comment(
-            `This template string can access all the data returned from the auth test. If you return the test object, you'll access the returned data with a label like \`{{json.X}}\`. If you return \`response.json\` from your test, then your label can be \`{{X}}\`. This can also be a function that returns a label. That function has the standard args \`(${standardArgs.join(
+            `This template string can access all the data returned from the auth test. If you return the test object, you'll access the returned data with a label like \`{{json.X}}\`. If you return \`response.data\` from your test, then your label can be \`{{X}}\`. This can also be a function that returns a label. That function has the standard args \`(${standardArgs.join(
               ', '
             )})\` and data returned from the test can be accessed in \`bundle.inputData.X\`.`
           ),
@@ -140,7 +140,7 @@ const afterMiddlewareFunc = (funcName, ...statements) =>
     functionDeclaration(funcName, { args: afterMiddlewareArgs }, ...statements)
   );
 
-const includeBearerFunc = funcName =>
+const includeBearerFunc = (funcName) =>
   beforeMiddlewareFunc(
     funcName,
     ifStatement(
@@ -194,17 +194,17 @@ const oauth2TokenExchangeFunc = (
       objProperty('client_id', 'process.env.CLIENT_ID'),
       objProperty('client_secret', 'process.env.CLIENT_SECRET'),
       objProperty('grant_type', strLiteral(grantType)),
-      ...bodyProps
+      ...bodyProps,
     ],
     "'Unable to fetch access token: ' + response.content",
     [
-      objProperty('access_token', 'response.json.access_token'),
-      objProperty('refresh_token', 'response.json.refresh_token')
+      objProperty('access_token', 'response.data.access_token'),
+      objProperty('refresh_token', 'response.data.refresh_token'),
     ],
     {
       returnComments: [
         comment('This function should return `access_token`.'),
-        ...returnComments
+        ...returnComments,
       ],
       requestProps: [
         objProperty(
@@ -215,8 +215,8 @@ const oauth2TokenExchangeFunc = (
               strLiteral('application/x-www-form-urlencoded')
             )
           )
-        )
-      ]
+        ),
+      ],
     }
   );
 };
@@ -231,14 +231,14 @@ const getAccessTokenFunc = () => {
           'accountDomain',
           'bundle.cleanedRequest.querystring.accountDomain'
         )}`
-      )
+      ),
     ],
     grantType: 'authorization_code',
     returnComments: [
       comment(
         'If your app does an app refresh, then `refresh_token` should be returned here as well'
-      )
-    ]
+      ),
+    ],
   });
 };
 
@@ -251,8 +251,8 @@ const refreshTokenFunc = () => {
       comment('If the refresh token stays constant, no need to return it.'),
       comment(
         'If the refresh token does change, return it here to update the stored value in Zapier'
-      )
-    ]
+      ),
+    ],
   });
 };
 
@@ -307,8 +307,8 @@ const oauth2AuthFile = () => {
               objProperty(refreshOath2AccessTokenFuncName),
               objProperty('autoRefresh', 'true')
             )
-          )
-        ]
+          ),
+        ],
       }
     )
   );
@@ -344,8 +344,8 @@ const customAuthFile = () => {
             objProperty('key', strLiteral('apiKey')),
             objProperty('label', strLiteral('API Key')),
             objProperty('required', 'true')
-          )
-        ]
+          ),
+        ],
       }
     )
   );
@@ -380,14 +380,14 @@ const sessionAuthFile = () => {
       'https://httpbin.zapier-tooling.com/post',
       [
         objProperty('username', 'bundle.authData.username'),
-        objProperty('password', 'bundle.authData.password')
+        objProperty('password', 'bundle.authData.password'),
       ],
       'The username/password you supplied is invalid',
       [
         comment(
           'FIXME: The `|| "secret"` below is just for demo purposes, you should remove it.'
         ),
-        objProperty('sessionKey', 'response.json.sessionKey || "secret"')
+        objProperty('sessionKey', 'response.data.sessionKey || "secret"'),
       ]
     ),
     beforeMiddlewareFunc(
@@ -427,14 +427,14 @@ const sessionAuthFile = () => {
             objProperty('required', 'true'),
             comment('this lets the user enter maksed data'),
             objProperty('type', strLiteral('password'))
-          )
+          ),
         ],
         extraConfigProps: [
           objProperty(
             'sessionConfig',
             obj(objProperty('perform', getSessionKeyName))
-          )
-        ]
+          ),
+        ],
       }
     )
   );
@@ -560,9 +560,9 @@ const oauth1AuthFile = () => {
               strLiteral('https://api.trello.com/1/members/me/')
             )
           )
-        )
+        ),
       ],
-      connectionLabel: strLiteral('{{username}}')
+      connectionLabel: strLiteral('{{username}}'),
     })
   );
 };
@@ -573,5 +573,5 @@ module.exports = {
   digest: digestAuthFile,
   oauth1: oauth1AuthFile,
   oauth2: oauth2AuthFile,
-  session: sessionAuthFile
+  session: sessionAuthFile,
 };

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -104,6 +104,7 @@ interface BaseHttpResponse {
 
 export interface HttpResponse extends BaseHttpResponse {
   content: string;
+  data?: object;
   json?: object;
 }
 

--- a/packages/core/src/execute.js
+++ b/packages/core/src/execute.js
@@ -1,26 +1,24 @@
 'use strict';
 
-const querystring = require('querystring');
-
 const _ = require('lodash');
 
 const addQueryParams = require('./http-middlewares/before/add-query-params');
-const createJSONtool = require('./tools/create-json-tool');
 const ensureArray = require('./tools/ensure-array');
 const injectInput = require('./http-middlewares/before/inject-input');
 const prepareRequest = require('./http-middlewares/before/prepare-request');
 const ZapierPromise = require('./tools/promise');
-const { FORM_TYPE } = require('./tools/http');
 
 const constants = require('./constants');
 
 const executeHttpRequest = (input, options) => {
   options = _.extend({}, options, constants.REQUEST_OBJECT_SHORTHAND_OPTIONS);
-  return input.z.request(options).then((resp) => {
-    if (resp.headers.get('content-type') === FORM_TYPE) {
-      return querystring.parse(resp.content);
+  return input.z.request(options).then((response) => {
+    if (response.data === undefined) {
+      throw new Error(
+        'Response needs to be JSON, form-urlencoded or parsed in middleware.'
+      );
     }
-    return createJSONtool().parse(resp.content);
+    return response.data;
   });
 };
 

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const nock = require('nock');
 const should = require('should');
 const createApp = require('../src/create-app');
 const createInput = require('../src/tools/create-input');
@@ -15,98 +16,98 @@ describe('create-app', () => {
 
   const app = createApp(appDefinition);
 
-  const createTestInput = method => {
+  const createTestInput = (method) => {
     const event = {
       bundle: {},
       method,
-      callback_url: 'calback_url'
+      callback_url: 'calback_url',
     };
 
     return createInput(appDefinition, event, testLogger);
   };
 
-  const createRawTestInput = event =>
+  const createRawTestInput = (event) =>
     createInput(appDefinition, event, testLogger);
 
-  it('should return data from promise', done => {
+  it('should return data from promise', (done) => {
     const input = createTestInput(
       'resources.workingfuncpromise.list.operation.perform'
     );
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql([{ id: 3456 }]);
         done();
       })
       .catch(done);
   });
 
-  it('should return data from promise (direct)', done => {
+  it('should return data from promise (direct)', (done) => {
     const input = createTestInput(
       'triggers.workingfuncpromiseList.operation.perform'
     );
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql([{ id: 3456 }]);
         done();
       })
       .catch(done);
   });
 
-  it('should return data from a sync function call', done => {
+  it('should return data from a sync function call', (done) => {
     const input = createTestInput('resources.list.list.operation.perform');
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql([{ id: 1234 }, { id: 5678 }]);
         done();
       })
       .catch(done);
   });
 
-  it('should return data from a sync function call (direct)', done => {
+  it('should return data from a sync function call (direct)', (done) => {
     const input = createTestInput('triggers.listList.operation.perform');
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql([{ id: 1234 }, { id: 5678 }]);
         done();
       })
       .catch(done);
   });
 
-  it('should return data from an async function call with callback', done => {
+  it('should return data from an async function call with callback', (done) => {
     const input = createTestInput(
       'resources.workingfuncasync.list.operation.perform'
     );
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql([{ id: 2345 }]);
         done();
       })
       .catch(done);
   });
 
-  it('should return data from an async function call with callback (direct)', done => {
+  it('should return data from an async function call with callback (direct)', (done) => {
     const input = createTestInput(
       'triggers.workingfuncasyncList.operation.perform'
     );
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql([{ id: 2345 }]);
         done();
       })
       .catch(done);
   });
 
-  it('should return data from live request call, applying HTTP before middleware', done => {
+  it('should return data from live request call, applying HTTP before middleware', (done) => {
     const input = createTestInput('resources.contact.list.operation.perform');
 
     app(input)
-      .then(output => {
+      .then((output) => {
         // httpbin.org/get puts request headers in the response body (good for testing):
         should.exist(output.results.headers);
 
@@ -121,7 +122,7 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should fail on a live request call', done => {
+  it('should fail on a live request call', (done) => {
     const input = createTestInput(
       'resources.failerhttp.list.operation.perform'
     );
@@ -130,7 +131,7 @@ describe('create-app', () => {
       .then(() => {
         done('expected an error');
       })
-      .catch(err => {
+      .catch((err) => {
         should(err).instanceOf(errors.ResponseError);
         err.name.should.eql('ResponseError');
         const response = JSON.parse(err.message);
@@ -145,14 +146,14 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should fail on a live request call (direct)', done => {
+  it('should fail on a live request call (direct)', (done) => {
     const input = createTestInput('triggers.failerhttpList.operation.perform');
 
     app(input)
       .then(() => {
         done('expected an error');
       })
-      .catch(err => {
+      .catch((err) => {
         should(err).instanceOf(errors.ResponseError);
         err.name.should.eql('ResponseError');
         const response = JSON.parse(err.message);
@@ -167,11 +168,11 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should make call via z.request', done => {
+  it('should make call via z.request', (done) => {
     const input = createTestInput('triggers.requestfuncList.operation.perform');
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results[0].headers['X-Hashy'].should.eql(
           '1a3ba5251cb33ee7ade01af6a7b960b8'
         );
@@ -181,13 +182,13 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should make call via z.request with sugar url param', done => {
+  it('should make call via z.request with sugar url param', (done) => {
     const input = createTestInput(
       'triggers.requestsugarList.operation.perform'
     );
 
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.headers['X-Hashy'].should.eql(
           '1a3ba5251cb33ee7ade01af6a7b960b8'
         );
@@ -197,7 +198,7 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should fail on a sync function', done => {
+  it('should fail on a sync function', (done) => {
     const input = createTestInput(
       'resources.failerfunc.list.operation.perform'
     );
@@ -206,26 +207,26 @@ describe('create-app', () => {
       .then(() => {
         done('expected an error');
       })
-      .catch(err => {
+      .catch((err) => {
         should(err.message).startWith('Failer on sync function!');
         done();
       });
   });
 
-  it('should fail on a sync function (direct)', done => {
+  it('should fail on a sync function (direct)', (done) => {
     const input = createTestInput('triggers.failerfuncList.operation.perform');
 
     app(input)
       .then(() => {
         done('expected an error');
       })
-      .catch(err => {
+      .catch((err) => {
         should(err.message).startWith('Failer on sync function!');
         done();
       });
   });
 
-  it('should fail on promise function', done => {
+  it('should fail on promise function', (done) => {
     const input = createTestInput(
       'resources.failerfuncpromise.list.operation.perform'
     );
@@ -234,13 +235,13 @@ describe('create-app', () => {
       .then(() => {
         done('expected an error');
       })
-      .catch(err => {
+      .catch((err) => {
         should(err.message).startWith('Failer on promise function!');
         done();
       });
   });
 
-  it('should fail on promise function (direct)', done => {
+  it('should fail on promise function (direct)', (done) => {
     const input = createTestInput(
       'triggers.failerfuncpromiseList.operation.perform'
     );
@@ -249,13 +250,13 @@ describe('create-app', () => {
       .then(() => {
         done('expected an error');
       })
-      .catch(err => {
+      .catch((err) => {
         should(err.message).startWith('Failer on promise function!');
         done();
       });
   });
 
-  it('should apply HTTP after middleware', done => {
+  it('should apply HTTP after middleware', (done) => {
     const input = createTestInput(
       'resources.contacterror.listWithError.operation.perform'
     );
@@ -264,16 +265,16 @@ describe('create-app', () => {
       .then(() => {
         done('expected an error, got success');
       })
-      .catch(error => {
+      .catch((error) => {
         error.name.should.eql('Error');
         done();
       });
   });
 
-  it('should return data from live request call (direct)', done => {
+  it('should return data from live request call (direct)', (done) => {
     const input = createTestInput('triggers.contactList.operation.perform');
     app(input)
-      .then(output => {
+      .then((output) => {
         output.results.url.should.eql('https://httpbin.org/get');
         output.results.headers['X-Hashy'].should.eql(
           '1a3ba5251cb33ee7ade01af6a7b960b8'
@@ -284,28 +285,28 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should return a rendered URL for OAuth2 authorizeURL', done => {
+  it('should return a rendered URL for OAuth2 authorizeURL', (done) => {
     const oauth2AppDefinition = dataTools.jsonCopy(appDefinition);
     oauth2AppDefinition.authentication = {
       type: 'oauth2',
       test: {
         url: 'https://example.com',
-        method: 'GET'
+        method: 'GET',
       },
       oauth2Config: {
         authorizeUrl: {
           url: 'https://{{bundle.authData.domain}}.example.com',
           params: {
-            scope: '{{bundle.inputData.scope}}'
-          }
+            scope: '{{bundle.inputData.scope}}',
+          },
         },
         getAccessToken: {
           url: 'https://example.com/oauth2/token',
           body: {},
-          method: 'POST'
+          method: 'POST',
         },
-        autoRefresh: false
-      }
+        autoRefresh: false,
+      },
     };
     const oauth2App = createApp(oauth2AppDefinition);
     const input = createTestInput('authentication.oauth2Config.authorizeUrl');
@@ -313,7 +314,7 @@ describe('create-app', () => {
     input.bundle.inputData = { scope: 'read,write' };
 
     oauth2App(input)
-      .then(output => {
+      .then((output) => {
         output.results.should.eql(
           'https://my-sub.example.com?scope=read%2Cwrite'
         );
@@ -322,17 +323,17 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should run a raw provided request', done => {
+  it('should run a raw provided request', (done) => {
     const input = createRawTestInput({
       command: 'request',
       bundle: {
         request: {
-          url: 'https://httpbin.org/get'
-        }
-      }
+          url: 'https://httpbin.org/get',
+        },
+      },
     });
     app(input)
-      .then(output => {
+      .then((output) => {
         const response = output.results;
         JSON.parse(response.content).url.should.eql('https://httpbin.org/get');
         done();
@@ -341,7 +342,7 @@ describe('create-app', () => {
   });
 
   describe('HTTP after middleware for auth refresh', () => {
-    it('should be applied to OAuth2 refresh app on shorthand requests', done => {
+    it('should be applied to OAuth2 refresh app on shorthand requests', (done) => {
       const oauth2AppDefinition = dataTools.deepCopy(appDefinition);
       oauth2AppDefinition.authentication = {
         type: 'oauth2',
@@ -349,8 +350,8 @@ describe('create-app', () => {
         oauth2Config: {
           authorizeUrl: {}, // stub, not needed for this test
           getAccessToken: {}, // stub, not needed for this test
-          autoRefresh: true
-        }
+          autoRefresh: true,
+        },
       };
       const oauth2App = createApp(oauth2AppDefinition);
 
@@ -358,16 +359,16 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.org/status/401'
-          }
+            url: 'https://httpbin.org/status/401',
+          },
         },
-        method: 'resources.executeRequestAsShorthand.list.operation.perform'
+        method: 'resources.executeRequestAsShorthand.list.operation.perform',
       };
       oauth2App(createInput(oauth2AppDefinition, event, testLogger))
         .then(() => {
           done('expected an error, got success');
         })
-        .catch(error => {
+        .catch((error) => {
           should(error).instanceOf(errors.ResponseError);
           error.name.should.eql('ResponseError');
           const response = JSON.parse(error.message);
@@ -376,7 +377,7 @@ describe('create-app', () => {
         });
     });
 
-    it('should be applied to OAuth2 refresh app on z.request in functions', done => {
+    it('should be applied to OAuth2 refresh app on z.request in functions', (done) => {
       const oauth2AppDefinition = dataTools.deepCopy(appDefinition);
       oauth2AppDefinition.authentication = {
         type: 'oauth2',
@@ -384,8 +385,8 @@ describe('create-app', () => {
         oauth2Config: {
           authorizeUrl: {}, // stub, not needed for this test
           getAccessToken: {}, // stub, not needed for this test
-          autoRefresh: true
-        }
+          autoRefresh: true,
+        },
       };
       const oauth2App = createApp(oauth2AppDefinition);
 
@@ -394,17 +395,17 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'https://httpbin.org/status/401'
-            }
-          }
+              url: 'https://httpbin.org/status/401',
+            },
+          },
         },
-        method: 'resources.executeRequestAsFunc.list.operation.perform'
+        method: 'resources.executeRequestAsFunc.list.operation.perform',
       };
       oauth2App(createInput(oauth2AppDefinition, event, testLogger))
         .then(() => {
           done('expected an error, got success');
         })
-        .catch(error => {
+        .catch((error) => {
           should(error).instanceOf(errors.ResponseError);
           error.name.should.eql('ResponseError');
           const response = JSON.parse(error.message);
@@ -413,14 +414,14 @@ describe('create-app', () => {
         });
     });
 
-    it('should be applied to session auth app on z.request in functions', done => {
+    it('should be applied to session auth app on z.request in functions', (done) => {
       const sessionAuthAppDefinition = dataTools.deepCopy(appDefinition);
       sessionAuthAppDefinition.authentication = {
         type: 'session',
         test: {},
         sessionConfig: {
-          perform: {} // stub, not needed for this test
-        }
+          perform: {}, // stub, not needed for this test
+        },
       };
       const sessionAuthApp = createApp(sessionAuthAppDefinition);
 
@@ -429,17 +430,17 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'https://httpbin.org/status/401'
-            }
-          }
+              url: 'https://httpbin.org/status/401',
+            },
+          },
         },
-        method: 'resources.executeRequestAsFunc.list.operation.perform'
+        method: 'resources.executeRequestAsFunc.list.operation.perform',
       };
       sessionAuthApp(createInput(sessionAuthAppDefinition, event, testLogger))
         .then(() => {
           done('expected an error, got success');
         })
-        .catch(error => {
+        .catch((error) => {
           should(error).instanceOf(errors.ResponseError);
           error.name.should.eql('ResponseError');
           const response = JSON.parse(error.message);
@@ -451,18 +452,18 @@ describe('create-app', () => {
 
   describe('inputFields', () => {
     const testInputOutputFields = (desc, method) => {
-      it(desc, done => {
+      it(desc, (done) => {
         const input = createTestInput(method);
         input.bundle.key1 = 'key 1';
         input.bundle.key2 = 'key 2';
         input.bundle.key3 = 'key 3';
 
         app(input)
-          .then(output => {
+          .then((output) => {
             output.results.should.eql([
               { key: 'key 1' },
               { key: 'key 2' },
-              { key: 'key 3' }
+              { key: 'key 3' },
             ]);
             done();
           })
@@ -512,17 +513,17 @@ describe('create-app', () => {
   });
 
   describe('hydration', () => {
-    it('should hydrate method', done => {
+    it('should hydrate method', (done) => {
       const input = createTestInput(
         'resources.honkerdonker.list.operation.perform'
       );
 
       app(input)
-        .then(output => {
+        .then((output) => {
           output.results.should.eql([
             'hydrate|||{"type":"method","method":"resources.honkerdonker.get.operation.perform","bundle":{"honkerId":1}}|||hydrate',
             'hydrate|||{"type":"method","method":"resources.honkerdonker.get.operation.perform","bundle":{"honkerId":2}}|||hydrate',
-            'hydrate|||{"type":"method","method":"resources.honkerdonker.get.operation.perform","bundle":{"honkerId":3}}|||hydrate'
+            'hydrate|||{"type":"method","method":"resources.honkerdonker.get.operation.perform","bundle":{"honkerId":3}}|||hydrate',
           ]);
           done();
         })
@@ -536,7 +537,7 @@ describe('create-app', () => {
         createTestInput(
           'resources.executeCallbackRequest.list.operation.perform'
         )
-      ).then(output => {
+      ).then((output) => {
         results = output;
       })
     );
@@ -548,21 +549,21 @@ describe('create-app', () => {
   });
 
   describe('using require', () => {
-    const createDefinition = source => ({
+    const createDefinition = (source) => ({
       triggers: {
         testRequire: {
           display: {
             label: 'Test Require',
-            description: 'Put zRequire through the ringer'
+            description: 'Put zRequire through the ringer',
           },
           key: 'testRequire',
           operation: {
             perform: {
-              source
-            }
-          }
-        }
-      }
+              source,
+            },
+          },
+        },
+      },
     });
 
     it('should throw a require error', async () => {
@@ -583,7 +584,7 @@ describe('create-app', () => {
             'For technical reasons, use z.require() instead of require().',
             'What happened:',
             '  Executing triggers.testRequire.operation.perform with bundle',
-            '  For technical reasons, use z.require() instead of require().'
+            '  For technical reasons, use z.require() instead of require().',
           ].join('\n')
         );
       }
@@ -613,6 +614,68 @@ describe('create-app', () => {
 
       await appFail(input).should.be.rejectedWith(
         /Cannot find module 'non-existing-package'/
+      );
+    });
+  });
+
+  describe('response.content parsing', () => {
+    it('should handle JSON', async () => {
+      const app = createApp(appDefinition);
+
+      const event = {
+        command: 'execute',
+        bundle: {
+          inputData: {
+            url: 'https://httpbin.org/get',
+          },
+        },
+        method: 'resources.executeRequestAsShorthand.create.operation.perform',
+      };
+      const { results } = await app(
+        createInput(appDefinition, event, testLogger)
+      );
+      should(results).be.an.Object().and.not.be.an.Array();
+    });
+    it('should handle form', async () => {
+      const app = createApp(appDefinition);
+
+      // httpbin doesn't actually have a form-urlencoded endpoint
+      nock('https://x-www-form-urlencoded.httpbin.org')
+        .get('/')
+        .reply(200, 'foo=bar', {
+          'content-type': 'application/x-www-form-urlencoded',
+        });
+
+      const event = {
+        command: 'execute',
+        bundle: {
+          inputData: {
+            url: 'https://x-www-form-urlencoded.httpbin.org/',
+          },
+        },
+        method: 'resources.executeRequestAsShorthand.create.operation.perform',
+      };
+      const { results } = await app(
+        createInput(appDefinition, event, testLogger)
+      );
+      should(results).match({ foo: 'bar' });
+    });
+    it('should error on other types like XML', async () => {
+      const app = createApp(appDefinition);
+
+      const event = {
+        command: 'execute',
+        bundle: {
+          inputData: {
+            url: 'https://httpbin.org/xml',
+          },
+        },
+        method: 'resources.executeRequestAsShorthand.create.operation.perform',
+      };
+      await app(
+        createInput(appDefinition, event, testLogger)
+      ).should.be.rejectedWith(
+        /Response needs to be JSON, form-urlencoded or parsed in middleware/
       );
     });
   });

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -390,7 +390,7 @@ describe('request client', () => {
       },
     });
     response.status.should.eql(200);
-    response.json.args.should.deepEqual({});
+    response.data.args.should.deepEqual({});
   });
 
   it('should allow GET with body', async () => {
@@ -405,7 +405,7 @@ describe('request client', () => {
       allowGetBody: true,
     });
     response.status.should.eql(200);
-    response.json.args.should.deepEqual({ name: 'Darth Vader' });
+    response.data.args.should.deepEqual({ name: 'Darth Vader' });
   });
 
   describe('adds query params', () => {
@@ -421,9 +421,9 @@ describe('request client', () => {
       }).then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
-        response.json.args.something.should.eql('');
-        response.json.args.really.should.eql('');
-        response.json.args.cool.should.eql('true');
+        response.data.args.something.should.eql('');
+        response.data.args.really.should.eql('');
+        response.data.args.cool.should.eql('true');
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
@@ -448,9 +448,9 @@ describe('request client', () => {
       }).then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
-        response.json.args.something.should.eql('');
-        response.json.args.really.should.eql('');
-        response.json.args.cool.should.eql('true');
+        response.data.args.something.should.eql('');
+        response.data.args.really.should.eql('');
+        response.data.args.cool.should.eql('true');
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
@@ -491,16 +491,16 @@ describe('request client', () => {
       }).then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
-        should(response.json.args.something).eql(undefined);
-        should(response.json.args.foo).eql(undefined);
-        should(response.json.args.bar).eql(undefined);
-        should(response.json.args.empty).eql(undefined);
-        should(response.json.args.really).eql(undefined);
-        response.json.args.cool.should.eql('false');
-        response.json.args.zzz.should.eql('[]');
-        response.json.args.yyy.should.eql('{}');
-        response.json.args.qqq.should.eql(' ');
-        response.json.args.name.should.eql('zapier');
+        should(response.data.args.something).eql(undefined);
+        should(response.data.args.foo).eql(undefined);
+        should(response.data.args.bar).eql(undefined);
+        should(response.data.args.empty).eql(undefined);
+        should(response.data.args.really).eql(undefined);
+        response.data.args.cool.should.eql('false');
+        response.data.args.zzz.should.eql('[]');
+        response.data.args.yyy.should.eql('{}');
+        response.data.args.qqq.should.eql(' ');
+        response.data.args.name.should.eql('zapier');
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
@@ -524,8 +524,8 @@ describe('request client', () => {
       }).then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
-        should(response.json.args.something).eql(undefined);
-        should(response.json.args.cool).eql(undefined);
+        should(response.data.args.something).eql(undefined);
+        should(response.data.args.cool).eql(undefined);
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
@@ -555,7 +555,7 @@ describe('request client', () => {
           zapId: '{{bundle.meta.zap.id}}',
         },
       }).then((response) => {
-        const { hookUrl, zapId } = JSON.parse(response.json.data);
+        const { hookUrl, zapId } = JSON.parse(response.data.data);
 
         hookUrl.should.eql(targetUrl);
         zapId.should.eql(987);
@@ -578,7 +578,7 @@ describe('request client', () => {
       }).then((response) => {
         const { url } = JSON.parse(response.content);
 
-        response.json.args.id.should.eql('123');
+        response.data.args.id.should.eql('123');
         url.should.eql('https://httpbin.org/delete?id=123');
       });
     });
@@ -608,7 +608,7 @@ describe('request client', () => {
           arr: '{{bundle.inputData.arr}}',
         },
       }).then((response) => {
-        const { json } = response.json;
+        const { json } = response.data;
 
         should(json.empty).eql(undefined);
         json.number.should.eql(123);
@@ -645,8 +645,7 @@ describe('request client', () => {
           arr: [1, 2, 3],
         },
       }).then((response) => {
-        const { json } = response.json;
-
+        const { json } = response.data;
         should(json.empty).eql(undefined);
         json.number.should.eql(123);
         json.bool.should.eql(true);
@@ -676,7 +675,7 @@ describe('request client', () => {
           body: true,
         },
       }).then((response) => {
-        const { json } = response.json;
+        const { json } = response.data;
 
         should(json.empty).eql(undefined);
         json.name.should.eql('Burgundy');
@@ -694,7 +693,7 @@ describe('request client', () => {
           value: 'exists',
         },
       }).then((response) => {
-        const { json } = response.json;
+        const { json } = response.data;
 
         should(json.empty).eql('');
         should(json.partial).eql('text ');
@@ -725,7 +724,7 @@ describe('request client', () => {
           Authorization: 'Bearer {{bundle.authData.access_token}}',
         },
       }).then((response) => {
-        const { json, headers } = response.json;
+        const { json, headers } = response.data;
 
         json.message.should.eql('We just got #123');
         headers.Authorization.should.eql('Bearer Let me in');
@@ -775,7 +774,7 @@ describe('request client', () => {
           city: '{{bundle.inputData.address.city}}',
         },
       }).then((response) => {
-        const { json } = response.json;
+        const { json } = response.data;
 
         json.streetAddress.should.eql('123 Zapier Way');
         json.city.should.eql('El Mundo');
@@ -809,7 +808,7 @@ describe('request client', () => {
           Authorization: 'Bearer {{bundle.authData.access_token}}',
         },
       }).then((response) => {
-        const { headers } = response.json;
+        const { headers } = response.data;
         const { url } = JSON.parse(response.content);
         url.should.eql('https://httpbin.org/get?limit=20&id=123');
         headers.Authorization.should.eql('Bearer Let me in');
@@ -851,7 +850,7 @@ describe('request client', () => {
         },
       });
 
-      response.json.json.should.deepEqual({
+      response.data.json.should.deepEqual({
         arr: 'arr: 1,2,3,red,blue',
         obj: 'obj: id=456,name=John',
         str: 'str: hello',

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -539,13 +539,13 @@ describe('http prepareResponse', () => {
           event: {
             bundle: {
               inputData: {
-                foo: 'bar'
-              }
-            }
+                foo: 'bar',
+              },
+            },
           },
-          app: {}
-        }
-      }
+          app: {},
+        },
+      },
     });
 
     const data = { foo: 'bar' };
@@ -555,14 +555,14 @@ describe('http prepareResponse', () => {
       status,
       input: request,
       headers: {
-        get: () => 'application/json'
+        get: () => 'application/json',
       },
-      text: () => Promise.resolve(content)
+      text: () => Promise.resolve(content),
     });
     should(response.status).equal(status);
     should(response.content).equal(content);
     should(response.data).match(data);
-    should(response.data).match(data); // DEPRECATED
+    should(response.json).match(data); // DEPRECATED
     should(response.request).equal(request);
     should(response.skipThrowForStatus).equal(request.skipThrowForStatus);
     should(response.headers).equal(response.headers);
@@ -577,13 +577,13 @@ describe('http prepareResponse', () => {
           event: {
             bundle: {
               inputData: {
-                foo: 'bar'
-              }
-            }
+                foo: 'bar',
+              },
+            },
           },
-          app: {}
-        }
-      }
+          app: {},
+        },
+      },
     });
 
     const content = JSON.stringify({ foo: 'bar' });
@@ -592,9 +592,9 @@ describe('http prepareResponse', () => {
       status,
       input: request,
       headers: {
-        get: () => 'application/json'
+        get: () => 'application/json',
       },
-      text: () => Promise.resolve(content)
+      text: () => Promise.resolve(content),
     });
     should(response.status).equal(status);
     should.throws(
@@ -603,7 +603,7 @@ describe('http prepareResponse', () => {
       /You passed {raw: true} in request()/
     );
     should(response.data).be.Undefined();
-    should(response.data).be.Undefined(); // DEPRECATED
+    should(response.json).be.Undefined(); // DEPRECATED
     should(response.request).equal(request);
     should(response.skipThrowForStatus).equal(request.skipThrowForStatus);
     should(response.headers).equal(response.headers);
@@ -618,13 +618,13 @@ describe('http prepareResponse', () => {
           event: {
             bundle: {
               inputData: {
-                foo: 'bar'
-              }
-            }
+                foo: 'bar',
+              },
+            },
           },
-          app: {}
-        }
-      }
+          app: {},
+        },
+      },
     });
 
     const data = { foo: 'bar' };
@@ -634,13 +634,13 @@ describe('http prepareResponse', () => {
       status,
       input: request,
       headers: {
-        get: () => 'something/else'
+        get: () => 'something/else',
       },
-      text: () => Promise.resolve(content)
+      text: () => Promise.resolve(content),
     });
     should(response.content).equal(content);
     should(response.data).match(data);
-    should(response.data).match(data); // DEPRECATED
+    should(response.json).match(data); // DEPRECATED
     should(response.getHeader(), 'something/else');
   });
   it('should be able to parse response.content when application/x-www-form-urlencoded', async () => {
@@ -651,13 +651,13 @@ describe('http prepareResponse', () => {
           event: {
             bundle: {
               inputData: {
-                foo: 'bar'
-              }
-            }
+                foo: 'bar',
+              },
+            },
           },
-          app: {}
-        }
-      }
+          app: {},
+        },
+      },
     });
 
     const data = { foo: 'bar' };
@@ -667,13 +667,13 @@ describe('http prepareResponse', () => {
       status,
       input: request,
       headers: {
-        get: () => 'application/x-www-form-urlencoded'
+        get: () => 'application/x-www-form-urlencoded',
       },
-      text: () => Promise.resolve(content)
+      text: () => Promise.resolve(content),
     });
     should(response.content).equal(content);
     should(response.data).match(data);
-    should(response.data).be.Undefined(); // DEPRECATED and not forwards compatible
+    should(response.json).be.Undefined(); // DEPRECATED and not forwards compatible
     should(response.getHeader(), 'application/x-www-form-urlencoded');
   });
 });

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -129,7 +129,7 @@ const RequestFunc = {
         return z
           .request({ url: '{{process.env.BASE_URL}}/get' })
           .then((resp) => {
-            const result = resp.json;
+            const result = resp.data;
             result.id = 123;
             return [result];
           });
@@ -149,7 +149,7 @@ const RequestSugar = {
     operation: {
       perform: (z /* , bundle */) => {
         return z.request('https://httpbin.org/get').then((resp) => {
-          return resp.json;
+          return resp.data;
         });
       },
     },
@@ -414,7 +414,7 @@ const ExecuteRequestAsFunc = {
       perform: (z, bundle) => {
         const req = _.defaults({}, bundle.inputData.options);
         return z.request(req).then((resp) => {
-          return bundle.inputData.returnValue || resp.json;
+          return bundle.inputData.returnValue || resp.data;
         });
       },
       inputFields: [
@@ -441,10 +441,27 @@ const ExecuteRequestAsShorthand = {
         {
           key: 'url',
           default: 'https://httpbin.org/status/403',
-        },
-      ],
-    },
+        }
+      ]
+    }
   },
+  create: {
+    display: {
+      label: 'Configurable Request (Shorthand)',
+      description: 'Used for one-offs in the tests.',
+    },
+    operation: {
+      perform: {
+        url: '{{bundle.inputData.url}}',
+      },
+      inputFields: [
+        {
+          key: 'url',
+          default: 'https://httpbin.org/status/403',
+        }
+      ]
+    }
+  }
 };
 const EnvironmentVariable = {
   key: 'env',


### PR DESCRIPTION
# Definitions:

- Code-mode: [`FunctionSchema`](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#functionschema)
- Form-mode: [`RequestSchema`](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#requestschema)

# Commits

I've split the work up in 3 commits:

- Changes: https://github.com/zapier/zapier-platform/pull/211/commits/44f509a763991bfa132da7536229fb0303c0c458
- Tests: https://github.com/zapier/zapier-platform/pull/211/commits/5bb92a242dc7f8493c02cc39b56e12b9492e64f6
- Documentation & Examples: https://github.com/zapier/zapier-platform/pull/211/commits/439a5963983332181cbde31c8cf9606e6370891d

# Changes

- `prepareContentResponse` now parses `.content` to `.data` if its either `application/x-www-form-urlencoded` or can be parsed as JSON.
- `prepareContentResponse` still sets `.json` but it should be considered deprecated.
- `executeHttpRequest` now uses `.data` instead of (again) parsing `.content` as `application/x-www-form-urlencoded` or JSON.
- `executeHttpRequest` now throws a helpful error instead of `SyntaxError` if `.data` is not set and thus not `application/x-www-form-urlencoded`, JSON or set in `afterResponse`.

See the first commit.

# Benefits

- Code-mode no longer need to parse `application/x-www-form-urlencoded`, just like form-mode requests.
- Developers don't need to `JSON.stringify()` their custom-parsed `.content` back to the same property for form-mode to work.
- The type-agnostic `.data` property allows us to later add support for types like XML.

See the below _Examples_.

# Examples

These examples all use `afterResponse`. The code-mode ones could also handle this within the function of course, but this makes it easier to compare between code and form-mode.

## Form-mode request with form response

Already and still works out of the box. It just now relies on `response.data` set by `prepareResponse` instead of parsing `response.content` just before returning it.

This means it may be a breaking change for CLI apps that were doing custom parsing in `afterResponse` as the *Form-mode request with XML response* example.

## Code-mode request with form response

### Before

```node
const querystring = require('querystring');

const afterResponse = (response) => {
  if (response.headers.get('content-type') === 'application/x-www-form-urlencoded') {
    response.json = querystring.parse(response.content);
  }
}
```

### After

```node
z.request('https://example.com/').then(response => response.data);
```

## Code-mode request with JSON response

You can still use `response.json` but we encourage switching to `response.data`.

### Before

```node
z.request('https://example.com/').then(response => response.json);
```

### After

```node
z.request('https://example.com/').then(response => response.data);
```

## Form-mode request with XML response

Note that both before and after currently are only possible in CLI apps, but once https://github.com/zapier/zapier/pull/39899 makes the Middleware tab public for all, this can also be used in visual builder apps.

### Before

As we defaulted to parse `response.content` as JSON:

```node
const parser = require('fast-xml-parser');

const afterResponse = (response) => {
  if ('xml' in response.headers.get('content-type')) {
    const parsed = parser(response.content);
    response.content = JSON.stringify(parsed);
  }
}
```

### After

As we now use `response.data`:

```node
const parser = require('fast-xml-parser');

const afterResponse = (response) => {
  if ('xml' in response.headers.get('content-type')) {
    response.data = parser(response.content);
  }
}
```

## Code-mode request with XML response

### Before

```node
const parser = require('fast-xml-parser');

const afterResponse = (response) => {
  if ('xml' in response.headers.get('content-type')) {
    response.json = parser(response.content);
  }
}
```

### After:

```node
const parser = require('fast-xml-parser');

const afterResponse = (response) => {
  if ('xml' in response.headers.get('content-type')) {
    response.data = parser(response.content);
  }
}
```