### PR TITLE
refactor(cli,core,legacy-scripting-runner): use Zapier-hosted httpbin

### DIFF
--- a/packages/cli/src/generators/templates/authTests/digest.test.js
+++ b/packages/cli/src/generators/templates/authTests/digest.test.js
@@ -18,7 +18,7 @@ describe('digest auth', () => {
     const response = await appTester(App.authentication.test, bundle);
 
     expect(response.status).toBe(200);
-    expect(response.data.authenticated).toBe(true);
+    expect(response.data.authorized).toBe(true);
     expect(response.data.user).toBe('myuser');
   });
 

--- a/packages/cli/src/utils/auth-files-codegen.js
+++ b/packages/cli/src/utils/auth-files-codegen.js
@@ -356,7 +356,9 @@ const digestAuthFile = () => {
   return file(
     // special digest auth
     authTestFunc(
-      strLiteral('https://httpbin.org/digest-auth/auth/myuser/mypass')
+      strLiteral(
+        'https://httpbin.zapier-tooling.com/digest-auth/auth/myuser/mypass'
+      )
     ),
     handleBadResponsesFunc(badFuncName),
     authFileExport(

--- a/packages/core/integration-test/integration-test.js
+++ b/packages/core/integration-test/integration-test.js
@@ -244,7 +244,7 @@ const doTest = (runner) => {
             noun: 'Foo',
             operation: {
               perform: {
-                url: 'https://httpbin.org/get',
+                url: 'https://httpbin.zapier-tooling.com/get',
                 params: {
                   id: 54321,
                 },
@@ -285,7 +285,7 @@ const doTest = (runner) => {
       });
     });
 
-    it('should handle array of [appRawOverrideHash, appRawExtension] and override perform with source', () => {
+    it('should handle array of [appRawOverrideHash, appRawExtension] and override perform with source', async () => {
       const definition = {
         creates: {
           foo: {
@@ -307,7 +307,7 @@ const doTest = (runner) => {
             operation: {
               perform: {
                 method: 'POST',
-                url: 'https://httpbin.org/post',
+                url: 'https://httpbin.zapier-tooling.com/post',
                 params: {
                   id: 54321,
                 },
@@ -330,12 +330,11 @@ const doTest = (runner) => {
         token: 'fake',
       };
 
-      return runner(event).then((response) => {
-        response.results.should.containEql({
-          args: {
-            id: '54321',
-          },
-        });
+      const response = await runner(event);
+      response.results.should.containEql({
+        args: {
+          id: ['54321'],
+        },
       });
     });
 
@@ -484,7 +483,7 @@ const doTest = (runner) => {
       });
     });
 
-    it('should handle function source in beforeRequest', () => {
+    it('should handle function source in beforeRequest', async () => {
       const definition = {
         beforeRequest: [
           {
@@ -497,7 +496,7 @@ const doTest = (runner) => {
             operation: {
               perform: {
                 method: 'POST',
-                url: 'https://httpbin.org/post',
+                url: 'https://httpbin.zapier-tooling.com/post',
               },
             },
           },
@@ -510,9 +509,8 @@ const doTest = (runner) => {
         appRawOverride: definition,
       };
 
-      return runner(event).then((response) => {
-        response.results.headers['X-Foo'].should.eql('it worked!');
-      });
+      const response = await runner(event);
+      response.results.headers['X-Foo'].should.deepEqual(['it worked!']);
     });
 
     it('should log requests', () => {

--- a/packages/core/integration-test/integration-test.js
+++ b/packages/core/integration-test/integration-test.js
@@ -11,6 +11,7 @@ const should = require('should');
 
 const createLambdaHandler = require('../src/tools/create-lambda-handler');
 const mocky = require('../test/tools/mocky');
+const { HTTPBIN_URL } = require('../test/constants');
 
 const lambda = new AWS.Lambda({
   apiVersion: '2015-03-31',
@@ -244,7 +245,7 @@ const doTest = (runner) => {
             noun: 'Foo',
             operation: {
               perform: {
-                url: 'https://httpbin.zapier-tooling.com/get',
+                url: `${HTTPBIN_URL}/get`,
                 params: {
                   id: 54321,
                 },
@@ -307,7 +308,7 @@ const doTest = (runner) => {
             operation: {
               perform: {
                 method: 'POST',
-                url: 'https://httpbin.zapier-tooling.com/post',
+                url: `${HTTPBIN_URL}/post`,
                 params: {
                   id: 54321,
                 },
@@ -496,7 +497,7 @@ const doTest = (runner) => {
             operation: {
               perform: {
                 method: 'POST',
-                url: 'https://httpbin.zapier-tooling.com/post',
+                url: `${HTTPBIN_URL}/post`,
               },
             },
           },

--- a/packages/core/test/constants.js
+++ b/packages/core/test/constants.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const HTTPBIN_URL = 'https://httpbin.zapier-tooling.com';
+
+module.exports = {
+  HTTPBIN_URL,
+};

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -103,99 +103,83 @@ describe('create-app', () => {
       .catch(done);
   });
 
-  it('should return data from live request call, applying HTTP before middleware', (done) => {
+  it('should return data from live request call, applying HTTP before middleware', async () => {
     const input = createTestInput('resources.contact.list.operation.perform');
+    const output = await app(input);
 
-    app(input)
-      .then((output) => {
-        // httpbin.org/get puts request headers in the response body (good for testing):
-        should.exist(output.results.headers);
+    should.exist(output.results.headers);
 
-        // verify that custom http before middleware was applied
-        output.results.headers['X-Hashy'].should.eql(
-          '1a3ba5251cb33ee7ade01af6a7b960b8'
-        );
-        output.results.headers['X-Author'].should.eql('One Cool Dev');
-
-        done();
-      })
-      .catch(done);
+    // verify that custom http before middleware was applied
+    output.results.headers['X-Hashy'].should.deepEqual([
+      '1a3ba5251cb33ee7ade01af6a7b960b8',
+    ]);
+    output.results.headers['X-Author'].should.deepEqual(['One Cool Dev']);
   });
 
-  it('should fail on a live request call', (done) => {
+  it('should fail on a live request call', async () => {
     const input = createTestInput(
       'resources.failerhttp.list.operation.perform'
     );
 
-    app(input)
-      .then(() => {
-        done('expected an error');
-      })
-      .catch((err) => {
-        should(err).instanceOf(errors.ResponseError);
-        err.name.should.eql('ResponseError');
-        const response = JSON.parse(err.message);
-        should(response.status).equal(403);
-        should(response.request.url).equal('https://httpbin.org/status/403');
-        should(response.headers['content-type']).equal(
-          'text/html; charset=utf-8'
-        );
-        should(response.content).equal('');
-        done();
-      })
-      .catch(done);
+    try {
+      await app(input);
+    } catch (err) {
+      should(err).instanceOf(errors.ResponseError);
+      err.name.should.eql('ResponseError');
+
+      const response = JSON.parse(err.message);
+      response.status.should.eql(403);
+      response.request.url.should.eql(
+        'https://httpbin.zapier-tooling.com/status/403'
+      );
+      return;
+    }
+
+    throw new Error('expected an error');
   });
 
-  it('should fail on a live request call (direct)', (done) => {
+  it('should fail on a live request call (direct)', async () => {
     const input = createTestInput('triggers.failerhttpList.operation.perform');
 
-    app(input)
-      .then(() => {
-        done('expected an error');
-      })
-      .catch((err) => {
-        should(err).instanceOf(errors.ResponseError);
-        err.name.should.eql('ResponseError');
-        const response = JSON.parse(err.message);
-        should(response.status).equal(403);
-        should(response.request.url).equal('https://httpbin.org/status/403');
-        should(response.headers['content-type']).equal(
-          'text/html; charset=utf-8'
-        );
-        should(response.content).equal('');
-        done();
-      })
-      .catch(done);
+    try {
+      await app(input);
+    } catch (err) {
+      should(err).instanceOf(errors.ResponseError);
+      err.name.should.eql('ResponseError');
+
+      const response = JSON.parse(err.message);
+      response.status.should.eql(403);
+      response.request.url.should.eql(
+        'https://httpbin.zapier-tooling.com/status/403'
+      );
+      return;
+    }
+
+    throw new Error('expected an error');
   });
 
-  it('should make call via z.request', (done) => {
+  it('should make call via z.request', async () => {
     const input = createTestInput('triggers.requestfuncList.operation.perform');
 
-    app(input)
-      .then((output) => {
-        output.results[0].headers['X-Hashy'].should.eql(
-          '1a3ba5251cb33ee7ade01af6a7b960b8'
-        );
-        output.results[0].headers['X-Author'].should.eql('One Cool Dev');
-        done();
-      })
-      .catch(done);
+    const output = await app(input);
+
+    output.results[0].headers['X-Hashy'].should.deepEqual([
+      '1a3ba5251cb33ee7ade01af6a7b960b8',
+    ]);
+    output.results[0].headers['X-Author'].should.deepEqual(['One Cool Dev']);
   });
 
-  it('should make call via z.request with sugar url param', (done) => {
+  it('should make call via z.request with sugar url param', async () => {
     const input = createTestInput(
       'triggers.requestsugarList.operation.perform'
     );
 
-    app(input)
-      .then((output) => {
-        output.results.headers['X-Hashy'].should.eql(
-          '1a3ba5251cb33ee7ade01af6a7b960b8'
-        );
-        output.results.headers['X-Author'].should.eql('One Cool Dev');
-        done();
-      })
-      .catch(done);
+    const output = await app(input);
+
+    output.results.headers['X-Hashy'].should.deepEqual([
+      '1a3ba5251cb33ee7ade01af6a7b960b8',
+    ]);
+    output.results.headers['X-Author'].should.deepEqual(['One Cool Dev']);
   });
 
   it('should fail on a sync function', (done) => {
@@ -271,18 +255,15 @@ describe('create-app', () => {
       });
   });
 
-  it('should return data from live request call (direct)', (done) => {
+  it('should return data from live request call (direct)', async () => {
     const input = createTestInput('triggers.contactList.operation.perform');
-    app(input)
-      .then((output) => {
-        output.results.url.should.eql('https://httpbin.org/get');
-        output.results.headers['X-Hashy'].should.eql(
-          '1a3ba5251cb33ee7ade01af6a7b960b8'
-        );
-        output.results.headers['X-Author'].should.eql('One Cool Dev');
-        done();
-      })
-      .catch(done);
+    const output = await app(input);
+
+    output.results.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    output.results.headers['X-Hashy'].should.deepEqual([
+      '1a3ba5251cb33ee7ade01af6a7b960b8',
+    ]);
+    output.results.headers['X-Author'].should.deepEqual(['One Cool Dev']);
   });
 
   it('should return a rendered URL for OAuth2 authorizeURL', (done) => {
@@ -328,14 +309,16 @@ describe('create-app', () => {
       command: 'request',
       bundle: {
         request: {
-          url: 'https://httpbin.org/get',
+          url: 'https://httpbin.zapier-tooling.com/get',
         },
       },
     });
     app(input)
       .then((output) => {
         const response = output.results;
-        JSON.parse(response.content).url.should.eql('https://httpbin.org/get');
+        JSON.parse(response.content).url.should.eql(
+          'https://httpbin.zapier-tooling.com/get'
+        );
         done();
       })
       .catch(done);
@@ -359,7 +342,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.org/status/401',
+            url: 'https://httpbin.zapier-tooling.com/status/401',
           },
         },
         method: 'resources.executeRequestAsShorthand.list.operation.perform',
@@ -395,7 +378,7 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'https://httpbin.org/status/401',
+              url: 'https://httpbin.zapier-tooling.com/status/401',
             },
           },
         },
@@ -430,7 +413,7 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'https://httpbin.org/status/401',
+              url: 'https://httpbin.zapier-tooling.com/status/401',
             },
           },
         },
@@ -626,7 +609,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.org/get',
+            url: 'https://httpbin.zapier-tooling.com/get',
           },
         },
         method: 'resources.executeRequestAsShorthand.create.operation.perform',
@@ -640,7 +623,7 @@ describe('create-app', () => {
       const app = createApp(appDefinition);
 
       // httpbin doesn't actually have a form-urlencoded endpoint
-      nock('https://x-www-form-urlencoded.httpbin.org')
+      nock('https://x-www-form-urlencoded.httpbin.zapier-tooling.com')
         .get('/')
         .reply(200, 'foo=bar', {
           'content-type': 'application/x-www-form-urlencoded',
@@ -650,7 +633,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://x-www-form-urlencoded.httpbin.org/',
+            url: 'https://x-www-form-urlencoded.httpbin.zapier-tooling.com/',
           },
         },
         method: 'resources.executeRequestAsShorthand.create.operation.perform',
@@ -667,7 +650,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.org/xml',
+            url: 'https://httpbin.zapier-tooling.com/xml',
           },
         },
         method: 'resources.executeRequestAsShorthand.create.operation.perform',

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -7,6 +7,7 @@ const createInput = require('../src/tools/create-input');
 const dataTools = require('../src/tools/data');
 const errors = require('../src/errors');
 const appDefinition = require('./userapp');
+const { HTTPBIN_URL } = require('./constants');
 
 describe('create-app', () => {
   const testLogger = (/* message, data */) => {
@@ -129,9 +130,7 @@ describe('create-app', () => {
 
       const response = JSON.parse(err.message);
       response.status.should.eql(403);
-      response.request.url.should.eql(
-        'https://httpbin.zapier-tooling.com/status/403'
-      );
+      response.request.url.should.eql(`${HTTPBIN_URL}/status/403`);
       return;
     }
 
@@ -149,9 +148,7 @@ describe('create-app', () => {
 
       const response = JSON.parse(err.message);
       response.status.should.eql(403);
-      response.request.url.should.eql(
-        'https://httpbin.zapier-tooling.com/status/403'
-      );
+      response.request.url.should.eql(`${HTTPBIN_URL}/status/403`);
       return;
     }
 
@@ -259,7 +256,7 @@ describe('create-app', () => {
     const input = createTestInput('triggers.contactList.operation.perform');
     const output = await app(input);
 
-    output.results.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    output.results.url.should.eql(`${HTTPBIN_URL}/get`);
     output.results.headers['X-Hashy'].should.deepEqual([
       '1a3ba5251cb33ee7ade01af6a7b960b8',
     ]);
@@ -309,16 +306,14 @@ describe('create-app', () => {
       command: 'request',
       bundle: {
         request: {
-          url: 'https://httpbin.zapier-tooling.com/get',
+          url: `${HTTPBIN_URL}/get`,
         },
       },
     });
     app(input)
       .then((output) => {
         const response = output.results;
-        JSON.parse(response.content).url.should.eql(
-          'https://httpbin.zapier-tooling.com/get'
-        );
+        JSON.parse(response.content).url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -342,7 +337,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.zapier-tooling.com/status/401',
+            url: `${HTTPBIN_URL}/status/401`,
           },
         },
         method: 'resources.executeRequestAsShorthand.list.operation.perform',
@@ -378,7 +373,7 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'https://httpbin.zapier-tooling.com/status/401',
+              url: `${HTTPBIN_URL}/status/401`,
             },
           },
         },
@@ -413,7 +408,7 @@ describe('create-app', () => {
         bundle: {
           inputData: {
             options: {
-              url: 'https://httpbin.zapier-tooling.com/status/401',
+              url: `${HTTPBIN_URL}/status/401`,
             },
           },
         },
@@ -609,7 +604,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.zapier-tooling.com/get',
+            url: `${HTTPBIN_URL}/get`,
           },
         },
         method: 'resources.executeRequestAsShorthand.create.operation.perform',
@@ -623,7 +618,7 @@ describe('create-app', () => {
       const app = createApp(appDefinition);
 
       // httpbin doesn't actually have a form-urlencoded endpoint
-      nock('https://x-www-form-urlencoded.httpbin.zapier-tooling.com')
+      nock('https://x-www-form-urlencoded.example.com')
         .get('/')
         .reply(200, 'foo=bar', {
           'content-type': 'application/x-www-form-urlencoded',
@@ -633,7 +628,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://x-www-form-urlencoded.httpbin.zapier-tooling.com/',
+            url: 'https://x-www-form-urlencoded.example.com/',
           },
         },
         method: 'resources.executeRequestAsShorthand.create.operation.perform',
@@ -650,7 +645,7 @@ describe('create-app', () => {
         command: 'execute',
         bundle: {
           inputData: {
-            url: 'https://httpbin.zapier-tooling.com/xml',
+            url: `${HTTPBIN_URL}/xml`,
           },
         },
         method: 'resources.executeRequestAsShorthand.create.operation.perform',

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -9,6 +9,7 @@ const should = require('should');
 const createAppRequestClient = require('../src/tools/create-app-request-client');
 const createInput = require('../src/tools/create-input');
 const errors = require('../src/errors');
+const { HTTPBIN_URL } = require('./constants');
 
 describe('request client', () => {
   const testLogger = () => Promise.resolve({});
@@ -16,7 +17,7 @@ describe('request client', () => {
 
   it('should include a user-agent header', (done) => {
     const request = createAppRequestClient(input);
-    request({ url: 'https://httpbin.zapier-tooling.com/get' })
+    request({ url: `${HTTPBIN_URL}/get` })
       .then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -24,7 +25,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+        body.url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -33,7 +34,7 @@ describe('request client', () => {
   it('should allow overriding the user-agent header', (done) => {
     const request = createAppRequestClient(input);
     request({
-      url: 'https://httpbin.zapier-tooling.com/get',
+      url: `${HTTPBIN_URL}/get`,
       headers: {
         'User-Agent': 'Zapier!',
       },
@@ -46,7 +47,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+        body.url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -55,7 +56,7 @@ describe('request client', () => {
   it('should have json serializable response', async () => {
     const request = createAppRequestClient(input);
     const responseBefore = await request({
-      url: 'https://httpbin.zapier-tooling.com/get',
+      url: `${HTTPBIN_URL}/get`,
     });
     const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -63,16 +64,16 @@ describe('request client', () => {
     response.status.should.eql(200);
 
     const body = JSON.parse(response.content);
-    body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    body.url.should.eql(`${HTTPBIN_URL}/get`);
   });
 
   it('should wrap a request entirely', (done) => {
     const request = createAppRequestClient(input);
-    request({ url: 'https://httpbin.zapier-tooling.com/get' })
+    request({ url: `${HTTPBIN_URL}/get` })
       .then((response) => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+        body.url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -83,7 +84,7 @@ describe('request client', () => {
     const request = createAppRequestClient(input);
     request({
       method: 'POST',
-      url: 'https://httpbin.zapier-tooling.com/post',
+      url: `${HTTPBIN_URL}/post`,
       body: Promise.resolve(payload),
     })
       .then((response) => {
@@ -150,11 +151,11 @@ describe('request client', () => {
 
   it('should support single url param', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.zapier-tooling.com/get')
+    request(`${HTTPBIN_URL}/get`)
       .then((response) => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+        body.url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -162,19 +163,19 @@ describe('request client', () => {
 
   it('should support url param with options', async () => {
     const request = createAppRequestClient(input);
-    const response = await request('https://httpbin.zapier-tooling.com/get', {
+    const response = await request(`${HTTPBIN_URL}/get`, {
       headers: { A: 'B' },
     });
 
     response.status.should.eql(200);
     const body = JSON.parse(response.content);
-    body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    body.url.should.eql(`${HTTPBIN_URL}/get`);
     body.headers.A.should.deepEqual(['B']);
   });
 
   it('should support bytes', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.zapier-tooling.com/bytes/1024')
+    request(`${HTTPBIN_URL}/bytes/1024`)
       .then((response) => {
         response.status.should.eql(200);
         // it tries to decode the bytes /shrug
@@ -186,7 +187,7 @@ describe('request client', () => {
 
   it('should support bytes raw', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.zapier-tooling.com/bytes/1024', { raw: true })
+    request(`${HTTPBIN_URL}/bytes/1024`, { raw: true })
       .then((response) => {
         response.status.should.eql(200);
         should(response.buffer).be.type('function');
@@ -199,7 +200,7 @@ describe('request client', () => {
 
   it('should support streaming bytes', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.zapier-tooling.com/stream-bytes/1024')
+    request(`${HTTPBIN_URL}/stream-bytes/1024`)
       .then((response) => {
         response.status.should.eql(200);
         // it tries to decode the bytes /shrug
@@ -211,7 +212,7 @@ describe('request client', () => {
 
   it('should support streaming bytes raw', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.zapier-tooling.com/stream-bytes/1024', {
+    request(`${HTTPBIN_URL}/stream-bytes/1024`, {
       raw: true,
     })
       .then((response) => {
@@ -226,7 +227,7 @@ describe('request client', () => {
 
   it('should support streaming bytes raw as buffer', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.zapier-tooling.com/stream-bytes/1024', {
+    request(`${HTTPBIN_URL}/stream-bytes/1024`, {
       raw: true,
     })
       .then((response) => {
@@ -254,7 +255,7 @@ describe('request client', () => {
       testLogger
     );
     const request = createAppRequestClient(inputWithBeforeMiddleware);
-    request({ url: 'https://httpbin.zapier-tooling.com/get' })
+    request({ url: `${HTTPBIN_URL}/get` })
       .then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -262,7 +263,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+        body.url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -271,14 +272,14 @@ describe('request client', () => {
   it('should default to run throwForStatus', () => {
     const request = createAppRequestClient(input);
     return request({
-      url: 'https://httpbin.zapier-tooling.com/status/400',
+      url: `${HTTPBIN_URL}/status/400`,
     }).should.be.rejectedWith(errors.ResponseError);
   });
 
   it('should be able to skip throwForStatus via request', async () => {
     const request = createAppRequestClient(input);
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/status/400',
+      url: `${HTTPBIN_URL}/status/400`,
       skipThrowForStatus: true,
     });
     response.status.should.eql(400);
@@ -299,7 +300,7 @@ describe('request client', () => {
     );
     const request = createAppRequestClient(inputWithAfterMiddleware);
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/status/400',
+      url: `${HTTPBIN_URL}/status/400`,
     });
     response.status.should.eql(400);
   });
@@ -307,7 +308,7 @@ describe('request client', () => {
   it('should parse form type request body', async () => {
     const request = createAppRequestClient(input);
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/post',
+      url: `${HTTPBIN_URL}/post`,
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -330,7 +331,7 @@ describe('request client', () => {
   it('should not parse form type request body when string', async () => {
     const request = createAppRequestClient(input);
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/post',
+      url: `${HTTPBIN_URL}/post`,
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -367,11 +368,9 @@ describe('request client', () => {
     const newInput = _.cloneDeep(input);
     newInput._zapier.event.verifySSL = false;
     const request = createAppRequestClient(newInput);
-    return request('https://httpbin.zapier-tooling.com/get').then(
-      (response) => {
-        response.status.should.eql(200);
-      }
-    );
+    return request(`${HTTPBIN_URL}/get`).then((response) => {
+      response.status.should.eql(200);
+    });
   });
 
   it('should delete GET body by default', async () => {
@@ -407,7 +406,7 @@ describe('request client', () => {
     it('should replace remaining curly params with empty string by default', async () => {
       const request = createAppRequestClient(input);
       const responseBefore = await request({
-        url: 'https://httpbin.zapier-tooling.com/get',
+        url: `${HTTPBIN_URL}/get`,
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -422,15 +421,13 @@ describe('request client', () => {
       response.status.should.eql(200);
 
       const body = JSON.parse(response.content);
-      body.url.should.eql(
-        'https://httpbin.zapier-tooling.com/get?something=&really=&cool=true'
-      );
+      body.url.should.eql(`${HTTPBIN_URL}/get?something=&really=&cool=true`);
     });
 
     it('should replace remaining curly params with empty string when set as false', async () => {
       const request = createAppRequestClient(input);
       const responseBefore = await request({
-        url: 'https://httpbin.zapier-tooling.com/get',
+        url: `${HTTPBIN_URL}/get`,
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -448,9 +445,7 @@ describe('request client', () => {
       response.status.should.eql(200);
 
       const body = JSON.parse(response.content);
-      body.url.should.eql(
-        'https://httpbin.zapier-tooling.com/get?something=&really=&cool=true'
-      );
+      body.url.should.eql(`${HTTPBIN_URL}/get?something=&really=&cool=true`);
     });
 
     it('should omit empty params when set as true', async () => {
@@ -466,7 +461,7 @@ describe('request client', () => {
       );
 
       const responseBefore = await request({
-        url: 'https://httpbin.zapier-tooling.com/get',
+        url: `${HTTPBIN_URL}/get`,
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -499,14 +494,14 @@ describe('request client', () => {
 
       const body = JSON.parse(response.content);
       body.url.should.eql(
-        'https://httpbin.zapier-tooling.com/get?cool=false&name=zapier&zzz=%5B%5D&yyy=%7B%7D&qqq=%20'
+        `${HTTPBIN_URL}/get?cool=false&name=zapier&zzz=%5B%5D&yyy=%7B%7D&qqq=%20`
       );
     });
 
     it('should not include ? if there are no params after cleaning', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/get',
+        url: `${HTTPBIN_URL}/get`,
         params: {
           something: '',
           cool: '',
@@ -522,7 +517,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+        body.url.should.eql(`${HTTPBIN_URL}/get`);
       });
     });
   });
@@ -541,7 +536,7 @@ describe('request client', () => {
       const subscribeInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(subscribeInput);
       const response = await request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           hookUrl: '{{bundle.targetUrl}}',
@@ -562,7 +557,7 @@ describe('request client', () => {
       const subscribeInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(subscribeInput);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/delete',
+        url: `${HTTPBIN_URL}/delete`,
         method: 'DELETE',
         params: {
           id: '{{bundle.subscribeData.id}}',
@@ -571,7 +566,7 @@ describe('request client', () => {
         const { url } = JSON.parse(response.content);
 
         response.data.args.id.should.deepEqual(['123']);
-        url.should.eql('https://httpbin.zapier-tooling.com/delete?id=123');
+        url.should.eql(`${HTTPBIN_URL}/delete?id=123`);
       });
     });
   });
@@ -591,7 +586,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           number: '{{bundle.inputData.number}}',
@@ -628,7 +623,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           number: 123,
@@ -657,7 +652,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           name: '{{bundle.inputData.name}}',
@@ -677,7 +672,7 @@ describe('request client', () => {
     it('should replace curlies with an empty string by default', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           empty: '{{bundle.inputData.empty}}',
@@ -707,7 +702,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       const response = await request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           message: 'We just got #{{bundle.inputData.resourceId}}',
@@ -733,7 +728,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           message: 'No arrays, thank you: {{bundle.inputData.badData}}',
@@ -758,7 +753,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           streetAddress: '{{bundle.inputData.address.street}}',
@@ -789,7 +784,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       const response = await request({
-        url: 'https://httpbin.zapier-tooling.com/get',
+        url: `${HTTPBIN_URL}/get`,
         method: 'GET',
         params: {
           limit: '{{bundle.meta.limit}}',
@@ -802,7 +797,7 @@ describe('request client', () => {
 
       const { headers } = response.data;
       const { url } = JSON.parse(response.content);
-      url.should.eql('https://httpbin.zapier-tooling.com/get?limit=20&id=123');
+      url.should.eql(`${HTTPBIN_URL}/get?limit=20&id=123`);
       headers.Authorization.should.deepEqual(['Bearer Let me in']);
     });
 
@@ -822,7 +817,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       const response = await request({
-        url: 'https://httpbin.zapier-tooling.com/post',
+        url: `${HTTPBIN_URL}/post`,
         method: 'POST',
         body: {
           arr: 'arr: {{bundle.inputData.arr}}',

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -16,7 +16,7 @@ describe('request client', () => {
 
   it('should include a user-agent header', (done) => {
     const request = createAppRequestClient(input);
-    request({ url: 'https://httpbin.org/get' })
+    request({ url: 'https://httpbin.zapier-tooling.com/get' })
       .then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -24,7 +24,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
+        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
         done();
       })
       .catch(done);
@@ -33,7 +33,7 @@ describe('request client', () => {
   it('should allow overriding the user-agent header', (done) => {
     const request = createAppRequestClient(input);
     request({
-      url: 'https://httpbin.org/get',
+      url: 'https://httpbin.zapier-tooling.com/get',
       headers: {
         'User-Agent': 'Zapier!',
       },
@@ -46,35 +46,33 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
+        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
         done();
       })
       .catch(done);
   });
 
-  it('should have json serializable response', (done) => {
+  it('should have json serializable response', async () => {
     const request = createAppRequestClient(input);
-    request({ url: 'https://httpbin.org/get' })
-      .then((responseBefore) => {
-        const response = JSON.parse(JSON.stringify(responseBefore));
+    const responseBefore = await request({
+      url: 'https://httpbin.zapier-tooling.com/get',
+    });
+    const response = JSON.parse(JSON.stringify(responseBefore));
 
-        response.headers['content-type'].should.eql('application/json');
-        response.status.should.eql(200);
+    response.headers['content-type'].should.containEql('application/json');
+    response.status.should.eql(200);
 
-        const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
-        done();
-      })
-      .catch(done);
+    const body = JSON.parse(response.content);
+    body.url.should.eql('https://httpbin.zapier-tooling.com/get');
   });
 
   it('should wrap a request entirely', (done) => {
     const request = createAppRequestClient(input);
-    request({ url: 'https://httpbin.org/get' })
+    request({ url: 'https://httpbin.zapier-tooling.com/get' })
       .then((response) => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
+        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
         done();
       })
       .catch(done);
@@ -85,7 +83,7 @@ describe('request client', () => {
     const request = createAppRequestClient(input);
     request({
       method: 'POST',
-      url: 'https://httpbin.org/post',
+      url: 'https://httpbin.zapier-tooling.com/post',
       body: Promise.resolve(payload),
     })
       .then((response) => {
@@ -152,32 +150,31 @@ describe('request client', () => {
 
   it('should support single url param', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/get')
+    request('https://httpbin.zapier-tooling.com/get')
       .then((response) => {
         response.status.should.eql(200);
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
+        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
         done();
       })
       .catch(done);
   });
 
-  it('should support url param with options', (done) => {
+  it('should support url param with options', async () => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/get', { headers: { A: 'B' } })
-      .then((response) => {
-        response.status.should.eql(200);
-        const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
-        body.headers.A.should.eql('B');
-        done();
-      })
-      .catch(done);
+    const response = await request('https://httpbin.zapier-tooling.com/get', {
+      headers: { A: 'B' },
+    });
+
+    response.status.should.eql(200);
+    const body = JSON.parse(response.content);
+    body.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    body.headers.A.should.deepEqual(['B']);
   });
 
   it('should support bytes', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/bytes/1024')
+    request('https://httpbin.zapier-tooling.com/bytes/1024')
       .then((response) => {
         response.status.should.eql(200);
         // it tries to decode the bytes /shrug
@@ -189,7 +186,7 @@ describe('request client', () => {
 
   it('should support bytes raw', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/bytes/1024', { raw: true })
+    request('https://httpbin.zapier-tooling.com/bytes/1024', { raw: true })
       .then((response) => {
         response.status.should.eql(200);
         should(response.buffer).be.type('function');
@@ -202,7 +199,7 @@ describe('request client', () => {
 
   it('should support streaming bytes', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/stream-bytes/1024')
+    request('https://httpbin.zapier-tooling.com/stream-bytes/1024')
       .then((response) => {
         response.status.should.eql(200);
         // it tries to decode the bytes /shrug
@@ -214,7 +211,7 @@ describe('request client', () => {
 
   it('should support streaming bytes raw', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/stream-bytes/1024', {
+    request('https://httpbin.zapier-tooling.com/stream-bytes/1024', {
       raw: true,
     })
       .then((response) => {
@@ -229,7 +226,7 @@ describe('request client', () => {
 
   it('should support streaming bytes raw as buffer', (done) => {
     const request = createAppRequestClient(input);
-    request('https://httpbin.org/stream-bytes/1024', {
+    request('https://httpbin.zapier-tooling.com/stream-bytes/1024', {
       raw: true,
     })
       .then((response) => {
@@ -257,7 +254,7 @@ describe('request client', () => {
       testLogger
     );
     const request = createAppRequestClient(inputWithBeforeMiddleware);
-    request({ url: 'https://httpbin.org/get' })
+    request({ url: 'https://httpbin.zapier-tooling.com/get' })
       .then((responseBefore) => {
         const response = JSON.parse(JSON.stringify(responseBefore));
 
@@ -265,7 +262,7 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
+        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
         done();
       })
       .catch(done);
@@ -274,14 +271,14 @@ describe('request client', () => {
   it('should default to run throwForStatus', () => {
     const request = createAppRequestClient(input);
     return request({
-      url: 'https://httpbin.org/status/400',
+      url: 'https://httpbin.zapier-tooling.com/status/400',
     }).should.be.rejectedWith(errors.ResponseError);
   });
 
   it('should be able to skip throwForStatus via request', async () => {
     const request = createAppRequestClient(input);
     const response = await request({
-      url: 'https://httpbin.org/status/400',
+      url: 'https://httpbin.zapier-tooling.com/status/400',
       skipThrowForStatus: true,
     });
     response.status.should.eql(400);
@@ -301,14 +298,16 @@ describe('request client', () => {
       testLogger
     );
     const request = createAppRequestClient(inputWithAfterMiddleware);
-    const response = await request({ url: 'https://httpbin.org/status/400' });
+    const response = await request({
+      url: 'https://httpbin.zapier-tooling.com/status/400',
+    });
     response.status.should.eql(400);
   });
 
-  it('should parse form type request body', (done) => {
+  it('should parse form type request body', async () => {
     const request = createAppRequestClient(input);
-    request({
-      url: 'https://httpbin.org/post',
+    const response = await request({
+      url: 'https://httpbin.zapier-tooling.com/post',
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
@@ -317,41 +316,35 @@ describe('request client', () => {
         name: 'Something Else',
         directions: '!!No Way José',
       },
-    })
-      .then((response) => {
-        response.status.should.eql(200);
-        response.request.body.should.eql(
-          'name=Something+Else&directions=!!No+Way+Jos%C3%A9'
-        );
-        const body = JSON.parse(response.content);
-        body.form.name.should.eql('Something Else');
-        body.form.directions.should.eql('!!No Way José');
-        done();
-      })
-      .catch(done);
+    });
+
+    response.status.should.eql(200);
+    response.request.body.should.eql(
+      'name=Something+Else&directions=!!No+Way+Jos%C3%A9'
+    );
+    const body = JSON.parse(response.content);
+    body.form.name.should.deepEqual(['Something Else']);
+    body.form.directions.should.deepEqual(['!!No Way José']);
   });
 
-  it('should not parse form type request body when string', (done) => {
+  it('should not parse form type request body when string', async () => {
     const request = createAppRequestClient(input);
-    request({
-      url: 'https://httpbin.org/post',
+    const response = await request({
+      url: 'https://httpbin.zapier-tooling.com/post',
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
       },
       body: 'name=Something Else&directions=!!No Way José',
-    })
-      .then((response) => {
-        response.status.should.eql(200);
-        response.request.body.should.eql(
-          'name=Something Else&directions=!!No Way José'
-        );
-        const body = JSON.parse(response.content);
-        body.form.name.should.eql('Something Else');
-        body.form.directions.should.eql('!!No Way José');
-        done();
-      })
-      .catch(done);
+    });
+
+    response.status.should.eql(200);
+    response.request.body.should.eql(
+      'name=Something Else&directions=!!No Way José'
+    );
+    const body = JSON.parse(response.content);
+    body.form.name.should.deepEqual(['Something Else']);
+    body.form.directions.should.deepEqual(['!!No Way José']);
   });
 
   it('should block self-signed SSL certificate', () => {
@@ -374,9 +367,11 @@ describe('request client', () => {
     const newInput = _.cloneDeep(input);
     newInput._zapier.event.verifySSL = false;
     const request = createAppRequestClient(newInput);
-    return request('https://httpbin.org/get').then((response) => {
-      response.status.should.eql(200);
-    });
+    return request('https://httpbin.zapier-tooling.com/get').then(
+      (response) => {
+        response.status.should.eql(200);
+      }
+    );
   });
 
   it('should delete GET body by default', async () => {
@@ -409,34 +404,33 @@ describe('request client', () => {
   });
 
   describe('adds query params', () => {
-    it('should replace remaining curly params with empty string by default', () => {
+    it('should replace remaining curly params with empty string by default', async () => {
       const request = createAppRequestClient(input);
-      return request({
-        url: 'https://httpbin.org/get',
+      const responseBefore = await request({
+        url: 'https://httpbin.zapier-tooling.com/get',
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
           cool: 'true',
         },
-      }).then((responseBefore) => {
-        const response = JSON.parse(JSON.stringify(responseBefore));
-
-        response.data.args.something.should.eql('');
-        response.data.args.really.should.eql('');
-        response.data.args.cool.should.eql('true');
-        response.status.should.eql(200);
-
-        const body = JSON.parse(response.content);
-        body.url.should.eql(
-          'https://httpbin.org/get?something=&really=&cool=true'
-        );
       });
+
+      const response = JSON.parse(JSON.stringify(responseBefore));
+      response.data.args.something.should.deepEqual(['']);
+      response.data.args.really.should.deepEqual(['']);
+      response.data.args.cool.should.deepEqual(['true']);
+      response.status.should.eql(200);
+
+      const body = JSON.parse(response.content);
+      body.url.should.eql(
+        'https://httpbin.zapier-tooling.com/get?something=&really=&cool=true'
+      );
     });
 
-    it('should replace remaining curly params with empty string when set as false', () => {
+    it('should replace remaining curly params with empty string when set as false', async () => {
       const request = createAppRequestClient(input);
-      return request({
-        url: 'https://httpbin.org/get',
+      const responseBefore = await request({
+        url: 'https://httpbin.zapier-tooling.com/get',
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -445,22 +439,21 @@ describe('request client', () => {
         removeMissingValuesFrom: {
           params: false,
         },
-      }).then((responseBefore) => {
-        const response = JSON.parse(JSON.stringify(responseBefore));
-
-        response.data.args.something.should.eql('');
-        response.data.args.really.should.eql('');
-        response.data.args.cool.should.eql('true');
-        response.status.should.eql(200);
-
-        const body = JSON.parse(response.content);
-        body.url.should.eql(
-          'https://httpbin.org/get?something=&really=&cool=true'
-        );
       });
+
+      const response = JSON.parse(JSON.stringify(responseBefore));
+      response.data.args.something.should.deepEqual(['']);
+      response.data.args.really.should.deepEqual(['']);
+      response.data.args.cool.should.deepEqual(['true']);
+      response.status.should.eql(200);
+
+      const body = JSON.parse(response.content);
+      body.url.should.eql(
+        'https://httpbin.zapier-tooling.com/get?something=&really=&cool=true'
+      );
     });
 
-    it('should omit empty params when set as true', () => {
+    it('should omit empty params when set as true', async () => {
       const event = {
         bundle: {
           inputData: {
@@ -472,8 +465,8 @@ describe('request client', () => {
         createInput({}, event, testLogger)
       );
 
-      return request({
-        url: 'https://httpbin.org/get',
+      const responseBefore = await request({
+        url: 'https://httpbin.zapier-tooling.com/get',
         params: {
           something: '',
           really: '{{bundle.inputData.really}}',
@@ -488,32 +481,32 @@ describe('request client', () => {
         removeMissingValuesFrom: {
           params: true,
         },
-      }).then((responseBefore) => {
-        const response = JSON.parse(JSON.stringify(responseBefore));
-
-        should(response.data.args.something).eql(undefined);
-        should(response.data.args.foo).eql(undefined);
-        should(response.data.args.bar).eql(undefined);
-        should(response.data.args.empty).eql(undefined);
-        should(response.data.args.really).eql(undefined);
-        response.data.args.cool.should.eql('false');
-        response.data.args.zzz.should.eql('[]');
-        response.data.args.yyy.should.eql('{}');
-        response.data.args.qqq.should.eql(' ');
-        response.data.args.name.should.eql('zapier');
-        response.status.should.eql(200);
-
-        const body = JSON.parse(response.content);
-        body.url.should.eql(
-          'https://httpbin.org/get?cool=false&name=zapier&zzz=[]&yyy={}&qqq= '
-        );
       });
+
+      const response = JSON.parse(JSON.stringify(responseBefore));
+      should(response.data.args.something).eql(undefined);
+      should(response.data.args.foo).eql(undefined);
+      should(response.data.args.bar).eql(undefined);
+      should(response.data.args.empty).eql(undefined);
+      should(response.data.args.really).eql(undefined);
+
+      response.data.args.cool.should.deepEqual(['false']);
+      response.data.args.zzz.should.deepEqual(['[]']);
+      response.data.args.yyy.should.deepEqual(['{}']);
+      response.data.args.qqq.should.deepEqual([' ']);
+      response.data.args.name.should.deepEqual(['zapier']);
+      response.status.should.eql(200);
+
+      const body = JSON.parse(response.content);
+      body.url.should.eql(
+        'https://httpbin.zapier-tooling.com/get?cool=false&name=zapier&zzz=%5B%5D&yyy=%7B%7D&qqq=%20'
+      );
     });
 
     it('should not include ? if there are no params after cleaning', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'https://httpbin.org/get',
+        url: 'https://httpbin.zapier-tooling.com/get',
         params: {
           something: '',
           cool: '',
@@ -529,13 +522,13 @@ describe('request client', () => {
         response.status.should.eql(200);
 
         const body = JSON.parse(response.content);
-        body.url.should.eql('https://httpbin.org/get');
+        body.url.should.eql('https://httpbin.zapier-tooling.com/get');
       });
     });
   });
 
   describe('shorthand hook subscriptions', () => {
-    it('should resolve bundle tokens in performSubscribe', () => {
+    it('should resolve bundle tokens in performSubscribe', async () => {
       const targetUrl = 'https://zapier.com/hooks';
       const event = {
         bundle: {
@@ -547,19 +540,18 @@ describe('request client', () => {
       };
       const subscribeInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(subscribeInput);
-      return request({
-        url: 'https://httpbin.org/post',
+      const response = await request({
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           hookUrl: '{{bundle.targetUrl}}',
           zapId: '{{bundle.meta.zap.id}}',
         },
-      }).then((response) => {
-        const { hookUrl, zapId } = JSON.parse(response.data.data);
-
-        hookUrl.should.eql(targetUrl);
-        zapId.should.eql(987);
       });
+
+      const { hookUrl, zapId } = JSON.parse(response.data.data);
+      hookUrl.should.eql(targetUrl);
+      zapId.should.eql(987);
     });
 
     it('should resolve bundle tokens in performUnubscribe', () => {
@@ -570,7 +562,7 @@ describe('request client', () => {
       const subscribeInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(subscribeInput);
       return request({
-        url: 'https://httpbin.org/delete',
+        url: 'https://httpbin.zapier-tooling.com/delete',
         method: 'DELETE',
         params: {
           id: '{{bundle.subscribeData.id}}',
@@ -578,8 +570,8 @@ describe('request client', () => {
       }).then((response) => {
         const { url } = JSON.parse(response.content);
 
-        response.data.args.id.should.eql('123');
-        url.should.eql('https://httpbin.org/delete?id=123');
+        response.data.args.id.should.deepEqual(['123']);
+        url.should.eql('https://httpbin.zapier-tooling.com/delete?id=123');
       });
     });
   });
@@ -599,7 +591,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.org/post',
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           number: '{{bundle.inputData.number}}',
@@ -636,7 +628,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.org/post',
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           number: 123,
@@ -665,7 +657,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.org/post',
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           name: '{{bundle.inputData.name}}',
@@ -685,7 +677,7 @@ describe('request client', () => {
     it('should replace curlies with an empty string by default', () => {
       const request = createAppRequestClient(input);
       return request({
-        url: 'https://httpbin.org/post',
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           empty: '{{bundle.inputData.empty}}',
@@ -701,7 +693,7 @@ describe('request client', () => {
       });
     });
 
-    it('should interpolate strings', () => {
+    it('should interpolate strings', async () => {
       const event = {
         bundle: {
           inputData: {
@@ -714,8 +706,8 @@ describe('request client', () => {
       };
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
-      return request({
-        url: 'https://httpbin.org/post',
+      const response = await request({
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           message: 'We just got #{{bundle.inputData.resourceId}}',
@@ -723,12 +715,11 @@ describe('request client', () => {
         headers: {
           Authorization: 'Bearer {{bundle.authData.access_token}}',
         },
-      }).then((response) => {
-        const { json, headers } = response.data;
-
-        json.message.should.eql('We just got #123');
-        headers.Authorization.should.eql('Bearer Let me in');
       });
+
+      const { json, headers } = response.data;
+      json.message.should.eql('We just got #123');
+      headers.Authorization.should.deepEqual(['Bearer Let me in']);
     });
 
     it('should throw when interpolating a string with an array', () => {
@@ -742,7 +733,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.org/post',
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           message: 'No arrays, thank you: {{bundle.inputData.badData}}',
@@ -767,7 +758,7 @@ describe('request client', () => {
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
       return request({
-        url: 'https://httpbin.org/post',
+        url: 'https://httpbin.zapier-tooling.com/post',
         method: 'POST',
         body: {
           streetAddress: '{{bundle.inputData.address.street}}',
@@ -781,7 +772,7 @@ describe('request client', () => {
       });
     });
 
-    it('should resolve all bundle fields', () => {
+    it('should resolve all bundle fields', async () => {
       const event = {
         bundle: {
           inputData: {
@@ -797,8 +788,8 @@ describe('request client', () => {
       };
       const bodyInput = createInput({}, event, testLogger);
       const request = createAppRequestClient(bodyInput);
-      return request({
-        url: 'https://httpbin.org/get',
+      const response = await request({
+        url: 'https://httpbin.zapier-tooling.com/get',
         method: 'GET',
         params: {
           limit: '{{bundle.meta.limit}}',
@@ -807,12 +798,12 @@ describe('request client', () => {
         headers: {
           Authorization: 'Bearer {{bundle.authData.access_token}}',
         },
-      }).then((response) => {
-        const { headers } = response.data;
-        const { url } = JSON.parse(response.content);
-        url.should.eql('https://httpbin.org/get?limit=20&id=123');
-        headers.Authorization.should.eql('Bearer Let me in');
       });
+
+      const { headers } = response.data;
+      const { url } = JSON.parse(response.content);
+      url.should.eql('https://httpbin.zapier-tooling.com/get?limit=20&id=123');
+      headers.Authorization.should.deepEqual(['Bearer Let me in']);
     });
 
     it('should be able to interpolate arrays/objects to a string', async () => {

--- a/packages/core/test/errors.js
+++ b/packages/core/test/errors.js
@@ -32,7 +32,7 @@ describe('errors', () => {
         },
         content: '',
         request: {
-          url: 'https://httpbin.org/status/400',
+          url: 'https://httpbin.zapier-tooling.com/status/400',
         },
       };
       const error = new errors.ResponseError(response);
@@ -40,7 +40,7 @@ describe('errors', () => {
       error.should.instanceOf(errors.ResponseError);
       error.name.should.eql('ResponseError');
       error.message.should.eql(
-        '{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"https://httpbin.org/status/400"}}'
+        '{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"https://httpbin.zapier-tooling.com/status/400"}}'
       );
     });
   });

--- a/packages/core/test/errors.js
+++ b/packages/core/test/errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const errors = require('../src/errors');
+const { HTTPBIN_URL } = require('./constants');
 
 describe('errors', () => {
   it('should name errors', () => {
@@ -32,7 +33,7 @@ describe('errors', () => {
         },
         content: '',
         request: {
-          url: 'https://httpbin.zapier-tooling.com/status/400',
+          url: `${HTTPBIN_URL}/status/400`,
         },
       };
       const error = new errors.ResponseError(response);
@@ -40,7 +41,7 @@ describe('errors', () => {
       error.should.instanceOf(errors.ResponseError);
       error.name.should.eql('ResponseError');
       error.message.should.eql(
-        '{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"https://httpbin.zapier-tooling.com/status/400"}}'
+        `{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"${HTTPBIN_URL}/status/400"}}`
       );
     });
   });

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -20,7 +20,7 @@ const oauth1SignRequest = require('../src/http-middlewares/before/oauth1-sign-re
 const { parseDictHeader } = require('../src/tools/http');
 
 describe('http requests', () => {
-  it('should support async before middleware', (done) => {
+  it('should support async before middleware', async () => {
     const addRequestHeader = (req) => {
       if (!req.headers) {
         req.headers = {};
@@ -36,18 +36,16 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.org/get' })
-      .then((response) => {
-        response.status.should.eql(200);
-        JSON.parse(response.content).headers.Customheader.should.eql(
-          'custom value'
-        );
-        done();
-      })
-      .catch(done);
+    const response = await wrappedRequest({
+      url: 'https://httpbin.zapier-tooling.com/get',
+    });
+    response.status.should.eql(200);
+    JSON.parse(response.content).headers.Customheader.should.deepEqual([
+      'custom value',
+    ]);
   });
 
-  it('should support sync before middleware', (done) => {
+  it('should support sync before middleware', async () => {
     const addRequestHeader = (req) => {
       if (!req.headers) {
         req.headers = {};
@@ -63,15 +61,13 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.org/get' })
-      .then((response) => {
-        response.status.should.eql(200);
-        JSON.parse(response.content).headers.Customheader.should.eql(
-          'custom value'
-        );
-        done();
-      })
-      .catch(done);
+    const response = await wrappedRequest({
+      url: 'https://httpbin.zapier-tooling.com/get',
+    });
+    response.status.should.eql(200);
+    JSON.parse(response.content).headers.Customheader.should.eql([
+      'custom value',
+    ]);
   });
 
   it('should throw error when middleware does not return object', (done) => {
@@ -89,10 +85,12 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.org/get' }).catch((err) => {
-      err.message.should.containEql('Middleware should return an object.');
-      done();
-    });
+    wrappedRequest({ url: 'https://httpbin.zapier-tooling.com/get' }).catch(
+      (err) => {
+        err.message.should.containEql('Middleware should return an object.');
+        done();
+      }
+    );
   });
 
   it('should support async after middleware', (done) => {
@@ -110,7 +108,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.org/get' })
+    wrappedRequest({ url: 'https://httpbin.zapier-tooling.com/get' })
       .then((response) => {
         response.status.should.eql(200);
         should.not.exist(response.results); // should not be 'enveloped'
@@ -135,7 +133,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.org/get' })
+    wrappedRequest({ url: 'https://httpbin.zapier-tooling.com/get' })
       .then((response) => {
         response.status.should.eql(200);
         JSON.parse(response.content).customKey.should.eql('custom value');
@@ -425,23 +423,24 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     await request({
-      url: 'https://httpbin.org/status/400',
+      url: 'https://httpbin.zapier-tooling.com/status/400',
     }).should.be.rejectedWith(errors.ResponseError, {
       name: 'ResponseError',
       doNotContextify: true,
       message:
-        '{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"https://httpbin.org/status/400"}}',
+        '{"status":400,"headers":{"content-type":null},"content":"","request":{"url":"https://httpbin.zapier-tooling.com/status/400"}}',
     });
   });
+
   it('does not throw for redirects (which we follow)', async () => {
     const testLogger = () => Promise.resolve({});
     const input = createInput({}, {}, testLogger);
     const request = createAppRequestClient(input);
 
     const response = await request({
-      url: 'https://httpbin.org/redirect-to',
+      url: 'https://httpbin.zapier-tooling.com/redirect-to',
       params: {
-        url: 'https://httpbin.org/status/200',
+        url: 'https://httpbin.zapier-tooling.com/status/200',
       },
     });
 
@@ -453,7 +452,7 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     const response = await request({
-      url: 'https://httpbin.org/status/200',
+      url: 'https://httpbin.zapier-tooling.com/status/200',
     });
 
     response.status.should.equal(200);
@@ -464,7 +463,7 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     const response = await request({
-      url: 'https://httpbin.org/status/600',
+      url: 'https://httpbin.zapier-tooling.com/status/600',
     });
 
     response.status.should.equal(600);

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -18,6 +18,7 @@ const prepareResponse = require('../src/http-middlewares/after/prepare-response'
 const applyMiddleware = require('../src/middleware');
 const oauth1SignRequest = require('../src/http-middlewares/before/oauth1-sign-request');
 const { parseDictHeader } = require('../src/tools/http');
+const { HTTPBIN_URL } = require('./constants');
 
 describe('http requests', () => {
   it('should support async before middleware', async () => {
@@ -36,9 +37,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    const response = await wrappedRequest({
-      url: 'https://httpbin.zapier-tooling.com/get',
-    });
+    const response = await wrappedRequest({ url: `${HTTPBIN_URL}/get` });
     response.status.should.eql(200);
     JSON.parse(response.content).headers.Customheader.should.deepEqual([
       'custom value',
@@ -62,7 +61,7 @@ describe('http requests', () => {
     );
 
     const response = await wrappedRequest({
-      url: 'https://httpbin.zapier-tooling.com/get',
+      url: `${HTTPBIN_URL}/get`,
     });
     response.status.should.eql(200);
     JSON.parse(response.content).headers.Customheader.should.eql([
@@ -85,12 +84,10 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.zapier-tooling.com/get' }).catch(
-      (err) => {
-        err.message.should.containEql('Middleware should return an object.');
-        done();
-      }
-    );
+    wrappedRequest({ url: `${HTTPBIN_URL}/get` }).catch((err) => {
+      err.message.should.containEql('Middleware should return an object.');
+      done();
+    });
   });
 
   it('should support async after middleware', (done) => {
@@ -108,7 +105,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.zapier-tooling.com/get' })
+    wrappedRequest({ url: `${HTTPBIN_URL}/get` })
       .then((response) => {
         response.status.should.eql(200);
         should.not.exist(response.results); // should not be 'enveloped'
@@ -133,7 +130,7 @@ describe('http requests', () => {
       { skipEnvelope: true }
     );
 
-    wrappedRequest({ url: 'https://httpbin.zapier-tooling.com/get' })
+    wrappedRequest({ url: `${HTTPBIN_URL}/get` })
       .then((response) => {
         response.status.should.eql(200);
         JSON.parse(response.content).customKey.should.eql('custom value');
@@ -352,7 +349,7 @@ describe('http addBasicAuthHeader before middelware', () => {
 describe('http addDigestAuthHeader before middleware', () => {
   it('computes the Authorization header', async () => {
     const origReq = {
-      url: 'https://httpbin.zapier-tooling.com/digest-auth/auth/joe/mypass/MD5',
+      url: `${HTTPBIN_URL}/digest-auth/auth/joe/mypass/MD5`,
       headers: {},
     };
     const z = {};
@@ -423,12 +420,11 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     await request({
-      url: 'https://httpbin.zapier-tooling.com/status/400',
+      url: `${HTTPBIN_URL}/status/400`,
     }).should.be.rejectedWith(errors.ResponseError, {
       name: 'ResponseError',
       doNotContextify: true,
-      message:
-        '{"status":400,"headers":{"content-type":null},"content":"","request":{"url":"https://httpbin.zapier-tooling.com/status/400"}}',
+      message: `{"status":400,"headers":{"content-type":null},"content":"","request":{"url":"${HTTPBIN_URL}/status/400"}}`,
     });
   });
 
@@ -438,9 +434,9 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/redirect-to',
+      url: `${HTTPBIN_URL}/redirect-to`,
       params: {
-        url: 'https://httpbin.zapier-tooling.com/status/200',
+        url: `${HTTPBIN_URL}/status/200`,
       },
     });
 
@@ -452,7 +448,7 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/status/200',
+      url: `${HTTPBIN_URL}/status/200`,
     });
 
     response.status.should.equal(200);
@@ -463,7 +459,7 @@ describe('http throwForStatus after middleware', () => {
     const request = createAppRequestClient(input);
 
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/status/600',
+      url: `${HTTPBIN_URL}/status/600`,
     });
 
     response.status.should.equal(600);
@@ -480,7 +476,7 @@ describe('http logResponse after middleware', () => {
   const request = createAppRequestClient(input);
 
   it('post JSON data', async () => {
-    const url = 'https://httpbin.zapier-tooling.com/post';
+    const url = `${HTTPBIN_URL}/post`;
     await request({ method: 'POST', url, body: { foo: 'bar' } });
 
     logged.message.should.equal(`200 POST ${url}`);
@@ -502,7 +498,7 @@ describe('http logResponse after middleware', () => {
   });
 
   it('upload file in form data', async () => {
-    const url = 'https://httpbin.zapier-tooling.com/post';
+    const url = `${HTTPBIN_URL}/post`;
 
     const form = new FormData();
     form.append('filename', 'sample.txt');

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -10,28 +10,27 @@ const {
 
 describe('logger', () => {
   const options = {
-    endpoint: 'https://httpbin.org/post',
+    endpoint: 'https://httpbin.zapier-tooling.com/post',
     token: 'fake-token',
   };
 
   // httpbin/post echoes all the input body and headers in the response
 
-  it('should log to graylog', () => {
+  it('should log to graylog', async () => {
     const event = {};
     const logger = createlogger(event, options);
     const data = { key: 'val' };
 
-    return logger('test', data).then((response) => {
-      response.headers.get('content-type').should.eql('application/json');
-      response.status.should.eql(200);
-      response.content.json.should.eql({
-        token: options.token,
-        message: 'test',
-        data: {
-          log_type: 'console',
-          key: 'val',
-        },
-      });
+    const response = await logger('test', data);
+    response.headers.get('content-type').should.containEql('application/json');
+    response.status.should.eql(200);
+    response.content.json.should.eql({
+      token: options.token,
+      message: 'test',
+      data: {
+        log_type: 'console',
+        key: 'val',
+      },
     });
   });
 

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -7,10 +7,11 @@ const { Headers } = require('node-fetch');
 const {
   replaceHeaders,
 } = require('../src/http-middlewares/after/middleware-utils');
+const { HTTPBIN_URL } = require('./constants');
 
 describe('logger', () => {
   const options = {
-    endpoint: 'https://httpbin.zapier-tooling.com/post',
+    endpoint: `${HTTPBIN_URL}/post`,
     token: 'fake-token',
   };
 

--- a/packages/core/test/request-client-internal.js
+++ b/packages/core/test/request-client-internal.js
@@ -4,51 +4,50 @@ const should = require('should');
 const request = require('../src/tools/request-client-internal');
 
 describe('http requests', () => {
-  it('should make GET requests', (done) => {
-    request({ url: 'https://httpbin.org/get' })
-      .then((response) => {
-        response.status.should.eql(200);
-        should.exist(response.content);
-        // httpbin capitalizes the response header name
-        should.exist(response.content.headers['User-Agent']);
-        response.content.headers['User-Agent']
-          .includes('zapier-platform-core/')
-          .should.be.true();
-        response.content.url.should.eql('https://httpbin.org/get');
-        done();
-      })
-      .catch(done);
+  it('should make GET requests', async () => {
+    const response = await request({
+      url: 'https://httpbin.zapier-tooling.com/get',
+    });
+    response.status.should.eql(200);
+    should.exist(response.content);
+    // httpbin capitalizes the response header name
+    should.exist(response.content.headers['User-Agent']);
+    response.content.headers['User-Agent'][0]
+      .includes('zapier-platform-core/')
+      .should.be.true();
+    response.content.url.should.eql('https://httpbin.zapier-tooling.com/get');
   });
 
   it('should make GET with url sugar param', (done) => {
-    request('https://httpbin.org/get')
+    request('https://httpbin.zapier-tooling.com/get')
       .then((response) => {
         response.status.should.eql(200);
         should.exist(response.content);
-        response.content.url.should.eql('https://httpbin.org/get');
+        response.content.url.should.eql(
+          'https://httpbin.zapier-tooling.com/get'
+        );
         done();
       })
       .catch(done);
   });
 
-  it('should make GET with url sugar param and options', (done) => {
+  it('should make GET with url sugar param and options', async () => {
     const options = { headers: { A: 'B', 'user-agent': 'cool thing' } };
-    request('https://httpbin.org/get', options)
-      .then((response) => {
-        response.status.should.eql(200);
-        should.exist(response.content);
-        response.content.url.should.eql('https://httpbin.org/get');
-        response.content.headers.A.should.eql('B');
-        // don't clobber other internal user-agent headers if we decide to use them
-        response.content.headers['User-Agent'].should.eql('cool thing');
-        done();
-      })
-      .catch(done);
+    const response = await request(
+      'https://httpbin.zapier-tooling.com/get',
+      options
+    );
+    response.status.should.eql(200);
+    should.exist(response.content);
+    response.content.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    response.content.headers.A.should.deepEqual(['B']);
+    // don't clobber other internal user-agent headers if we decide to use them
+    response.content.headers['User-Agent'].should.deepEqual(['cool thing']);
   });
 
   it('should make POST requests', (done) => {
     request({
-      url: 'https://httpbin.org/post',
+      url: 'https://httpbin.zapier-tooling.com/post',
       method: 'POST',
       body: 'test',
     })

--- a/packages/core/test/request-client-internal.js
+++ b/packages/core/test/request-client-internal.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const should = require('should');
+
 const request = require('../src/tools/request-client-internal');
+const { HTTPBIN_URL } = require('./constants');
 
 describe('http requests', () => {
   it('should make GET requests', async () => {
     const response = await request({
-      url: 'https://httpbin.zapier-tooling.com/get',
+      url: `${HTTPBIN_URL}/get`,
     });
     response.status.should.eql(200);
     should.exist(response.content);
@@ -15,17 +17,15 @@ describe('http requests', () => {
     response.content.headers['User-Agent'][0]
       .includes('zapier-platform-core/')
       .should.be.true();
-    response.content.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    response.content.url.should.eql(`${HTTPBIN_URL}/get`);
   });
 
   it('should make GET with url sugar param', (done) => {
-    request('https://httpbin.zapier-tooling.com/get')
+    request(`${HTTPBIN_URL}/get`)
       .then((response) => {
         response.status.should.eql(200);
         should.exist(response.content);
-        response.content.url.should.eql(
-          'https://httpbin.zapier-tooling.com/get'
-        );
+        response.content.url.should.eql(`${HTTPBIN_URL}/get`);
         done();
       })
       .catch(done);
@@ -33,13 +33,10 @@ describe('http requests', () => {
 
   it('should make GET with url sugar param and options', async () => {
     const options = { headers: { A: 'B', 'user-agent': 'cool thing' } };
-    const response = await request(
-      'https://httpbin.zapier-tooling.com/get',
-      options
-    );
+    const response = await request(`${HTTPBIN_URL}/get`, options);
     response.status.should.eql(200);
     should.exist(response.content);
-    response.content.url.should.eql('https://httpbin.zapier-tooling.com/get');
+    response.content.url.should.eql(`${HTTPBIN_URL}/get`);
     response.content.headers.A.should.deepEqual(['B']);
     // don't clobber other internal user-agent headers if we decide to use them
     response.content.headers['User-Agent'].should.deepEqual(['cool thing']);
@@ -47,7 +44,7 @@ describe('http requests', () => {
 
   it('should make POST requests', (done) => {
     request({
-      url: 'https://httpbin.zapier-tooling.com/post',
+      url: `${HTTPBIN_URL}/post`,
       method: 'POST',
       body: 'test',
     })

--- a/packages/core/test/tools/file-stasher.js
+++ b/packages/core/test/tools/file-stasher.js
@@ -94,9 +94,12 @@ describe('file upload', () => {
     mocky.mockUpload();
 
     const request = createAppRequestClient(input);
-    const file = request('https://httpbin.org/stream-bytes/1024', {
-      raw: true,
-    });
+    const file = request(
+      'https://httpbin.zapier-tooling.com/stream-bytes/1024',
+      {
+        raw: true,
+      }
+    );
     stashFile(file)
       .then((url) => {
         should(url).eql(
@@ -222,7 +225,7 @@ describe('file upload', () => {
 
     const request = createAppRequestClient(input);
     const file = request({
-      url: 'https://httpbin.org/response-headers',
+      url: 'https://httpbin.zapier-tooling.com/response-headers',
       params: {
         'Content-Disposition': 'inline; filename="an example.json"',
       },

--- a/packages/core/test/tools/file-stasher.js
+++ b/packages/core/test/tools/file-stasher.js
@@ -11,6 +11,7 @@ const mocky = require('./mocky');
 const createFileStasher = require('../../src/tools/create-file-stasher');
 const createAppRequestClient = require('../../src/tools/create-app-request-client');
 const createInput = require('../../src/tools/create-input');
+const { HTTPBIN_URL } = require('../constants');
 
 describe('file upload', () => {
   const testLogger = () => Promise.resolve({});
@@ -94,12 +95,9 @@ describe('file upload', () => {
     mocky.mockUpload();
 
     const request = createAppRequestClient(input);
-    const file = request(
-      'https://httpbin.zapier-tooling.com/stream-bytes/1024',
-      {
-        raw: true,
-      }
-    );
+    const file = request(`${HTTPBIN_URL}/stream-bytes/1024`, {
+      raw: true,
+    });
     stashFile(file)
       .then((url) => {
         should(url).eql(
@@ -225,7 +223,7 @@ describe('file upload', () => {
 
     const request = createAppRequestClient(input);
     const file = request({
-      url: 'https://httpbin.zapier-tooling.com/response-headers',
+      url: `${HTTPBIN_URL}/response-headers`,
       params: {
         'Content-Disposition': 'inline; filename="an example.json"',
       },

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -1,6 +1,6 @@
 // an example app!
 
-process.env.BASE_URL = 'https://httpbin.org';
+process.env.BASE_URL = 'https://httpbin.zapier-tooling.com';
 
 const _ = require('lodash');
 const helpers = require('./helpers');
@@ -148,9 +148,11 @@ const RequestSugar = {
     },
     operation: {
       perform: (z /* , bundle */) => {
-        return z.request('https://httpbin.org/get').then((resp) => {
-          return resp.data;
-        });
+        return z
+          .request('https://httpbin.zapier-tooling.com/get')
+          .then((resp) => {
+            return resp.data;
+          });
       },
     },
   },
@@ -214,7 +216,7 @@ const FailerHttp = {
     },
     operation: {
       perform: {
-        url: 'https://httpbin.org/status/403',
+        url: 'https://httpbin.zapier-tooling.com/status/403',
       },
     },
   },
@@ -440,7 +442,7 @@ const ExecuteRequestAsShorthand = {
       inputFields: [
         {
           key: 'url',
-          default: 'https://httpbin.org/status/403',
+          default: 'https://httpbin.zapier-tooling.com/status/403',
         },
       ],
     },
@@ -457,7 +459,7 @@ const ExecuteRequestAsShorthand = {
       inputFields: [
         {
           key: 'url',
-          default: 'https://httpbin.org/status/403',
+          default: 'https://httpbin.zapier-tooling.com/status/403',
         },
       ],
     },

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -1,9 +1,12 @@
-// an example app!
+'use strict';
 
-process.env.BASE_URL = 'https://httpbin.zapier-tooling.com';
+// an example app!
 
 const _ = require('lodash');
 const helpers = require('./helpers');
+const { HTTPBIN_URL } = require('../constants');
+
+process.env.BASE_URL = HTTPBIN_URL;
 
 const List = {
   key: 'list',
@@ -148,11 +151,9 @@ const RequestSugar = {
     },
     operation: {
       perform: (z /* , bundle */) => {
-        return z
-          .request('https://httpbin.zapier-tooling.com/get')
-          .then((resp) => {
-            return resp.data;
-          });
+        return z.request(`${HTTPBIN_URL}/get`).then((resp) => {
+          return resp.data;
+        });
       },
     },
   },
@@ -216,7 +217,7 @@ const FailerHttp = {
     },
     operation: {
       perform: {
-        url: 'https://httpbin.zapier-tooling.com/status/403',
+        url: `${HTTPBIN_URL}/status/403`,
       },
     },
   },
@@ -442,7 +443,7 @@ const ExecuteRequestAsShorthand = {
       inputFields: [
         {
           key: 'url',
-          default: 'https://httpbin.zapier-tooling.com/status/403',
+          default: `${HTTPBIN_URL}/status/403`,
         },
       ],
     },
@@ -459,7 +460,7 @@ const ExecuteRequestAsShorthand = {
       inputFields: [
         {
           key: 'url',
-          default: 'https://httpbin.zapier-tooling.com/status/403',
+          default: `${HTTPBIN_URL}/status/403`,
         },
       ],
     },

--- a/packages/legacy-scripting-runner/test/constants.js
+++ b/packages/legacy-scripting-runner/test/constants.js
@@ -2,6 +2,10 @@ const AUTH_JSON_SERVER_URL =
   process.env.AUTH_JSON_SERVER_URL ||
   'https://auth-json-server.zapier-staging.com';
 
+const HTTPBIN_URL =
+  process.env.HTTPBIN_URL || 'https://httpbin.zapier-tooling.com';
+
 module.exports = {
   AUTH_JSON_SERVER_URL,
+  HTTPBIN_URL,
 };

--- a/packages/legacy-scripting-runner/test/example-app/api-key-auth.js
+++ b/packages/legacy-scripting-runner/test/example-app/api-key-auth.js
@@ -1,4 +1,4 @@
-const { AUTH_JSON_SERVER_URL } = require('../auth-json-server');
+const { AUTH_JSON_SERVER_URL } = require('../constants');
 
 const testAuthSource = `
   const responsePromise = z.request({

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -1,4 +1,4 @@
-const { AUTH_JSON_SERVER_URL } = require('../auth-json-server');
+const { AUTH_JSON_SERVER_URL, HTTPBIN_URL } = require('../constants');
 
 const legacyScriptingSource = `
     var qs = require('querystring');
@@ -56,12 +56,12 @@ const legacyScriptingSource = `
       },
 
       pre_oauthv2_refresh_httpbin_form: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         return bundle.request;
       },
 
       pre_oauthv2_refresh_httpbin_json: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.headers['Content-Type'] = 'application/json';
         return bundle.request;
       },
@@ -78,7 +78,7 @@ const legacyScriptingSource = `
         bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
 
         return {
-          url: 'https://httpbin.zapier-tooling.com/post',
+          url: '${HTTPBIN_URL}/post',
           method: bundle.request.method,
           headers: bundle.request.headers,
           data: bundle.request.data
@@ -86,7 +86,7 @@ const legacyScriptingSource = `
       },
 
       pre_oauthv2_refresh_bundle_load: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = qs.stringify(bundle.load);
         bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
         return bundle.request;
@@ -194,7 +194,7 @@ const legacyScriptingSource = `
       movie_pre_poll_default_headers: function(bundle) {
         // Copy Accept and Content-Type to params so we know they're already
         // available in pre_poll
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        bundle.request.url = '${HTTPBIN_URL}/get';
         bundle.request.params.accept = bundle.request.headers.Accept;
         bundle.request.params.contentType = bundle.request.headers['Content-Type'];
         return bundle.request;
@@ -202,7 +202,7 @@ const legacyScriptingSource = `
 
       movie_pre_poll_dynamic_dropdown: function(bundle) {
         bundle.request.method = 'POST';
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
 
         // bundle.trigger_fields should be the values of the input fields of the
         // action/search/trigger that pulls the dynamic dropdown. Send it to
@@ -212,7 +212,7 @@ const legacyScriptingSource = `
       },
 
       movie_pre_poll_null_request_data: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        bundle.request.url = '${HTTPBIN_URL}/get';
         bundle.request.params.requestDataIsNull =
           bundle.request.data === null ? 'yes' : 'no';
         return bundle.request;
@@ -220,14 +220,14 @@ const legacyScriptingSource = `
 
       movie_pre_poll_bundle_meta: function(bundle) {
         bundle.request.method = 'POST';
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify(bundle.meta);
         return bundle.request;
       },
 
       movie_pre_poll_request_options: function(bundle) {
         bundle.request.method = 'POST';
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.headers.foo = '1234';
         bundle.request.params.bar = '5678';
         bundle.request.data = '{"aa":"bb"}';
@@ -236,13 +236,13 @@ const legacyScriptingSource = `
 
       movie_pre_poll_invalid_chars_in_headers: function(bundle) {
         bundle.request.headers['x-api-key'] = ' \\t\\n\\r H\\t E \\nY \\r\\n\\t ';
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        bundle.request.url = '${HTTPBIN_URL}/get';
         return bundle.request;
       },
 
       movie_pre_poll_number_header: function(bundle) {
         bundle.request.headers['x-api-key'] = Math.floor( Date.now() / 1000 )
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        bundle.request.url = '${HTTPBIN_URL}/get';
         return bundle.request;
       },
 
@@ -289,7 +289,7 @@ const legacyScriptingSource = `
       movie_poll_default_headers: function(bundle) {
         // Copy Accept and Content-Type to params so we know they're already
         // available in pre_poll
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/get';
+        bundle.request.url = '${HTTPBIN_URL}/get';
         bundle.request.params.accept = bundle.request.headers.Accept;
         bundle.request.params.contentType = bundle.request.headers['Content-Type'];
 
@@ -472,7 +472,7 @@ const legacyScriptingSource = `
       movie_pre_write_unflatten: function(bundle) {
         // Make sure bundle.action_fields is unflatten, bundle.action_fields_full
         // isn't, and bundle.action_fields_raw still got curlies
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({
           action_fields: bundle.action_fields,
           action_fields_full: bundle.action_fields_full,
@@ -485,7 +485,7 @@ const legacyScriptingSource = `
       movie_pre_write_action_fields: function(bundle) {
         // Make sure bundle.action_fields is filtered, bundle.action_fields_full
         // isn't, and bundle.action_fields_raw still got curlies
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({
           action_fields: bundle.action_fields,
           action_fields_full: bundle.action_fields_full,
@@ -519,7 +519,7 @@ const legacyScriptingSource = `
       },
 
       movie_pre_write_intercept_error: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/status/418';
+        bundle.request.url = '${HTTPBIN_URL}/status/418';
         return bundle.request;
       },
 
@@ -533,7 +533,7 @@ const legacyScriptingSource = `
       movie_pre_write_default_headers: function(bundle) {
         // Copy Accept and Content-Type to request body so we know they're
         // already available in pre_write
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({
           accept: bundle.request.headers.Accept,
           contentType: bundle.request.headers['Content-Type']
@@ -561,12 +561,12 @@ const legacyScriptingSource = `
       },
 
       movie_pre_write_no_content: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/status/204';
+        bundle.request.url = '${HTTPBIN_URL}/status/204';
         return bundle.request;
       },
 
       movie_write_default_headers: function(bundle) {
-        bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+        bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({
           accept: bundle.request.headers.Accept,
           contentType: bundle.request.headers['Content-Type']
@@ -716,7 +716,7 @@ const legacyScriptingSource = `
 
       // To be replaced with 'file_pre_write' at runtime
       file_pre_write_fully_replace_url: function(bundle) {
-        bundle.request.files.file = 'https://httpbin.zapier-tooling.com/image/jpeg';
+        bundle.request.files.file = '${HTTPBIN_URL}/image/jpeg';
         return bundle.request;
       },
 
@@ -728,21 +728,21 @@ const legacyScriptingSource = `
 
       file_pre_write_content_dispoistion_with_quotes: function(bundle) {
         bundle.request.files.file =
-          'https://httpbin.zapier-tooling.com/response-headers?' +
+          '${HTTPBIN_URL}/response-headers?' +
           'Content-Disposition=filename=%22an%20example.json%22';
         return bundle.request;
       },
 
       file_pre_write_content_dispoistion_no_quotes: function(bundle) {
         bundle.request.files.file =
-          'https://httpbin.zapier-tooling.com/response-headers?' +
+          '${HTTPBIN_URL}/response-headers?' +
           'Content-Disposition=filename=example.json';
         return bundle.request;
       },
 
       file_pre_write_content_dispoistion_non_ascii: function(bundle) {
         bundle.request.files.file =
-          'https://httpbin.zapier-tooling.com/response-headers?' +
+          '${HTTPBIN_URL}/response-headers?' +
           'Content-Disposition=filename*=UTF-8%27%27%25E4%25B8%25AD%25E6%2596%2587.json';
         return bundle.request;
       },
@@ -1209,9 +1209,8 @@ const App = {
   legacy: {
     scriptingSource: legacyScriptingSource,
 
-    subscribeUrl: 'https://httpbin.zapier-tooling.com/post',
-    unsubscribeUrl:
-      'https://httpbin.zapier-tooling.com/delete?sub_id={{subscription_id}}',
+    subscribeUrl: `${HTTPBIN_URL}/post`,
+    unsubscribeUrl: `${HTTPBIN_URL}/delete?sub_id={{subscription_id}}`,
 
     authentication: {
       oauth2Config: {

--- a/packages/legacy-scripting-runner/test/example-app/oauth2.js
+++ b/packages/legacy-scripting-runner/test/example-app/oauth2.js
@@ -1,4 +1,4 @@
-const { AUTH_JSON_SERVER_URL } = require('../auth-json-server');
+const { AUTH_JSON_SERVER_URL } = require('../constants');
 
 const testAuthSource = `
   const responsePromise = z.request({

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const should = require('should');
 const nock = require('nock');
 
-const { AUTH_JSON_SERVER_URL } = require('./auth-json-server');
+const { AUTH_JSON_SERVER_URL, HTTPBIN_URL } = require('./constants');
 const apiKeyAuth = require('./example-app/api-key-auth');
 const appDefinition = require('./example-app');
 const oauth2Config = require('./example-app/oauth2');
@@ -429,8 +429,7 @@ describe('Integration Test', () => {
         'movie_post_poll_make_array',
         'recipe_post_poll'
       );
-      appDef.legacy.triggers.recipe.operation.url =
-        'https://httpbin.zapier-tooling.com/get?name={{name}}&active={{active}}';
+      appDef.legacy.triggers.recipe.operation.url = `${HTTPBIN_URL}/get?name={{name}}&active={{active}}`;
       const _compiledApp = schemaTools.prepareApp(appDef);
       const _app = createApp(appDef);
 
@@ -443,10 +442,7 @@ describe('Integration Test', () => {
       return _app(input).then((output) => {
         const echoed = output.results[0];
         should.deepEqual(echoed.args, { name: ['john'], active: ['False'] });
-        should.equal(
-          echoed.url,
-          'https://httpbin.zapier-tooling.com/get?name=john&active=False'
-        );
+        should.equal(echoed.url, `${HTTPBIN_URL}/get?name=john&active=False`);
       });
     });
 
@@ -780,8 +776,7 @@ describe('Integration Test', () => {
 
     it('KEY_pre_poll, array curlies', () => {
       const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.triggers.movie.operation.url =
-        'https://httpbin.zapier-tooling.com/get?things={{things}}';
+      appDef.legacy.triggers.movie.operation.url = `${HTTPBIN_URL}/get?things={{things}}`;
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'movie_post_poll_make_array',
         'movie_post_poll'
@@ -812,7 +807,7 @@ describe('Integration Test', () => {
           things: ['eyedrops,cyclops,ipod'],
         });
         req.url.should.equal(
-          'https://httpbin.zapier-tooling.com/get?things=eyedrops%2Ccyclops%2Cipod'
+          `${HTTPBIN_URL}/get?things=eyedrops%2Ccyclops%2Cipod`
         );
       });
     });
@@ -1142,10 +1137,7 @@ describe('Integration Test', () => {
           const payload = JSON.parse(movie.trailer.split('|||')[1]);
           should.equal(payload.type, 'file');
           should.equal(payload.method, 'hydrators.legacyFileHydrator');
-          should.equal(
-            payload.bundle.url,
-            'https://auth-json-server.zapier-staging.com/movies'
-          );
+          should.equal(payload.bundle.url, `${AUTH_JSON_SERVER_URL}/movies`);
           should.equal(payload.bundle.request.params.id, movie.id);
           should.equal(payload.bundle.meta.name, `movie ${movie.id}.json`);
           should.equal(payload.bundle.meta.length, 1234);
@@ -2642,7 +2634,7 @@ describe('Integration Test', () => {
         // In reality, file will always be a "hydrate URL" that looks something
         // like https://zapier.com/engine/hydrate/1/abcd/, but in fact any
         // valid URL would work.
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2667,7 +2659,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'this is a pig.png',
-        file: 'https://httpbin.zapier-tooling.com/redirect-to?url=/image/png',
+        file: `${HTTPBIN_URL}/redirect-to?url=/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2696,7 +2688,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'this is a pig.png',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2725,7 +2717,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'this is a wolf.jpg',
-        file: 'https://httpbin.zapier-tooling.com/image/jpeg',
+        file: `${HTTPBIN_URL}/image/jpeg`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2754,7 +2746,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2783,7 +2775,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2812,7 +2804,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2841,7 +2833,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2870,7 +2862,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2899,7 +2891,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2928,7 +2920,7 @@ describe('Integration Test', () => {
       input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
         filename: 'dont.care',
-        file: 'https://httpbin.zapier-tooling.com/image/png',
+        file: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -2956,7 +2948,7 @@ describe('Integration Test', () => {
       input.bundle.inputData = {
         id: 'whatever',
         name: 'a pig',
-        file_1: 'https://httpbin.zapier-tooling.com/image/png',
+        file_1: `${HTTPBIN_URL}/image/png`,
       };
       return app(input).then((output) => {
         const file = output.results.file;
@@ -3060,7 +3052,7 @@ describe('Integration Test', () => {
         input.bundle.authData = { api_key: 'super secret' };
         input.bundle.inputData = {
           // This endpoint echoes what we send to it, so we know if auth info was sent
-          url: 'https://httpbin.zapier-tooling.com/get',
+          url: `${HTTPBIN_URL}/get`,
         };
         return app(input).then((output) => {
           const {
@@ -3098,7 +3090,7 @@ describe('Integration Test', () => {
         input.bundle.authData = { api_key: 'super secret' };
         input.bundle.inputData = {
           // This endpoint echoes what we send to it, so we know if auth info was sent
-          url: 'https://httpbin.zapier-tooling.com/get',
+          url: `${HTTPBIN_URL}/get`,
           request: {
             params: { foo: 1, bar: 'hello' },
           },
@@ -3142,7 +3134,7 @@ describe('Integration Test', () => {
         input.bundle.authData = { api_key: 'super secret' };
         input.bundle.inputData = {
           // This endpoint echoes what we send to it, so we know if auth info was sent
-          url: 'https://httpbin.zapier-tooling.com/get',
+          url: `${HTTPBIN_URL}/get`,
           request: {
             params: { foo: 1, bar: 'hello' },
           },

--- a/packages/legacy-scripting-runner/test/zfactory.js
+++ b/packages/legacy-scripting-runner/test/zfactory.js
@@ -23,7 +23,7 @@ describe('z', () => {
     done();
   });
 
-  it('z.request - sync', (done) => {
+  it('z.request - sync', () => {
     const bundleRequest = {
       method: 'GET',
       url: 'https://httpbin.zapier-tooling.com/get',
@@ -44,10 +44,8 @@ describe('z', () => {
 
     response.status_code.should.eql(200);
     const results = JSON.parse(response.content);
-    results.args.should.eql(bundleRequest.params);
-    results.headers.Accept.should.eql(bundleRequest.headers.Accept);
-
-    done();
+    results.args.should.deepEqual({ hello: ['world'] });
+    results.headers.Accept.should.deepEqual(['application/json']);
   });
 
   it('z.request - async', (done) => {
@@ -74,9 +72,9 @@ describe('z', () => {
 
       response.status_code.should.eql(200);
       const results = JSON.parse(response.content);
-      results.args.should.eql(bundleRequest.params);
+      results.args.should.eql({ hello: ['world'] });
       results.data.should.eql(bundleRequest.data);
-      results.headers.Accept.should.eql(bundleRequest.headers.Accept);
+      results.headers.Accept.should.deepEqual(['application/json']);
 
       done();
     });

--- a/packages/legacy-scripting-runner/test/zfactory.js
+++ b/packages/legacy-scripting-runner/test/zfactory.js
@@ -1,6 +1,7 @@
 const should = require('should');
 
 const z = require('../zfactory')();
+const { HTTPBIN_URL } = require('./constants');
 
 describe('z', () => {
   it('z.hash', (done) => {
@@ -26,7 +27,7 @@ describe('z', () => {
   it('z.request - sync', () => {
     const bundleRequest = {
       method: 'GET',
-      url: 'https://httpbin.zapier-tooling.com/get',
+      url: `${HTTPBIN_URL}/get`,
       params: {
         hello: 'world',
       },
@@ -51,7 +52,7 @@ describe('z', () => {
   it('z.request - async', (done) => {
     const bundleRequest = {
       method: 'POST',
-      url: 'https://httpbin.zapier-tooling.com/post',
+      url: `${HTTPBIN_URL}/post`,
       params: {
         hello: 'world',
       },

--- a/packages/legacy-scripting-runner/test/zfactory.js
+++ b/packages/legacy-scripting-runner/test/zfactory.js
@@ -26,7 +26,7 @@ describe('z', () => {
   it('z.request - sync', (done) => {
     const bundleRequest = {
       method: 'GET',
-      url: 'https://httpbin.org/get',
+      url: 'https://httpbin.zapier-tooling.com/get',
       params: {
         hello: 'world',
       },
@@ -53,7 +53,7 @@ describe('z', () => {
   it('z.request - async', (done) => {
     const bundleRequest = {
       method: 'POST',
-      url: 'https://httpbin.org/post',
+      url: 'https://httpbin.zapier-tooling.com/post',
       params: {
         hello: 'world',
       },


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Replaces all `httpbin.org` with `httpbin.zapier-tooling.com`. Most of the changes are in tests, so there are no user or developer-facing changes. The only change that affects developers is the `digest-auth` project template.

The biggest difference between httpbin.org and httpbin.zapier-tooling.com is that the Zapier one uses arrays to hold values for headers and query params. So in the test code, we need to change a lot of `.should.eql(value)` to `.should.deepEqual([value])`.

While I was there, I refactored some of promise usages into async/await syntax.