### PR TITLE
improvement(cli): condense checks for present and valid credentials

### DIFF
--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -7,6 +7,8 @@ const { startSpinner, endSpinner, formatStyles } = require('../utils/display');
 const { isValidAppInstall } = require('../utils/misc');
 const { recordAnalytics } = require('../utils/analytics');
 
+const { getWritableApp } = require('../utils/api');
+
 const inquirer = require('inquirer');
 
 const DATA_FORMATS = ['json', 'raw'];
@@ -86,6 +88,13 @@ class ZapierBaseCommand extends Command {
         `${version} is an invalid version str. Try something like \`1.2.3\``
       );
     }
+  }
+
+  async getWritableApp() {
+    this.startSpinner('Checking authentication & permissions');
+    const app = await getWritableApp();
+    this.stopSpinner();
+    return app;
   }
 
   // UTILS

--- a/packages/cli/src/oclif/commands/delete/integration.js
+++ b/packages/cli/src/oclif/commands/delete/integration.js
@@ -1,10 +1,10 @@
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { getWritableApp, callAPI } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 class DeleteAppCommand extends BaseCommand {
   async perform() {
-    const { id, title } = await getWritableApp();
+    const { id, title } = await this.getWritableApp();
 
     this.startSpinner(`Deleting "${title}"`);
     await callAPI(`/apps/${id}`, {

--- a/packages/cli/src/oclif/commands/delete/integration.js
+++ b/packages/cli/src/oclif/commands/delete/integration.js
@@ -1,12 +1,11 @@
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { getLinkedApp, callAPI } = require('../../../utils/api');
+const { getWritableApp, callAPI } = require('../../../utils/api');
 
 class DeleteAppCommand extends BaseCommand {
   async perform() {
-    this.startSpinner('Loading App');
-    const { id, title } = await getLinkedApp();
-    this.stopSpinner();
+    const { id, title } = await getWritableApp();
+
     this.startSpinner(`Deleting "${title}"`);
     await callAPI(`/apps/${id}`, {
       method: 'DELETE'

--- a/packages/cli/src/oclif/commands/delete/version.js
+++ b/packages/cli/src/oclif/commands/delete/version.js
@@ -1,13 +1,13 @@
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { getWritableApp, callAPI } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 class DeleteVersionCommand extends BaseCommand {
   async perform() {
     const { version } = this.args;
     this.throwForInvalidVersion(version);
 
-    const { id, title } = await getWritableApp();
+    const { id, title } = await this.getWritableApp();
 
     this.startSpinner(`Deleting version ${version} of app "${title}"`);
     await callAPI(`/apps/${id}/versions/${version}`, {

--- a/packages/cli/src/oclif/commands/delete/version.js
+++ b/packages/cli/src/oclif/commands/delete/version.js
@@ -1,14 +1,14 @@
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { getLinkedApp, callAPI } = require('../../../utils/api');
+const { getWritableApp, callAPI } = require('../../../utils/api');
 
 class DeleteVersionCommand extends BaseCommand {
   async perform() {
     const { version } = this.args;
-    // validate version
-    this.startSpinner('Loading App');
-    const { id, title } = await getLinkedApp();
-    this.stopSpinner();
+    this.throwForInvalidVersion(version);
+
+    const { id, title } = await getWritableApp();
+
     this.startSpinner(`Deleting version ${version} of app "${title}"`);
     await callAPI(`/apps/${id}/versions/${version}`, {
       method: 'DELETE'

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -1,13 +1,11 @@
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
 
-const { callAPI, getLinkedApp, checkCredentials } = require('../../utils/api');
+const { callAPI, getWritableApp } = require('../../utils/api');
 
 class DeprecateCommand extends BaseCommand {
   async perform() {
-    await checkCredentials();
-
-    const app = await getLinkedApp();
+    const app = await getWritableApp();
     const { version, date } = this.args;
     this.log(
       `Preparing to deprecate version ${version} your app "${app.title}".\n`

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -1,11 +1,11 @@
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
 
-const { callAPI, getWritableApp } = require('../../utils/api');
+const { callAPI } = require('../../utils/api');
 
 class DeprecateCommand extends BaseCommand {
   async perform() {
-    const app = await getWritableApp();
+    const app = await this.getWritableApp();
     const { version, date } = this.args;
     this.log(
       `Preparing to deprecate version ${version} your app "${app.title}".\n`

--- a/packages/cli/src/oclif/commands/describe.js
+++ b/packages/cli/src/oclif/commands/describe.js
@@ -2,7 +2,7 @@ const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
 const { bold, grey } = require('colors/safe');
 const {
-  getLinkedApp,
+  getWritableApp,
   getLinkedAppConfig,
   getVersionInfo
 } = require('../../utils/api');
@@ -67,7 +67,7 @@ class DescribeCommand extends BaseCommand {
   async perform() {
     this.startSpinner('Fetching integration info');
     const [app, appConfig, version, definition] = await Promise.all([
-      getLinkedApp().catch(() => null),
+      getWritableApp().catch(() => null),
       getLinkedAppConfig().catch(() => null),
       getVersionInfo().catch(() => null),
       localAppCommand({ command: 'definition' })

--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -3,7 +3,7 @@ const { omit } = require('lodash');
 
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getWritableApp } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 const successMessage = version =>
   `Successfully wrote the following to the environment of version ${cyan(
@@ -36,7 +36,7 @@ class SetEnvCommand extends BaseCommand {
       return result;
     }, {});
 
-    const app = await getWritableApp();
+    const app = await this.getWritableApp();
 
     const url = `/apps/${app.id}/versions/${version}/multi-environment`;
 

--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -3,7 +3,7 @@ const { omit } = require('lodash');
 
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getLinkedApp } = require('../../../utils/api');
+const { callAPI, getWritableApp } = require('../../../utils/api');
 
 const successMessage = version =>
   `Successfully wrote the following to the environment of version ${cyan(
@@ -36,7 +36,7 @@ class SetEnvCommand extends BaseCommand {
       return result;
     }, {});
 
-    const app = await getLinkedApp();
+    const app = await getWritableApp();
 
     const url = `/apps/${app.id}/versions/${version}/multi-environment`;
 

--- a/packages/cli/src/oclif/commands/env/unset.js
+++ b/packages/cli/src/oclif/commands/env/unset.js
@@ -2,7 +2,7 @@ const { cyan } = require('colors/safe');
 
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getWritableApp } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 const successMessage = version =>
   `Successfully unset the following keys in the environment of version ${cyan(
@@ -33,7 +33,7 @@ class UnsetEnvCommand extends BaseCommand {
       return result;
     }, {});
 
-    const app = await getWritableApp();
+    const app = await this.getWritableApp();
 
     const url = `/apps/${app.id}/versions/${version}/multi-environment`;
 

--- a/packages/cli/src/oclif/commands/env/unset.js
+++ b/packages/cli/src/oclif/commands/env/unset.js
@@ -2,7 +2,7 @@ const { cyan } = require('colors/safe');
 
 const BaseCommand = require('../../ZapierBaseCommand');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getLinkedApp } = require('../../../utils/api');
+const { callAPI, getWritableApp } = require('../../../utils/api');
 
 const successMessage = version =>
   `Successfully unset the following keys in the environment of version ${cyan(
@@ -33,7 +33,7 @@ class UnsetEnvCommand extends BaseCommand {
       return result;
     }, {});
 
-    const app = await getLinkedApp();
+    const app = await getWritableApp();
 
     const url = `/apps/${app.id}/versions/${version}/multi-environment`;
 

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -2,7 +2,7 @@ const { flags } = require('@oclif/command');
 
 const BaseCommand = require('../ZapierBaseCommand');
 const PromoteCommand = require('./promote');
-const { callAPI, getWritableApp } = require('../../utils/api');
+const { callAPI } = require('../../utils/api');
 const { buildFlags } = require('../buildFlags');
 
 class MigrateCommand extends BaseCommand {
@@ -22,7 +22,7 @@ class MigrateCommand extends BaseCommand {
       );
     }
 
-    const app = await getWritableApp();
+    const app = await this.getWritableApp();
 
     let promoteFirst = false;
     if (

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -2,7 +2,7 @@ const { flags } = require('@oclif/command');
 
 const BaseCommand = require('../ZapierBaseCommand');
 const PromoteCommand = require('./promote');
-const { callAPI, getLinkedApp } = require('../../utils/api');
+const { callAPI, getWritableApp } = require('../../utils/api');
 const { buildFlags } = require('../buildFlags');
 
 class MigrateCommand extends BaseCommand {
@@ -22,7 +22,7 @@ class MigrateCommand extends BaseCommand {
       );
     }
 
-    const app = await getLinkedApp();
+    const app = await getWritableApp();
 
     let promoteFirst = false;
     if (

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -3,7 +3,7 @@ const colors = require('colors/safe');
 
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
-const { callAPI, getWritableApp } = require('../../utils/api');
+const { callAPI } = require('../../utils/api');
 const { flattenCheckResult } = require('../../utils/display');
 const { getVersionChangelog } = require('../../utils/changelog');
 
@@ -25,7 +25,7 @@ const serializeErrors = errors => {
 
 class PromoteCommand extends BaseCommand {
   async perform() {
-    const app = await getWritableApp();
+    const app = await this.getWritableApp();
 
     const version = this.args.version;
 

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -3,7 +3,7 @@ const colors = require('colors/safe');
 
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
-const { callAPI, checkCredentials, getLinkedApp } = require('../../utils/api');
+const { callAPI, getWritableApp } = require('../../utils/api');
 const { flattenCheckResult } = require('../../utils/display');
 const { getVersionChangelog } = require('../../utils/changelog');
 
@@ -25,7 +25,7 @@ const serializeErrors = errors => {
 
 class PromoteCommand extends BaseCommand {
   async perform() {
-    await checkCredentials();
+    const app = await getWritableApp();
 
     const version = this.args.version;
 
@@ -56,7 +56,6 @@ class PromoteCommand extends BaseCommand {
       this.error('Cancelled promote.');
     }
 
-    const app = await getLinkedApp();
     this.log(
       `Preparing to promote version ${version} of your integration "${app.title}".`
     );

--- a/packages/cli/src/oclif/commands/team/add.js
+++ b/packages/cli/src/oclif/commands/team/add.js
@@ -2,7 +2,7 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 // const { flags } = require('@oclif/command');
 const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getLinkedApp } = require('../../../utils/api');
+const { callAPI, getWritableApp } = require('../../../utils/api');
 
 const inviteMessage = (roleIsAdmin, title) =>
   roleIsAdmin
@@ -11,9 +11,7 @@ const inviteMessage = (roleIsAdmin, title) =>
 
 class TeamAddCommand extends ZapierBaseCommand {
   async perform() {
-    this.startSpinner('Getting integration info');
-    const { id, title } = await getLinkedApp();
-    this.stopSpinner();
+    const { id, title } = await getWritableApp();
 
     const roleIsAdmin = this.args.role === 'admin';
     const message = this.args.message || inviteMessage(roleIsAdmin, title);

--- a/packages/cli/src/oclif/commands/team/add.js
+++ b/packages/cli/src/oclif/commands/team/add.js
@@ -2,7 +2,7 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 // const { flags } = require('@oclif/command');
 const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getWritableApp } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 const inviteMessage = (roleIsAdmin, title) =>
   roleIsAdmin
@@ -11,7 +11,7 @@ const inviteMessage = (roleIsAdmin, title) =>
 
 class TeamAddCommand extends ZapierBaseCommand {
   async perform() {
-    const { id, title } = await getWritableApp();
+    const { id, title } = await this.getWritableApp();
 
     const roleIsAdmin = this.args.role === 'admin';
     const message = this.args.message || inviteMessage(roleIsAdmin, title);

--- a/packages/cli/src/oclif/commands/team/remove.js
+++ b/packages/cli/src/oclif/commands/team/remove.js
@@ -3,7 +3,7 @@ const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
 const {
   callAPI,
-  getLinkedApp,
+  getWritableApp,
   listEndpointMulti
 } = require('../../../utils/api');
 const { BASE_ENDPOINT } = require('../../../constants');
@@ -53,7 +53,7 @@ class TeamRemoveCommand extends ZapierBaseCommand {
     const roleIsAdmin = role === 'admin';
 
     this.startSpinner('Removing Team Member');
-    const { id: appId } = await getLinkedApp();
+    const { id: appId } = await getWritableApp();
     const url = roleIsAdmin
       ? `/apps/${appId}/collaborators/${invitationId}`
       : `${BASE_ENDPOINT}/api/platform/v3/integrations/${appId}/subscribers/${invitationId}`;

--- a/packages/cli/src/oclif/commands/users/add.js
+++ b/packages/cli/src/oclif/commands/users/add.js
@@ -2,7 +2,7 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 const { flags } = require('@oclif/command');
 const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getWritableApp } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 class UsersAddCommand extends ZapierBaseCommand {
   async perform() {
@@ -19,7 +19,7 @@ class UsersAddCommand extends ZapierBaseCommand {
       return;
     }
 
-    const { id } = await getWritableApp();
+    const { id } = await this.getWritableApp();
     this.startSpinner('Inviting user');
     const url = `/apps/${id}/invitees/${this.args.email}${
       this.args.version ? `/${this.args.version}` : ''

--- a/packages/cli/src/oclif/commands/users/add.js
+++ b/packages/cli/src/oclif/commands/users/add.js
@@ -2,7 +2,7 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 const { flags } = require('@oclif/command');
 const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getLinkedApp } = require('../../../utils/api');
+const { callAPI, getWritableApp } = require('../../../utils/api');
 
 class UsersAddCommand extends ZapierBaseCommand {
   async perform() {
@@ -19,8 +19,8 @@ class UsersAddCommand extends ZapierBaseCommand {
       return;
     }
 
+    const { id } = await getWritableApp();
     this.startSpinner('Inviting user');
-    const { id } = await getLinkedApp();
     const url = `/apps/${id}/invitees/${this.args.email}${
       this.args.version ? `/${this.args.version}` : ''
     }`;

--- a/packages/cli/src/oclif/commands/users/remove.js
+++ b/packages/cli/src/oclif/commands/users/remove.js
@@ -2,7 +2,7 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 const { flags } = require('@oclif/command');
 const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getLinkedApp } = require('../../../utils/api');
+const { callAPI, getWritableApp } = require('../../../utils/api');
 
 class UsersRemoveCommand extends ZapierBaseCommand {
   async perform() {
@@ -19,8 +19,8 @@ class UsersRemoveCommand extends ZapierBaseCommand {
       return;
     }
 
+    const { id } = await getWritableApp();
     this.startSpinner('Removing User');
-    const { id } = await getLinkedApp();
     const url = `/apps/${id}/invitees/${this.args.email}`;
     await callAPI(url, { method: 'DELETE' });
     this.stopSpinner();

--- a/packages/cli/src/oclif/commands/users/remove.js
+++ b/packages/cli/src/oclif/commands/users/remove.js
@@ -2,7 +2,7 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 const { flags } = require('@oclif/command');
 const { cyan } = require('colors/safe');
 const { buildFlags } = require('../../buildFlags');
-const { callAPI, getWritableApp } = require('../../../utils/api');
+const { callAPI } = require('../../../utils/api');
 
 class UsersRemoveCommand extends ZapierBaseCommand {
   async perform() {
@@ -19,7 +19,7 @@ class UsersRemoveCommand extends ZapierBaseCommand {
       return;
     }
 
-    const { id } = await getWritableApp();
+    const { id } = await this.getWritableApp();
     this.startSpinner('Removing User');
     const url = `/apps/${id}/invitees/${this.args.email}`;
     await callAPI(url, { method: 'DELETE' });

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -33,7 +33,7 @@ const { prettyJSONstringify, startSpinner, endSpinner } = require('./display');
 
 const {
   getLinkedAppConfig,
-  checkCredentials,
+  getWritableApp,
   upload: _uploadFunc,
   validateApp
 } = require('./api');
@@ -439,15 +439,17 @@ const buildAndOrUpload = async (
     throw new Error('must either build or upload');
   }
 
-  startSpinner('Checking authentication');
-  await checkCredentials();
-  endSpinner();
+  // we should able to build without any auth, but if we're uploading, we should fail early
+  let app;
+  if (upload) {
+    app = await getWritableApp();
+  }
 
   if (build) {
     await _buildFunc(buildOpts);
   }
   if (upload) {
-    await _uploadFunc();
+    await _uploadFunc(app);
   }
 };
 


### PR DESCRIPTION
The original purpose of this PR was to improve the experience of `build`, `upload`, and `push`. `build` shouldn't need login details or a linked app to work (helpful for scratch testing). Upload does need both of those things, but it should check for them before we try to `build` (fail fast and early). It also improves the error message for these operations so users have more clear guidance on how to fix their problem.

While I was in there, I took a pass at reducing the number of duplicate calls to `/check` we do. There were a number of places where multiple functions in a command would each separately verify whether or not the user was logged in and could access the app. As a result, we should have fewer HTTP calls happening and everything should feel snappier as a result!