### PR TITLE
feat(legacy-scripting-runner): more complete bundle logs and runEvent refactoring

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -186,8 +186,16 @@ const addRequestData = async (event, z, bundle, convertedBundle) => {
 
 const addResponse = (event, bundle, convertedBundle) => {
   if (event.name.endsWith('.post')) {
-    convertedBundle.response = event.response;
-    convertedBundle.response.status_code = event.response.status;
+    convertedBundle.response = { ...event.response };
+    convertedBundle.response.status_code = convertedBundle.response.status;
+    if (convertedBundle.response.request) {
+      convertedBundle.response.request = {
+        ...convertedBundle.response.request
+      };
+      // `request.input` contains the entire app definition, which is big and
+      // unnecessary for legacy scripting
+      delete convertedBundle.response.request.input;
+    }
   }
 };
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Originally, we're using field `request_data` as the function input for bundle logs, and function output and uncaught errors aren't being logged. This PR fixes that, so we use `input` and `output` fields for bundle logs. We're going to log uncaught errors in `error_message` as well.

While I was there, I also
- refactored the confusing `runEvent` code with `async/await`
- removed the unnecessary `bundle.response.request.input` passed into legacy scripting