### PR TITLE
fix(legacy-scripting-runner): allow post_read_resource to return array

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1190,7 +1190,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       'search.resource.pre',
       'search.resource.post',
       'search.resource',
-      { parseResponseForPostMethod: true }
+      { parseResponseForPostMethod: true, ensureType: 'object-first' }
     );
   };
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -799,6 +799,11 @@ const legacyScriptingSource = `
         return movie;
       },
 
+      movie_post_read_resource_array: function(bundle) {
+        // WB would take the first item if the result is an array
+        return [{rating: 'PG', year: 2020}];
+      },
+
       movie_read_resource_disabled: function(bundle) {
         bundle.request.url = bundle.request.url.replace('/movie/', '/movies/');
         var response = z.request(bundle.request);

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -45,7 +45,7 @@ describe('Integration Test', () => {
     const event = {
       command: 'execute',
       bundle: {},
-      method
+      method,
     };
     return createInput(compiledApp, event, testLogger);
   };
@@ -68,9 +68,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = {
         username: 'user',
-        password: 'secret'
+        password: 'secret',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.key1, 'sec');
         should.equal(output.results.key2, 'ret');
       });
@@ -88,9 +88,9 @@ describe('Integration Test', () => {
         'authentication.connectionLabel'
       );
       input.bundle.inputData = {
-        name: 'Mark'
+        name: 'Mark',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results, 'Hi Mark');
       });
     });
@@ -99,10 +99,10 @@ describe('Integration Test', () => {
       const input = createTestInput(compiledApp, 'authentication.test');
       input.bundle.authData = {
         key1: 'sec',
-        key2: 'ret'
+        key2: 'ret',
       };
       input.bundle.meta = { isTestingAuth: true };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const user = output.results;
         should.equal(user.id, 1);
         should.equal(user.username, 'Bret');
@@ -113,10 +113,10 @@ describe('Integration Test', () => {
       const input = createTestInput(compiledApp, 'authentication.test');
       input.bundle.authData = {
         key1: 'sec',
-        key2: 'ret'
+        key2: 'ret',
       };
       input.bundle.meta = { standard_poll: false, test_poll: true };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const user = output.results;
         should.equal(user.id, 1);
         should.equal(user.username, 'Bret');
@@ -131,7 +131,7 @@ describe('Integration Test', () => {
       origEnv = process.env;
       process.env = {
         CLIENT_ID: '1234',
-        CLIENT_SECRET: 'asdf'
+        CLIENT_SECRET: 'asdf',
       };
     });
 
@@ -154,9 +154,9 @@ describe('Integration Test', () => {
       input.bundle.inputData = {
         my_client_id: '1234',
         redirect_uri: 'https://example.com',
-        state: 'qwerty'
+        state: 'qwerty',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(
           output.results,
           `${AUTH_JSON_SERVER_URL}/oauth/authorize?` +
@@ -179,9 +179,9 @@ describe('Integration Test', () => {
       );
       input.bundle.inputData = {
         redirect_uri: 'https://example.com/new',
-        state: 'qwerty'
+        state: 'qwerty',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(
           output.results,
           `${AUTH_JSON_SERVER_URL}/oauth/authorize?` +
@@ -207,9 +207,9 @@ describe('Integration Test', () => {
       );
       input.bundle.inputData = {
         redirect_uri: 'https://example.com',
-        code: 'one_time_code'
+        code: 'one_time_code',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.access_token, 'a_token');
         should.equal(output.results.something_custom, 'alright!');
         should.not.exist(output.results.name);
@@ -233,9 +233,9 @@ describe('Integration Test', () => {
       );
       input.bundle.inputData = {
         redirect_uri: 'https://example.com',
-        code: 'one_time_code'
+        code: 'one_time_code',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.access_token, 'a_token');
         should.equal(output.results.something_custom, 'alright!!!');
         should.equal(output.results.name, 'Jane Doe');
@@ -253,9 +253,9 @@ describe('Integration Test', () => {
       );
       input.bundle.inputData = {
         redirect_uri: 'https://example.com',
-        code: 'one_time_code'
+        code: 'one_time_code',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.access_token, 'a_token');
         should.equal(output.results.something_custom, 'alright!!!');
         should.equal(output.results.name, 'Jane Doe');
@@ -276,9 +276,9 @@ describe('Integration Test', () => {
         'authentication.oauth2Config.refreshAccessToken'
       );
       input.bundle.authData = {
-        refresh_token: 'a_refresh_token'
+        refresh_token: 'a_refresh_token',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.access_token, 'a_new_token');
       });
     });
@@ -298,9 +298,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = {
         refresh_token: 'my_refresh_token',
-        access_token: 'my_access_token'
+        access_token: 'my_access_token',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const response = output.results;
         should.not.exist(response.headers.Authorization);
         should.equal(response.form.refresh_token, 'my_refresh_token');
@@ -322,9 +322,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = {
         refresh_token: 'my_refresh_token',
-        access_token: 'my_access_token'
+        access_token: 'my_access_token',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const response = output.results;
         should.not.exist(response.headers.Authorization);
         should.equal(response.json.refresh_token, 'my_refresh_token');
@@ -345,9 +345,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = {
         refresh_token: 'my_refresh_token',
-        access_token: 'my_access_token'
+        access_token: 'my_access_token',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const data = output.results.form;
 
         should.deepEqual(data, {
@@ -356,7 +356,7 @@ describe('Integration Test', () => {
           client_secret: [process.env.CLIENT_SECRET],
           foo: ['hello'],
           grant_type: ['refresh_token'],
-          refresh_token: ['my_refresh_token']
+          refresh_token: ['my_refresh_token'],
         });
       });
     });
@@ -375,16 +375,16 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = {
         refresh_token: 'my_refresh_token',
-        access_token: 'my_access_token'
+        access_token: 'my_access_token',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const response = output.results;
         should.not.exist(response.headers.Authorization);
         should.deepEqual(response.form, {
           client_id: [process.env.CLIENT_ID],
           client_secret: [process.env.CLIENT_SECRET],
           grant_type: ['refresh_token'],
-          refresh_token: ['my_refresh_token']
+          refresh_token: ['my_refresh_token'],
         });
       });
     });
@@ -408,9 +408,9 @@ describe('Integration Test', () => {
       );
       input.bundle.inputData = {
         redirect_uri: 'https://example.com',
-        code: 'one_time_code'
+        code: 'one_time_code',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.access_token, 'a_token');
         should.equal(output.results.something_custom, 'alright!');
         should.not.exist(output.results.name);
@@ -440,7 +440,7 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { name: 'john' };
       input.bundle.inputData = { name: 'johnny', active: false };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.deepEqual(echoed.args, { name: ['john'], active: ['False'] });
         should.equal(
@@ -457,9 +457,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.meta = {
-        zap: { name: 'My Awesome Zap' }
+        zap: { name: 'My Awesome Zap' },
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.greaterThan(1);
 
         const firstContact = output.results[0];
@@ -483,7 +483,7 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const movies = output.results;
         movies[0].titleHas2.should.be.false();
         movies[1].titleHas2.should.be.true();
@@ -504,7 +504,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.equal(echoed.headers.Accept[0], 'application/json');
         should.equal(
@@ -525,7 +525,7 @@ describe('Integration Test', () => {
         'triggers.contact_pre.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const contact = output.results[0];
@@ -550,7 +550,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.equal(echoed.headers.Accept[0], 'application/json');
         should.equal(
@@ -583,13 +583,13 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.meta = {
-        isFillingDynamicDropdown: true
+        isFillingDynamicDropdown: true,
       };
       input.bundle.inputData = {
         name: 'test',
-        greeting: 'hello'
+        greeting: 'hello',
       };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
 
         // When pulling for a dynamic dropdown (DD), bundle.inputData and
@@ -626,7 +626,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.equal(echoed.args.requestDataIsNull[0], 'yes');
       });
@@ -655,9 +655,9 @@ describe('Integration Test', () => {
         isTestingAuth: false,
         isPopulatingDedupe: true,
         limit: 20,
-        page: 1
+        page: 1,
       };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.deepEqual(echoed.json, {
           auth_test: false,
@@ -668,7 +668,7 @@ describe('Integration Test', () => {
           test_poll: false,
           hydrate: true,
           limit: 20,
-          page: 1
+          page: 1,
         });
       });
     });
@@ -690,7 +690,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.equal(echoed.headers['X-Api-Key'], 'H E Y');
       });
@@ -713,7 +713,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.exist(echoed.headers['X-Api-Key']);
       });
@@ -734,7 +734,7 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const movies = output.results;
         movies.length.should.greaterThan(1);
         should.equal(movies[0].title, 'title 1');
@@ -772,7 +772,7 @@ describe('Integration Test', () => {
         'triggers.recipe.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const firstRecipe = output.results[0];
         should.equal(firstRecipe.name, 'name 1');
       });
@@ -804,12 +804,12 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.inputData = {
-        things: ['eyedrops', 'cyclops', 'ipod']
+        things: ['eyedrops', 'cyclops', 'ipod'],
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const req = output.results[0];
         req.args.should.deepEqual({
-          things: ['eyedrops,cyclops,ipod']
+          things: ['eyedrops,cyclops,ipod'],
         });
         req.url.should.equal(
           'https://httpbin.zapier-tooling.com/get?things=eyedrops%2Ccyclops%2Cipod'
@@ -835,7 +835,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const echoed = output.results[0];
         should.equal(echoed.args.name, 'Luke Skywalker');
       });
@@ -847,7 +847,7 @@ describe('Integration Test', () => {
         'triggers.contact_post.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.greaterThan(1);
 
         const firstContact = output.results[0];
@@ -891,17 +891,17 @@ describe('Integration Test', () => {
         'triggers.contact_post.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const contacts = output.results;
         should.equal(contacts.length, 2);
 
         should.deepEqual(contacts[0], {
           id: 123,
-          name: 'Alice'
+          name: 'Alice',
         });
         should.deepEqual(contacts[1], {
           id: 456,
-          name: 'Bob'
+          name: 'Bob',
         });
       });
     });
@@ -921,10 +921,10 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const movies = output.results;
         movies.length.should.greaterThan(1);
-        movies.forEach(movie => {
+        movies.forEach((movie) => {
           should.not.exist(movie.id);
           should.exist(movie.title);
         });
@@ -948,7 +948,7 @@ describe('Integration Test', () => {
         _compiledApp,
         'triggers.movie.operation.perform'
       );
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const request = output.results[0];
         should.equal(request.method, 'POST');
         should.equal(request.headers.foo, '1234');
@@ -963,7 +963,7 @@ describe('Integration Test', () => {
         'triggers.contact_pre_post.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const contact = output.results[0];
@@ -987,7 +987,7 @@ describe('Integration Test', () => {
         'triggers.contact_full.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 5);
         should.equal(fields[0].key, 'id');
@@ -1014,7 +1014,7 @@ describe('Integration Test', () => {
         'triggers.contact_full.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 6);
         should.equal(fields[0].key, 'id');
@@ -1032,7 +1032,7 @@ describe('Integration Test', () => {
         'triggers.contact_full.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 6);
         should.equal(fields[0].key, 'id');
@@ -1053,9 +1053,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.meta = {
         standard_poll: true,
-        test_poll: true
+        test_poll: true,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movies = output.results;
         movies.length.should.greaterThan(1);
         should.equal(movies[0].title, 'title 1');
@@ -1077,10 +1077,10 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const movies = output.results;
         movies.length.should.greaterThan(1);
-        movies.forEach(movie => {
+        movies.forEach((movie) => {
           movie.user.should.startWith('hydrate|||');
           movie.user.should.endWith('|||hydrate');
 
@@ -1108,10 +1108,10 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return _app(input).then(output => {
+      return _app(input).then((output) => {
         const movies = output.results;
         movies.length.should.greaterThan(1);
-        movies.forEach(movie => {
+        movies.forEach((movie) => {
           movie.trailer.should.startWith('hydrate|||');
           movie.trailer.should.endWith('|||hydrate');
 
@@ -1153,11 +1153,11 @@ describe('Integration Test', () => {
             cast: ['John Doe', 'Jane Doe'],
             meta: {
               running_time: 120,
-              format: 'widescreen'
-            }
-          }
+              format: 'widescreen',
+            },
+          },
         ]);
-      return app(input).then(output => {
+      return app(input).then((output) => {
         // The result from the scripting runner should be flattened
         const expectedResult = {
           id: '1',
@@ -1166,7 +1166,7 @@ describe('Integration Test', () => {
           genre: 'genre 1',
           cast: 'John Doe,Jane Doe',
           meta__running_time: 120,
-          meta__format: 'widescreen'
+          meta__format: 'widescreen',
         };
         should.deepEqual(output.results[0], expectedResult);
       });
@@ -1199,14 +1199,14 @@ describe('Integration Test', () => {
       );
       input.bundle.cleanedRequest = {
         id: 9,
-        name: 'Amy'
+        name: 'Amy',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
         const contact = output.results[0];
         should.deepEqual(contact, {
           id: 9,
-          name: 'Amy'
+          name: 'Amy',
         });
       });
     });
@@ -1224,9 +1224,9 @@ describe('Integration Test', () => {
       );
       input.bundle.cleanedRequest = {
         id: 10,
-        name: 'Bob'
+        name: 'Bob',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const contact = output.results[0];
@@ -1249,9 +1249,9 @@ describe('Integration Test', () => {
       );
       input.bundle.cleanedRequest = [
         { id: 11, name: 'Cate' },
-        { id: 22, name: 'Dave' }
+        { id: 22, name: 'Dave' },
       ];
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const contacts = output.results;
         should.equal(contacts.length, 2);
         should.equal(contacts[0].id, 11);
@@ -1277,12 +1277,12 @@ describe('Integration Test', () => {
       input.bundle.rawRequest = {
         headers: {
           'Content-Type': 'application/xml',
-          'Http-X-Custom': 'hello'
+          'Http-X-Custom': 'hello',
         },
         content: '<name>Tom</name>',
-        querystring: 'foo=bar'
+        querystring: 'foo=bar',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const result = output.results[0];
         should.equal(result.headers['Content-Type'], 'application/xml');
         should.equal(result.headers['Http-X-Custom'], 'hello');
@@ -1314,9 +1314,9 @@ describe('Integration Test', () => {
       input.bundle.cleanedRequest = {
         id: 3,
         name: 'Eric',
-        resource_url: 'https://dont.care'
+        resource_url: 'https://dont.care',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const contact = output.results[0];
@@ -1351,9 +1351,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.cleanedRequest = {
         id: 3,
-        name: 'Eric'
+        name: 'Eric',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const contact = output.results[0];
@@ -1383,9 +1383,9 @@ describe('Integration Test', () => {
       input.bundle.cleanedRequest = {
         id: 3,
         name: 'Dont Care',
-        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`
+        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -1414,9 +1414,9 @@ describe('Integration Test', () => {
       input.bundle.cleanedRequest = {
         id: 3,
         name: 'Dont Care',
-        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`
+        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const contact = output.results[0];
@@ -1446,9 +1446,9 @@ describe('Integration Test', () => {
       input.bundle.cleanedRequest = {
         id: 3,
         name: 'Dont Care',
-        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`
+        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const things = output.results;
         should.equal(things.length, 2);
         should.equal(things[0].id, 3);
@@ -1484,9 +1484,9 @@ describe('Integration Test', () => {
       input.bundle.cleanedRequest = {
         id: 3,
         name: 'Dont Care',
-        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`
+        resource_url: `${AUTH_JSON_SERVER_URL}/users/3`,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -1509,7 +1509,7 @@ describe('Integration Test', () => {
       input.bundle.inputData = { foo: 'bar' };
       input.bundle.targetUrl = 'https://foo.bar';
       input.bundle.meta = { zap: { id: 9511 } };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.json.event, 'contact.created');
         should.equal(
           output.results.json.hidden_message,
@@ -1519,10 +1519,10 @@ describe('Integration Test', () => {
         should.equal(output.results.hiddenMessage, 'post_subscribe was here!');
 
         should.deepEqual(output.results.json.bundleAuthFields, {
-          api_key: 'hey hey'
+          api_key: 'hey hey',
         });
         should.deepEqual(output.results.json.bundleTriggerFields, {
-          foo: 'bar'
+          foo: 'bar',
         });
         should.equal(output.results.json.bundleTargetUrl, 'https://foo.bar');
         should.equal(output.results.json.bundleEvent, 'contact.created');
@@ -1548,7 +1548,7 @@ describe('Integration Test', () => {
       input.bundle.targetUrl = 'https://foo.bar';
       input.bundle.subscribeData = { subscription_id: 7744 };
       input.bundle.meta = { zap: { id: 9512 } };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.equal(output.results.request.method, 'DELETE');
 
         const echoed = output.results.json;
@@ -1560,7 +1560,7 @@ describe('Integration Test', () => {
         should.deepEqual(echoed.json.bundleAuthFields, { api_key: 'yo yo' });
         should.deepEqual(echoed.json.bundleTriggerFields, {
           foo: 'bar',
-          subscription_id: 8866
+          subscription_id: 8866,
         });
         should.equal(echoed.json.bundleTargetUrl, 'https://foo.bar');
         should.equal(echoed.json.bundleEvent, 'contact.created');
@@ -1594,8 +1594,8 @@ describe('Integration Test', () => {
         cast: ['John Doe', 'Jane Doe'],
         meta: {
           running_time: 120,
-          format: 'widescreen'
-        }
+          format: 'widescreen',
+        },
       };
       input.bundle.authData = { api_key: 'secret' };
       // title key is removed deliberately for other tests
@@ -1604,7 +1604,7 @@ describe('Integration Test', () => {
           releaseDate: 1471295527,
           genre: 'genre 1',
           cast: 'John Doe,Jane Doe',
-          meta: 'running_time|120\nformat|widescreen'
+          meta: 'running_time|120\nformat|widescreen',
         })
         .reply(200, { id: 'abcd1234' });
       return app(input).then(() => {
@@ -1626,9 +1626,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'It',
-        genre: 'Horror'
+        genre: 'Horror',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.not.exist(movie.title);
@@ -1655,9 +1655,9 @@ describe('Integration Test', () => {
       input.bundle.inputData = {
         title: 'The Dark Knight',
         genre: 'Drama',
-        resource_name: 'movies'
+        resource_name: 'movies',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.not.exist(movie.title);
@@ -1682,9 +1682,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'The Shape of Water',
-        genre: 'Fantasy'
+        genre: 'Fantasy',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.equal(movie.title, 'The Shape of Water');
@@ -1709,33 +1709,33 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         meta__title: 'The Shape of Water',
-        meta__genre: 'Fantasy'
+        meta__genre: 'Fantasy',
       };
       input.bundle.inputDataRaw = {
         meta__title: '{{123__title}}',
-        meta__genre: '{{234__genre}}'
+        meta__genre: '{{234__genre}}',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const echoed = output.results.json;
         should.deepEqual(echoed.action_fields, {
           meta: {
             title: 'The Shape of Water',
-            genre: 'Fantasy'
-          }
+            genre: 'Fantasy',
+          },
         });
         should.deepEqual(echoed.action_fields_full, {
           meta__title: 'The Shape of Water',
-          meta__genre: 'Fantasy'
+          meta__genre: 'Fantasy',
         });
         should.deepEqual(echoed.action_fields_raw, {
           meta__title: '{{123__title}}',
-          meta__genre: '{{234__genre}}'
+          meta__genre: '{{234__genre}}',
         });
         should.deepEqual(echoed.orig_data, {
           meta: {
             title: 'The Shape of Water',
-            genre: 'Fantasy'
-          }
+            genre: 'Fantasy',
+          },
         });
       });
     });
@@ -1756,21 +1756,21 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        title: 'The Shape of Water'
+        title: 'The Shape of Water',
       };
       input.bundle.inputDataRaw = {
-        title: '{{123__title}}'
+        title: '{{123__title}}',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const echoed = output.results.json;
 
         // Doesn't have 'title' because it's in fieldsExcludedFromBody
         should.deepEqual(echoed.action_fields, {});
         should.deepEqual(echoed.action_fields_full, {
-          title: 'The Shape of Water'
+          title: 'The Shape of Water',
         });
         should.deepEqual(echoed.action_fields_raw, {
-          title: '{{123__title}}'
+          title: '{{123__title}}',
         });
         should.deepEqual(echoed.orig_data, {});
       });
@@ -1789,7 +1789,7 @@ describe('Integration Test', () => {
         compiledApp,
         'creates.movie.operation.perform'
       );
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const echoed = output.results;
         should.equal(echoed.headers.Accept[0], 'application/json');
         should.equal(
@@ -1821,9 +1821,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         urlPath: '/recipes',
-        name: 'Egg & Cheese'
+        name: 'Egg & Cheese',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const recipe = output.results;
         should.exist(recipe.id);
         should.equal(recipe.name, 'Egg & Cheese');
@@ -1848,9 +1848,9 @@ describe('Integration Test', () => {
       input.bundle.inputData = {
         title: 'IT 2',
         genre: 'Horror',
-        year: 2019
+        year: 2019,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.not.exist(movie.title); // title is in fieldsExcludedFromBody
@@ -1873,7 +1873,7 @@ describe('Integration Test', () => {
         compiledApp,
         'creates.movie.operation.perform'
       );
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.deepEqual(output.results, {});
       });
     });
@@ -1896,9 +1896,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'Get Out',
-        genre: 'Comedy'
+        genre: 'Comedy',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.not.exist(movie.title);
@@ -1925,9 +1925,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'First Man',
-        genre: 'Drama'
+        genre: 'Drama',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.not.exist(movie.title);
@@ -1956,7 +1956,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'First Man',
-        genre: 'Drama'
+        genre: 'Drama',
       };
       return app(input).should.be.rejectedWith(/Unexpected identifier/);
     });
@@ -1977,7 +1977,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.perform'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.equal(movie.title, 'Joker');
         should.equal(movie.year, 2019);
@@ -2002,9 +2002,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'The Rise of Skywalker',
-        genre: 'Sci-fi'
+        genre: 'Sci-fi',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.deepEqual(output.results, {});
       });
     });
@@ -2027,9 +2027,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'Us',
-        genre: 'Horror'
+        genre: 'Horror',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.deepEqual(output.results, { message: 'ok' });
       });
     });
@@ -2077,9 +2077,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'Phantom Thread',
-        genre: 'Drama'
+        genre: 'Drama',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.equal(movie.title, 'Phantom Thread');
@@ -2105,9 +2105,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'Room',
-        genre: 'Drama'
+        genre: 'Drama',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.equal(movie.title, 'Room');
@@ -2133,9 +2133,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         title: 'Arrival',
-        genre: 'Sci-fi'
+        genre: 'Sci-fi',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.equal(movie.title, 'Arrival');
@@ -2161,7 +2161,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = [];
 
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.deepEqual(output.results, {});
       });
     });
@@ -2183,7 +2183,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = [1234];
 
-      return app(input).then(output => {
+      return app(input).then((output) => {
         should.deepEqual(output.results, { message: 1234 });
       });
     });
@@ -2211,9 +2211,9 @@ describe('Integration Test', () => {
       input.bundle.inputData = {
         title: 'La La Land',
         genre: 'Musical',
-        resource_name: 'movie'
+        resource_name: 'movie',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.exist(movie.id);
         should.equal(movie.title, 'La La Land');
@@ -2235,7 +2235,7 @@ describe('Integration Test', () => {
         compiledApp,
         'creates.movie.operation.perform'
       );
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const echoed = output.results;
         should.equal(echoed.headers.Accept[0], 'application/json');
         should.equal(
@@ -2262,7 +2262,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 3);
         should.equal(fields[0].key, 'title');
@@ -2286,7 +2286,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 3);
         should.equal(fields[0].key, 'title');
@@ -2311,9 +2311,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        urlPath: '/input-fields'
+        urlPath: '/input-fields',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 3);
         should.equal(fields[0].key, 'name');
@@ -2338,7 +2338,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 4);
         should.equal(fields[0].key, 'title');
@@ -2365,7 +2365,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 4);
         should.equal(fields[3].key, 'attrs');
@@ -2391,7 +2391,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 2);
         should.equal(fields[0].key, 'title');
@@ -2418,7 +2418,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 4);
         should.equal(fields[0].key, 'title');
@@ -2444,7 +2444,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 4);
         should.equal(fields[0].key, 'title');
@@ -2467,7 +2467,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 6);
         should.equal(fields[0].key, 'id');
@@ -2494,7 +2494,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 6);
         should.equal(fields[0].key, 'id');
@@ -2522,7 +2522,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 7);
         should.equal(fields[0].key, 'id');
@@ -2555,7 +2555,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 7);
         should.equal(fields[0].key, 'id');
@@ -2584,7 +2584,7 @@ describe('Integration Test', () => {
         'creates.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 7);
         should.equal(fields[0].key, 'id');
@@ -2613,9 +2613,9 @@ describe('Integration Test', () => {
         // In reality, file will always be a "hydrate URL" that looks something
         // like https://zapier.com/engine/hydrate/1/abcd/, but in fact any
         // valid URL would work.
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
         should.equal(file.mimetype, 'image/png');
@@ -2638,9 +2638,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'this is a pig.png',
-        file: 'https://httpbin.zapier-tooling.com/redirect-to?url=/image/png'
+        file: 'https://httpbin.zapier-tooling.com/redirect-to?url=/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
         should.equal(file.mimetype, 'image/png');
@@ -2667,9 +2667,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'this is a pig.png',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
         should.equal(file.mimetype, 'image/png');
@@ -2696,9 +2696,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'this is a wolf.jpg',
-        file: 'https://httpbin.zapier-tooling.com/image/jpeg'
+        file: 'https://httpbin.zapier-tooling.com/image/jpeg',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, 'eb1db8fa7b8277f2de5d7b40d6cdbc708aac4e52');
         should.equal(file.mimetype, 'image/jpeg');
@@ -2725,9 +2725,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, 'e3076b0be57756b9e7e23192a9d29dfb0b3f4b31');
         should.equal(file.mimetype, 'text/plain');
@@ -2754,9 +2754,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, 'eb1db8fa7b8277f2de5d7b40d6cdbc708aac4e52');
         should.equal(file.mimetype, 'image/jpeg');
@@ -2783,9 +2783,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, 'd17d3480b251a1556c3a4a48fdbd8a0aa2746c6f');
         should.equal(file.mimetype, 'text/plain');
@@ -2812,9 +2812,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, '04bc9f090eafc29a4ab29b05f0f306365b017857');
         should.equal(file.mimetype, 'application/json');
@@ -2841,9 +2841,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, 'ebad26f071d502f26ea7afccea320195c1ad7e8e');
         should.equal(file.mimetype, 'application/json');
@@ -2870,9 +2870,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, 'd7bd9d0e663a001291d1536715403744cbff054d');
         should.equal(file.mimetype, 'application/json');
@@ -2899,9 +2899,9 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png'
+        file: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
 
@@ -2927,9 +2927,9 @@ describe('Integration Test', () => {
       input.bundle.inputData = {
         id: 'whatever',
         name: 'a pig',
-        file_1: 'https://httpbin.zapier-tooling.com/image/png'
+        file_1: 'https://httpbin.zapier-tooling.com/image/png',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const file = output.results.file;
         should.equal(file.sha1, '379f5137831350c900e757b39e525b9db1426d53');
 
@@ -2953,10 +2953,10 @@ describe('Integration Test', () => {
         input.bundle.inputData = {
           method: 'getUser',
           bundle: {
-            userId: 3
-          }
+            userId: 3,
+          },
         };
-        return app(input).then(output => {
+        return app(input).then((output) => {
           const user = output.results;
           should.equal(user.id, 3);
           should.equal(user.name, 'Clementine Bauch');
@@ -2972,8 +2972,8 @@ describe('Integration Test', () => {
         input.bundle.inputData = {
           method: 'getUser',
           bundle: {
-            userId: 3
-          }
+            userId: 3,
+          },
         };
         return app(input).should.be.rejectedWith(/Unauthorized/);
       });
@@ -2986,15 +2986,15 @@ describe('Integration Test', () => {
         input.bundle.inputData = {
           method: 'getUser',
           bundle: {
-            userId: 3
-          }
+            userId: 3,
+          },
         };
         return app(input).should.be.rejectedWith(/Unauthorized/);
       });
     });
 
     describe('legacyFileHydrator', () => {
-      const mockFileStahser = input => {
+      const mockFileStahser = (input) => {
         // Mock z.stashFile to do nothing but return file content and meta
         input.z.stashFile = async (
           filePromise,
@@ -3011,7 +3011,7 @@ describe('Integration Test', () => {
             content: JSON.parse(content),
             knownLength,
             filename,
-            contentType
+            contentType,
           };
         };
         return input;
@@ -3021,7 +3021,7 @@ describe('Integration Test', () => {
         const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
         const compiledApp = schemaTools.prepareApp(appDefWithAuth);
         const app = createAppWithCustomBefores(appDefWithAuth, [
-          mockFileStahser
+          mockFileStahser,
         ]);
 
         const input = createTestInput(
@@ -3031,15 +3031,15 @@ describe('Integration Test', () => {
         input.bundle.authData = { api_key: 'super secret' };
         input.bundle.inputData = {
           // This endpoint echoes what we send to it, so we know if auth info was sent
-          url: 'https://httpbin.zapier-tooling.com/get'
+          url: 'https://httpbin.zapier-tooling.com/get',
         };
-        return app(input).then(output => {
+        return app(input).then((output) => {
           const {
             response,
             content,
             knownLength,
             filename,
-            contentType
+            contentType,
           } = output.results;
           should.equal(content.headers['X-Api-Key'], 'super secret');
           should.not.exist(knownLength);
@@ -3059,7 +3059,7 @@ describe('Integration Test', () => {
         const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
         const compiledApp = schemaTools.prepareApp(appDefWithAuth);
         const app = createAppWithCustomBefores(appDefWithAuth, [
-          mockFileStahser
+          mockFileStahser,
         ]);
 
         const input = createTestInput(
@@ -3071,16 +3071,16 @@ describe('Integration Test', () => {
           // This endpoint echoes what we send to it, so we know if auth info was sent
           url: 'https://httpbin.zapier-tooling.com/get',
           request: {
-            params: { foo: 1, bar: 'hello' }
-          }
+            params: { foo: 1, bar: 'hello' },
+          },
         };
-        return app(input).then(output => {
+        return app(input).then((output) => {
           const {
             response,
             content,
             knownLength,
             filename,
-            contentType
+            contentType,
           } = output.results;
 
           should.equal(content.args.foo, '1');
@@ -3103,7 +3103,7 @@ describe('Integration Test', () => {
         const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
         const compiledApp = schemaTools.prepareApp(appDefWithAuth);
         const app = createAppWithCustomBefores(appDefWithAuth, [
-          mockFileStahser
+          mockFileStahser,
         ]);
 
         const input = createTestInput(
@@ -3115,20 +3115,20 @@ describe('Integration Test', () => {
           // This endpoint echoes what we send to it, so we know if auth info was sent
           url: 'https://httpbin.zapier-tooling.com/get',
           request: {
-            params: { foo: 1, bar: 'hello' }
+            params: { foo: 1, bar: 'hello' },
           },
           meta: {
             length: 1234,
-            name: 'hello.json'
-          }
+            name: 'hello.json',
+          },
         };
-        return app(input).then(output => {
+        return app(input).then((output) => {
           const {
             response,
             content,
             knownLength,
             filename,
-            contentType
+            contentType,
           } = output.results;
 
           should.equal(content.args.foo, '1');
@@ -3163,9 +3163,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 10'
+        query: 'title 10',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -3189,9 +3189,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 20'
+        query: 'title 20',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -3217,9 +3217,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 20'
+        query: 'title 20',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -3247,9 +3247,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 20'
+        query: 'title 20',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -3273,9 +3273,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        query: 'title 12'
+        query: 'title 12',
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         output.results.length.should.equal(1);
 
         const movie = output.results[0];
@@ -3301,9 +3301,9 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        id: 5
+        id: 5,
       };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.equal(movie.id, 5);
         should.equal(movie.title, 'title 5');
@@ -3326,7 +3326,7 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = { id: 5 };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.equal(movie.id, 5);
         should.equal(movie.title, 'title 5');
@@ -3354,7 +3354,7 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = { id: 6 };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.equal(movie.id, 6);
         should.equal(
@@ -3362,6 +3362,34 @@ describe('Integration Test', () => {
           'title 6 (movie_post_read_resource was here)'
         );
         should.equal(movie.anotherId, 6);
+      });
+    });
+
+    it('KEY_post_read_resource, returning array', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      const legacyProps = appDefWithAuth.legacy.searches.movie.operation;
+      legacyProps.resourceUrl = legacyProps.resourceUrl.replace(
+        '/movie/',
+        '/movies/'
+      );
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'movie_post_read_resource_array',
+        'movie_post_read_resource'
+      );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.performGet'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = { id: 6 };
+      return app(input).then((output) => {
+        const movie = output.results;
+        should.equal(movie.rating, 'PG');
+        should.equal(movie.year, 2020);
       });
     });
 
@@ -3385,7 +3413,7 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = { id: 7 };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.equal(movie.id, 7);
         should.equal(
@@ -3412,7 +3440,7 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = { id: 8 };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const movie = output.results;
         should.equal(movie.id, 8);
         should.equal(movie.title, 'title 8 (movie_read_resource was here)');
@@ -3431,7 +3459,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 2);
         should.equal(fields[0].key, 'query');
@@ -3454,7 +3482,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 2);
         should.equal(fields[0].key, 'query');
@@ -3478,7 +3506,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 3);
         should.equal(fields[0].key, 'query');
@@ -3507,7 +3535,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 3);
         should.equal(fields[0].key, 'query');
@@ -3532,7 +3560,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.inputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 3);
         should.equal(fields[0].key, 'query');
@@ -3554,7 +3582,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 6);
         should.equal(fields[0].key, 'id');
@@ -3581,7 +3609,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 6);
         should.equal(fields[0].key, 'id');
@@ -3609,7 +3637,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 7);
         should.equal(fields[0].key, 'id');
@@ -3642,7 +3670,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 7);
         should.equal(fields[0].key, 'id');
@@ -3671,7 +3699,7 @@ describe('Integration Test', () => {
         'searches.movie.operation.outputFields'
       );
       input.bundle.authData = { api_key: 'secret' };
-      return app(input).then(output => {
+      return app(input).then((output) => {
         const fields = output.results;
         should.equal(fields.length, 7);
         should.equal(fields[0].key, 'id');


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Web Builder allows search resource URL (or `post_read_resource`) to return an array. If the result is an array, WB would take the first item of the array and use that to hydrate the search results.

CLI doesn't allow that for `performGet`. `performGet` must return an object. This PR fixes it so that `performGet` always returns an object even if the resource URL (or `post_read_resource`) gives us an array.