### PR TITLE
BREAKING CHANGE(cli) raise error if integration depends on cli

### DIFF
--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -70,7 +70,7 @@ class ZapierBaseCommand extends Command {
     this.error(`subclass the "perform" method in the "${this.id}" command`);
   }
 
-  // put ina method so we can disable it easily in tests
+  // put in a method so we can disable it easily in tests
   throwForInvalidAppInstall() {
     if (this._staticClassReference.skipValidInstallCheck) {
       return;

--- a/packages/cli/src/utils/misc.js
+++ b/packages/cli/src/utils/misc.js
@@ -10,6 +10,7 @@ const semver = require('semver');
 
 const {
   PLATFORM_PACKAGE,
+  PACKAGE_NAME,
   PACKAGE_VERSION,
   LAMBDA_VERSION,
 } = require('../constants');
@@ -81,12 +82,20 @@ const isValidAppInstall = () => {
   let packageJson;
   try {
     packageJson = require(path.join(process.cwd(), 'package.json'));
+
+    if (_.get(packageJson, ['dependencies', PACKAGE_NAME])) {
+      return {
+        valid: false,
+        reason: `Your integration should not depend on ${PACKAGE_NAME}. Please remove it from the \`dependencies\` section of your \`package.json\`. If you want to include a local install, it should go in \`devDependencies.\``,
+      };
+    }
+
     const coreVersion = _.get(packageJson, ['dependencies', PLATFORM_PACKAGE]);
     // could check for a lot more, but this is probably enough: https://docs.npmjs.com/files/package.json#dependencies
     if (!coreVersion) {
       return {
         valid: false,
-        reason: `Your app doesn't depend on ${PLATFORM_PACKAGE}. Run \`${colors.cyan(
+        reason: `Your integration doesn't depend on ${PLATFORM_PACKAGE}. Run \`${colors.cyan(
           `npm install -E ${PLATFORM_PACKAGE}`
         )}\` to resolve`,
       };
@@ -94,7 +103,7 @@ const isValidAppInstall = () => {
       // semver.valid only matches single versions
       return {
         valid: false,
-        reason: `Your app must depend on an exact version of ${PLATFORM_PACKAGE}. Instead of "${coreVersion}", specify an exact version (such as "${PACKAGE_VERSION}")`,
+        reason: `Your integration must depend on an exact version of ${PLATFORM_PACKAGE}. Instead of "${coreVersion}", specify an exact version (such as "${PACKAGE_VERSION}")`,
       };
     }
   } catch (err) {


### PR DESCRIPTION
something I noticed with a partner app today - sometimes they list CLI as a dep. Never need to, so now we'll error for it. We don't really have a zip size problem anymore, but it doesn't hurt to keep devs from including it by accident. 