### PR TITLE
fix(legacy-scripting-runner): prune body if allowGetBody and body is empty

### DIFF
--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -272,6 +272,11 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_GET_with_empty_body: function(bundle) {
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/echo';
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -841,6 +841,30 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, GET with empty body', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_GET_with_empty_body',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        const echoed = output.results[0];
+        should.not.exist(echoed.textBody);
+      });
+    });
+
     it('KEY_post_poll, jQuery utils', () => {
       const input = createTestInput(
         compiledApp,

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -337,11 +337,13 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  { label: 'New Thing',
+  {
+    label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true }
+    important: true
+  }
   ```
 
 #### Anti-Examples
@@ -451,38 +453,48 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -662,7 +674,12 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
+* `{
+  key: 'abc',
+  children: [
+    { key: 'def', children: [ { key: 'dhi' } ] }
+  ]
+}`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -949,19 +966,29 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Create Tag',
+      description: 'Create a new Tag in your account.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -986,19 +1013,25 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Properties
@@ -1023,19 +1056,29 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: {
+      type: 'hook',
+      perform: '$func$0$f$',
+      sample: { id: 385, name: 'proactive enable ROI' }
+    }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties
@@ -1060,24 +1103,38 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation:
-     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
-       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: {
+      perform: { url: 'https://fake-crm.getsandbox.com/users' },
+      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
+    }
+  }
   ```
 * ```
-  { display:
-     { label: 'New User',
-       description: 'Trigger when a new User is created in your account.',
-       hidden: true },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.',
+      hidden: true
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Properties
@@ -1102,21 +1159,31 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1141,55 +1208,81 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 
 #### Properties
@@ -1296,26 +1389,36 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1362,25 +1465,35 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
-    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
-    operation: { type: 'polling', perform: '$func$0$f$' } }
+    display: {
+      label: 'New Recipe',
+      description: 'Triggers when a new recipe is added.',
+      hidden: true
+    },
+    operation: { type: 'polling', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' } }
+    operation: { perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In #195, we introduced `allowGetBody` as a `z.request` option. There's a bug. When the option is enabled, we always send an empty object as the request body. Depending on the server implementation, some could raise an error if they get a `{}` in a GET request's body. This PR fixes that so legacy-scripting-runner doesn't do that. Core will still do that (sends an empty-object request body), so we should fix it from core too. But given that legacy-scripting-runner is the only user of `allowGetBody`, we can fix it later.