### PR TITLE
fix(core): allowGetBody shouldn't send empty body

### DIFF
--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -44,7 +44,7 @@ const coerceBody = (req) => {
   const contentType = getContentType(req.headers || {});
 
   // No need for body on get
-  if (req.method === 'GET' && !req.allowGetBody) {
+  if (req.method === 'GET' && (!req.allowGetBody || _.isEmpty(req.body))) {
     delete req.body;
   }
 

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -382,30 +382,43 @@ describe('request client', () => {
   it('should delete GET body by default', async () => {
     const request = createAppRequestClient(input);
     const response = await request({
-      // Use postman-echo because httpbin doesn't echo GET body
       method: 'GET',
-      url: 'https://postman-echo.com/get',
+      url: 'https://auth-json-server.zapier-staging.com/echo',
       body: {
         name: 'Darth Vader',
       },
     });
     response.status.should.eql(200);
-    response.data.args.should.deepEqual({});
+    response.data.method.should.eql('GET');
+    should.not.exist(response.data.textBody);
   });
 
   it('should allow GET with body', async () => {
     const request = createAppRequestClient(input);
     const response = await request({
-      // Use postman-echo because httpbin doesn't echo GET body
       method: 'GET',
-      url: 'https://postman-echo.com/get',
+      url: 'https://auth-json-server.zapier-staging.com/echo',
       body: {
         name: 'Darth Vader',
       },
       allowGetBody: true,
     });
     response.status.should.eql(200);
-    response.data.args.should.deepEqual({ name: 'Darth Vader' });
+    response.data.method.should.eql('GET');
+    response.data.textBody.should.eql('{"name":"Darth Vader"}');
+  });
+
+  it('allowGetBody should not send empty body', async () => {
+    const request = createAppRequestClient(input);
+    const response = await request({
+      method: 'GET',
+      url: 'https://auth-json-server.zapier-staging.com/echo',
+      body: {},
+      allowGetBody: true,
+    });
+    response.status.should.eql(200);
+    response.data.method.should.eql('GET');
+    should.not.exist(response.data.textBody);
   });
 
   describe('adds query params', () => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes a bug with the `z.request` option `allowGetBody`, introduced in #195. The bug arises when `allowGetBody` is true and `body` is an empty object, `z.request` would send the empty object (encoded as `{}` in JSON) along with the GET request. This could break when the target server isn't expecting an empty object in a GET request. The newly-added test should be self-explanatory.

 While I was there, I changed the test endpoint from postman-echo to the new echo endpoint of the auth-json-server.