### PR TITLE
ci: use Travis build stages to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ before_install:
   - pip install --user awscli
 install:
   - yarn install
+stages:
+  - name: "Test"
+  - name: "Deploy"
+    if: tag IS present AND env(TRAVIS_NODE_VERSION) IS "10.16.3"
 jobs:
   include:
-    - stage: "Tests"
+    - stage: "Test"
       name: "cli: unit tests"
       script: "yarn workspace zapier-platform-cli test"
     - name: "cli: smoke tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '10.16.3' # lambda version as of 2019-11-21
+  - "10"
 before_install:
   - npm install -g yarn
   - pip install --user awscli
@@ -9,7 +9,7 @@ install:
 stages:
   - name: "Test"
   - name: "Deploy"
-    if: tag IS present AND env(TRAVIS_NODE_VERSION) IS "10.16.3"
+    if: tag IS present AND env(TRAVIS_NODE_VERSION) IS "10"
 jobs:
   include:
     - stage: "Test"
@@ -36,7 +36,7 @@ jobs:
         script: ./scripts/publish.sh
         on:
           tags: true,
-          node: "10.16.3"
+          node: "10"
         skip_cleanup: true
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ stages:
 jobs:
   include:
     - stage: "Test"
-      name: "cli: unit tests"
+      name: "lint"
+      script: "yarn lint"
+    - name: "cli: unit tests"
       script: "yarn workspace zapier-platform-cli test"
     - name: "cli: smoke tests"
       script: "yarn workspace zapier-platform-cli smoke-test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,34 @@ before_install:
   - pip install --user awscli
 install:
   - yarn install
-script:
-  - yarn validate
+jobs:
+  include:
+    - stage: "Tests"
+      name: "cli: unit tests"
+      script: "yarn workspace zapier-platform-cli test"
+    - name: "cli: smoke tests"
+      script: "yarn workspace zapier-platform-cli smoke-test"
+    - name: "core: unit tests"
+      script: "yarn workspace zapier-platform-core test"
+    - name: "core: smoke tests"
+      script: "yarn workspace zapier-platform-core smoke-test"
+    - name: "schema: unit tests"
+      script: "yarn workspace zapier-platform-schema test"
+    - name: "schema: smoke tests"
+      script: "yarn workspace zapier-platform-schema smoke-test"
+    - name: "legacy-scripting-runner: integration tests"
+      script: "yarn workspace zapier-platform-legacy-scripting-runner test"
+    - stage: "Deploy"
+      script: skip
+      deploy:
+        provider: script
+        script: ./scripts/publish.sh
+        on:
+          tags: true,
+          node: "10.16.3"
+        skip_cleanup: true
 notifications:
   email: false
-deploy:
-  provider: script
-  script: ./scripts/publish.sh
-  on:
-    tags: true
-    node: '10.16.3'
-  skip_cleanup: true
 env:
   global:
     - PATH: PATH=$HOME/.local/bin:$PATH

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "example-apps/*"
   ],
   "scripts": {
-    "lint": "lerna run --stream --ignore zapier-platform-example-app-* lint",
+    "lint": "lerna run --ignore zapier-platform-example-app-* lint",
     "lint-examples": "eslint examples",
     "validate": "lerna run --ignore zapier-platform-example-app-* validate",
     "bump": "./scripts/bump.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "precommit": "yarn docs && git add docs README.md ../../docs",
     "version": "yarn docs && git add docs/* README.md",
     "postversion": "git push && git push --tags",
-    "lint": "eslint src snippets --fix",
+    "lint": "eslint src snippets",
     "test": "NODE_ENV=test mocha -t 50000 --recursive src/tests",
     "smoke-test": "NODE_ENV=test mocha -t 120000 --recursive src/smoke-tests",
     "validate-templates": "./scripts/validate-app-templates.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     "local-integration-test": "mocha -t 10000 integration-test --local",
     "lambda-integration-test": "mocha -t 10000 integration-test --lambda",
     "smoke-test": "mocha -t 120000 smoke-test",
-    "lint": "eslint src test --fix",
+    "lint": "eslint src test",
     "build-integration-test": "bin/build.sh local.bundle.zip",
     "upload-integration-test": "bin/upload-lambda.js local.bundle.zip",
     "deploy-integration-test": "yarn build-integration-test && yarn upload-integration-test",

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -11,7 +11,7 @@
     "/*.js"
   ],
   "scripts": {
-    "lint": "eslint . --fix",
+    "lint": "eslint .",
     "test": "CLIENT_ID=1234 CLIENT_SECRET=asdf AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake mocha --recursive -t 20000",
     "preversion": "git pull",
     "postversion": "git push && git push --tags",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -17,7 +17,7 @@
     "test": "mocha -t 10000 --recursive test",
     "smoke-test": "mocha -t 10000 --recursive smoke-test",
     "test:debug": "mocha -t 5-10000 --recursive --inspect-brk test",
-    "lint": "eslint lib --fix",
+    "lint": "eslint lib",
     "coverage": "istanbul cover _mocha -- --recursive",
     "export": "node bin/export.js && prettier --write exported-schema.json",
     "docs": "node bin/docs.js",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Leverages Travis [Build Stages](https://docs.travis-ci.com/user/build-stages/) to run groups of tests in parallel.