### PR TITLE
refactor(legacy-scripting-runner): some tests aren't compiling function source

### DIFF
--- a/packages/legacy-scripting-runner/test/example-app/api-key-auth.js
+++ b/packages/legacy-scripting-runner/test/example-app/api-key-auth.js
@@ -12,14 +12,6 @@ const testAuthSource = `
   });
 `;
 
-const beforeRequestSource = `
-  return z.legacyScripting.beforeRequest(request, z, bundle);
-`;
-
-const afterResponseSource = `
-  return z.legacyScripting.afterResponse(response, z, bundle);
-`;
-
 module.exports = {
   legacy: {
     authentication: {
@@ -40,13 +32,4 @@ module.exports = {
       },
     ],
   },
-  beforeRequest: [
-    {
-      source: beforeRequestSource,
-      args: ['request', 'z', 'bundle'],
-    },
-  ],
-  afterResponse: [
-    { source: afterResponseSource, args: ['response', 'z', 'bundle'] },
-  ],
 };

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -1155,9 +1155,9 @@ const MovieSearch = {
   },
 };
 
-// const beforeRequestSource = `
-//   return z.legacyScripting.beforeRequest(request, z, bundle);
-// `;
+const beforeRequestSource = `
+  return z.legacyScripting.beforeRequest(request, z, bundle);
+`;
 
 const afterResponseSource = `
   return z.legacyScripting.afterResponse(response, z, bundle);
@@ -1194,12 +1194,12 @@ const App = {
     },
   },
   // This breaks `applyBeforeMiddleware` which it looks like gets the original definition without `findSourceRequireFunctions` applied?!
-  // beforeRequest: [
-  //   {
-  //     source: beforeRequestSource,
-  //     args: ['request', 'z', 'bundle']
-  //   }
-  // ],
+  beforeRequest: [
+    {
+      source: beforeRequestSource,
+      args: ['request', 'z', 'bundle'],
+    },
+  ],
   afterResponse: [
     {
       source: afterResponseSource,

--- a/packages/legacy-scripting-runner/test/example-app/oauth2.js
+++ b/packages/legacy-scripting-runner/test/example-app/oauth2.js
@@ -24,14 +24,6 @@ const refreshAccessTokenSource = `
   return z.legacyScripting.run(bundle, 'auth.oauth2.refresh');
 `;
 
-const beforeRequestSource = `
-  return z.legacyScripting.beforeRequest(request, z, bundle);
-`;
-
-const afterResponseSource = `
-  return z.legacyScripting.afterResponse(response, z, bundle);
-`;
-
 module.exports = {
   legacy: {
     authentication: {
@@ -65,10 +57,4 @@ module.exports = {
       autoRefresh: true,
     },
   },
-  beforeRequest: [
-    { source: beforeRequestSource, args: ['request', 'z', 'bundle'] },
-  ],
-  afterResponse: [
-    { source: afterResponseSource, args: ['response', 'z', 'bundle'] },
-  ],
 };

--- a/packages/legacy-scripting-runner/test/example-app/session-auth.js
+++ b/packages/legacy-scripting-runner/test/example-app/session-auth.js
@@ -12,14 +12,6 @@ const getConnectionLabelSource = `
   return z.legacyScripting.run(bundle, 'auth.connectionLabel');
 `;
 
-const beforeRequestSource = `
-  return z.legacyScripting.beforeRequest(request, z, bundle);
-`;
-
-const afterResponseSource = `
-  return z.legacyScripting.afterResponse(response, z, bundle);
-`;
-
 module.exports = {
   legacy: {
     authentication: {
@@ -52,10 +44,4 @@ module.exports = {
     },
     connectionLabel: { source: getConnectionLabelSource },
   },
-  beforeRequest: [
-    { source: beforeRequestSource, args: ['request', 'z', 'bundle'] },
-  ],
-  afterResponse: [
-    { source: afterResponseSource, args: ['response', 'z', 'bundle'] },
-  ],
 };

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1216,9 +1216,11 @@ describe('Integration Test', () => {
 
   describe('hook trigger', () => {
     it('scriptingless', () => {
-      const app = createApp(appDefinition);
+      const appDef = _.cloneDeep(appDefinition);
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
       const input = createTestInput(
-        appDefinition,
+        compiledApp,
         'triggers.contact_hook_scriptingless.operation.perform'
       );
       input.bundle.cleanedRequest = {
@@ -1241,9 +1243,10 @@ describe('Integration Test', () => {
         'contact_hook_scripting_catch_hook_returning_object',
         'contact_hook_scripting_catch_hook'
       );
+      const compiledApp = schemaTools.prepareApp(appDef);
       const app = createApp(appDef);
       const input = createTestInput(
-        appDef,
+        compiledApp,
         'triggers.contact_hook_scripting.operation.perform'
       );
       input.bundle.cleanedRequest = {
@@ -1266,9 +1269,10 @@ describe('Integration Test', () => {
         'contact_hook_scripting_catch_hook_returning_array',
         'contact_hook_scripting_catch_hook'
       );
+      const compiledApp = schemaTools.prepareApp(appDef);
       const app = createApp(appDef);
       const input = createTestInput(
-        appDef,
+        compiledApp,
         'triggers.contact_hook_scripting.operation.perform'
       );
       input.bundle.cleanedRequest = [
@@ -1293,9 +1297,10 @@ describe('Integration Test', () => {
         'contact_hook_scripting_catch_hook_raw_request',
         'contact_hook_scripting_catch_hook'
       );
+      const compiledApp = schemaTools.prepareApp(appDef);
       const app = createApp(appDef);
       const input = createTestInput(
-        appDef,
+        compiledApp,
         'triggers.contact_hook_scripting.operation.perform'
       );
       input.bundle.rawRequest = {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes https://github.com/zapier/zapier-platform/pull/210/files#r418914759, where some tests of legacy-scripting-runner aren't properly compiling function source in the app definition. This only fixes the tests and won't affect the library itself.