### PR TITLE
fix(core): don't log request body when it's form data

### DIFF
--- a/packages/core/src/http-middlewares/after/log-response.js
+++ b/packages/core/src/http-middlewares/after/log-response.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const stream = require('stream');
+
 // Prepare a request/reponse to be logged to the backend.
 // Generally respects the "Zapier" request and resp object format.
 const prepareRequestLog = (req, resp) => {
@@ -18,13 +20,9 @@ const prepareRequestLog = (req, resp) => {
   }
 
   let requestBody = req.body;
-  if (
-    requestBody &&
-    requestBody.constructor &&
-    requestBody.constructor.name === 'FormData'
-  ) {
-    // Avoid JSON.stringify form data
-    requestBody = '<form data>';
+  if (requestBody instanceof stream) {
+    // Avoid JSON.stringify form data or any streams
+    requestBody = '<streaming data>';
   }
 
   const data = {

--- a/packages/core/src/http-middlewares/after/log-response.js
+++ b/packages/core/src/http-middlewares/after/log-response.js
@@ -6,15 +6,25 @@ const prepareRequestLog = (req, resp) => {
   req = req || {};
   resp = resp || {};
 
-  let body;
+  let responseBody;
   if (!req.raw) {
     if (typeof resp.content !== 'string') {
-      body = JSON.stringify(resp.content);
+      responseBody = JSON.stringify(resp.content);
     } else {
-      body = resp.content;
+      responseBody = resp.content;
     }
   } else {
-    body = '<probably streaming data>';
+    responseBody = '<probably streaming data>';
+  }
+
+  let requestBody = req.body;
+  if (
+    requestBody &&
+    requestBody.constructor &&
+    requestBody.constructor.name === 'FormData'
+  ) {
+    // Avoid JSON.stringify form data
+    requestBody = '<form data>';
   }
 
   const data = {
@@ -23,11 +33,11 @@ const prepareRequestLog = (req, resp) => {
     request_url: req.url,
     request_method: req.method || 'GET',
     request_headers: req.headers,
-    request_data: req.body,
+    request_data: requestBody,
     request_via_client: true,
     response_status_code: resp.status,
     response_headers: resp.headers,
-    response_content: body
+    response_content: responseBody
   };
 
   if (req._requestStart) {
@@ -43,9 +53,7 @@ const prepareRequestLog = (req, resp) => {
   }
 
   return {
-    message: `${data.response_status_code} ${data.request_method} ${
-      data.request_url
-    }`,
+    message: `${data.response_status_code} ${data.request_method} ${data.request_url}`,
     data: data
   };
 };

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -518,7 +518,7 @@ describe('http logResponse after middleware', () => {
       log_type: 'http',
       request_url: url,
       request_method: 'POST',
-      request_data: '<form data>',
+      request_data: '<streaming data>',
       response_status_code: 200
     });
 

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -1,6 +1,11 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
+const FormData = require('form-data');
 const should = require('should');
+
 const errors = require('../src/errors');
 const createAppRequestClient = require('../src/tools/create-app-request-client');
 const createInput = require('../src/tools/create-input');
@@ -463,5 +468,64 @@ describe('http throwForStatus after middleware', () => {
     });
 
     response.status.should.equal(600);
+  });
+});
+
+describe('http logResponse after middleware', () => {
+  let logged;
+  const testLogger = async (message, data) => {
+    logged = { message, data: JSON.stringify(data) };
+    return {};
+  };
+  const input = createInput({}, {}, testLogger);
+  const request = createAppRequestClient(input);
+
+  it('post JSON data', async () => {
+    const url = 'https://httpbin.zapier-tooling.com/post';
+    await request({ method: 'POST', url, body: { foo: 'bar' } });
+
+    logged.message.should.equal(`200 POST ${url}`);
+
+    const logData = JSON.parse(logged.data);
+    logData.should.containEql({
+      log_type: 'http',
+      request_url: url,
+      request_method: 'POST',
+      request_data: '{"foo":"bar"}',
+      response_status_code: 200
+    });
+
+    const loggedResponseBody = JSON.parse(logData.response_content);
+    loggedResponseBody.should.containEql({
+      url,
+      data: '{"foo":"bar"}'
+    });
+  });
+
+  it('upload file in form data', async () => {
+    const url = 'https://httpbin.zapier-tooling.com/post';
+
+    const form = new FormData();
+    form.append('filename', 'sample.txt');
+    form.append('file', fs.createReadStream(path.join(__dirname, 'test.txt')));
+
+    await request({ method: 'POST', url, body: form });
+
+    logged.message.should.equal(`200 POST ${url}`);
+
+    const logData = JSON.parse(logged.data);
+    logData.should.containEql({
+      log_type: 'http',
+      request_url: url,
+      request_method: 'POST',
+      request_data: '<form data>',
+      response_status_code: 200
+    });
+
+    const loggedResponseBody = JSON.parse(logData.response_content);
+    loggedResponseBody.should.containEql({
+      url,
+      form: { filename: ['sample.txt'] }
+    });
   });
 });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes `logResponse` middleware so we don't `JSON.stringify` a `FormData` object.

Passing a `FormData` object to request body is valid usage when you want to upload a file:

```js
const FormData = require('form-data')

const perform = async (z, bundle) => {
  const form = new FormData();
  form.append('filename', 'sample.txt');
  form.append('file', getStreamSomewhere());

  const response = await z.request({
    url: 'https://...',
    body: form
  });

  // ...
};
```

I notice the `logResponse` middleware would just `JSON.stringify` the `FormData` object and send it to our log server, which results in something like [this](https://cdn.zapier.com/storage/files/2244d52292eeb3cba00d0dbac55f70e9.txt). This does not make sense but fine for most cases, at least it doesn't crash. However, I found for certain stream objects, such as Node.js' built-in `http.request`, it would crash with this error:

```
TypeError: Converting circular structure to JSON
    at JSON.stringify
```

This PR fixes that by not JSON stringifying request body when it's a `FormData` object.