### PR TITLE
docs: add v10 notes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1301,10 +1301,11 @@ zapier convert 1234 --version 1.0.1 my-app
     },
   });
 
-  <span class="hljs-comment">// Call response.throwForStatus() if you&apos;re using a core version &lt; 10</span>
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
 
   <span class="hljs-keyword">return</span> {
     <span class="hljs-attr">sessionKey</span>: response.data.sessionKey,
+    <span class="hljs-comment">// or response.json.sessionKey if you&apos;re using core v9 and older</span>
   };
 };
 
@@ -1948,8 +1949,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeFields = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
 
+  <span class="hljs-comment">// Call reponse.throwForStatus() if you&apos;re using core v9 or older</span>
+
   <span class="hljs-comment">// Should return an array like [{&quot;key&quot;:&quot;field_1&quot;},{&quot;key&quot;:&quot;field_2&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.data;
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -2187,7 +2190,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id,
     },
   });
-  <span class="hljs-keyword">return</span> response.data;
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 </code></pre>
@@ -2465,8 +2471,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeOutputFields = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
 
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
   <span class="hljs-comment">// Should return an array like [{&quot;key&quot;:&quot;field_1&quot;,&quot;label&quot;:&quot;Label for Custom Field&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.data;
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re on core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -2706,10 +2714,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><code>z.errors</code> is a collection error classes that you can throw in your code, like <code>throw new z.errors.HaltedError(&apos;...&apos;)</code>.</p><p>The available errors are:</p><ul>
-<li>(<em>New in v9.3.0</em>) Error - Stops the current operation, allowing for (auto) replay. Read more on <a href="#general-errors">General Errors</a></li>
-<li>HaltedError - Stops current operation, but will never turn off Zap. Read more on <a href="#halting-execution">Halting Execution</a></li>
-<li>ExpiredAuthError - Turns off Zap and emails user to manually reconnect. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
-<li>RefreshAuthError - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
+<li><code>Error</code> (<em>new in v9.3.0</em>) - Stops the current operation, allowing for (auto) replay. Read more on <a href="#general-errors">General Errors</a></li>
+<li><code>HaltedError</code> - Stops current operation, but will never turn off Zap. Read more on <a href="#halting-execution">Halting Execution</a></li>
+<li><code>ExpiredAuthError</code> - Turns off Zap and emails user to manually reconnect. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
+<li><code>RefreshAuthError</code> - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 </ul><p>For more details on error handling in general, see <a href="#error-handling">here</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -2905,7 +2913,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </blockquote><p>There&apos;s also <code>bundle.meta.zap.id</code>, which is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p><p>The user&apos;s Zap ID is available during the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
 
   <span class="hljs-keyword">const</span> options = {
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks&apos;</span>,
@@ -2916,7 +2924,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     },
   };
 
-  <span class="hljs-keyword">return</span> z.request(options).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(options);
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-built_in">module</span>.exports = {
@@ -3158,7 +3167,10 @@ zapier env 1.0.0
     <span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>,
     httpOptions
   );
-  <span class="hljs-keyword">return</span> response.data;
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -3292,7 +3304,7 @@ zapier env 1.0.0
   };
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(customHttpOptions);
 
-  <span class="hljs-keyword">const</span> recipes = response.data;
+  <span class="hljs-keyword">const</span> recipes = response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
   <span class="hljs-comment">// You can do any custom processing of recipes here...</span>
   <span class="hljs-keyword">return</span> recipes;
 };
@@ -3358,7 +3370,7 @@ zapier env 1.0.0
             );
           }
 
-          <span class="hljs-keyword">return</span> response.data;
+          <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
         },
       },
     },
@@ -3401,18 +3413,18 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> request;
 };
 
+<span class="hljs-comment">// This example only works on core v10+!</span>
 <span class="hljs-keyword">const</span> handleErrors = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
   <span class="hljs-comment">// Prevent `throwForStatus` from throwing for a certain status.</span>
   <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
     response.skipThrowForStatus = <span class="hljs-literal">true</span>;
   }
-
-  <span class="hljs-comment">// Throw an error that `throwForStatus` wouldn&apos;t throw (correctly) for.</span>
   <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
     <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.data.message, response.data.code);
   }
 };
 
+<span class="hljs-comment">// This example only works on core v10+!</span>
 <span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
   <span class="hljs-comment">// Parse content that is not JSON</span>
   <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
@@ -3484,11 +3496,11 @@ zapier env 1.0.0
 <li><code>agent</code>: Node.js <code>http.Agent</code> instance, allows custom proxy, certificate etc. Default is <code>null</code>.</li>
 <li><code>timeout</code>: request / response timeout in ms. Set to <code>0</code> to disable (OS limit still applies), timeout reset on <code>redirect</code>. Default is <code>0</code> (disabled).</li>
 <li><code>size</code>: maximum response body size in bytes. Set to <code>0</code> to disable. Default is <code>0</code> (disabled).</li>
-<li><code>skipThrowForStatus</code>: don&apos;t call <code>response.throwForStatus()</code> before resolving the request with <code>response</code>. See <a href="#http-response-object">HTTP Response Object</a>.</li>
+<li><code>skipThrowForStatus</code> (<em>new in v10.0.0</em>): don&apos;t call <code>response.throwForStatus()</code> before resolving the request with <code>response</code>. See <a href="#http-response-object">HTTP Response Object</a>.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">z.request({
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
   <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com&apos;</span>,
   <span class="hljs-attr">method</span>: <span class="hljs-string">&apos;POST&apos;</span>,
   <span class="hljs-attr">headers</span>: {
@@ -3525,38 +3537,48 @@ zapier env 1.0.0
       <p>The response object returned by <code>z.request([url], options)</code> supports the following fields and methods:</p><ul>
 <li><code>status</code>: The response status code, i.e. <code>200</code>, <code>404</code>, etc.</li>
 <li><code>content</code>: The response content as a String. For Buffer, try <code>options.raw = true</code>.</li>
-<li><code>data</code>: The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
-<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated: Use <code>data</code> instead.</li>
+<li><code>data</code> (<em>new in v10.0.0</em>): The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
+<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated since v10.0.0: Use <code>data</code> instead.</li>
 <li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise).</li>
 <li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
-<li><code>skipThrowForStatus</code>: don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
+<li><code>skipThrowForStatus</code> (<em>new in v10.0.0</em>): don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
 <li><code>throwForStatus()</code>: Throw error if 400 &lt;= <code>status</code> &lt; 600.</li>
 <li><code>request</code>: The original request options object (see above).</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">z.request({
-  <span class="hljs-comment">// ..</span>
-}).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> {
-  <span class="hljs-comment">// a bunch of examples lines for cherry picking</span>
-  response.status;
-  response.headers[<span class="hljs-string">&apos;Content-Type&apos;</span>];
-  response.getHeader(<span class="hljs-string">&apos;content-type&apos;</span>);
-  response.request; <span class="hljs-comment">// original request options</span>
-  response.throwForStatus();
-  <span class="hljs-keyword">if</span> (options.raw === <span class="hljs-literal">false</span>) { <span class="hljs-comment">// (default)</span>
-    response.data; <span class="hljs-comment">// same as...</span>
-    <span class="hljs-built_in">JSON</span>.parse(response.content); <span class="hljs-comment">// or...</span>
-    querystring.parse(response.content);
-  } <span class="hljs-keyword">else</span> {
-    response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
-    response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
-    response.json().then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> json);
-    response.body.pipe(otherStream);
-  }
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
+  <span class="hljs-comment">// options</span>
 });
+
+<span class="hljs-comment">// A bunch of examples lines for cherry picking</span>
+response.status;
+response.headers[<span class="hljs-string">&apos;Content-Type&apos;</span>];
+response.getHeader(<span class="hljs-string">&apos;content-type&apos;</span>);
+response.request; <span class="hljs-comment">// original request options</span>
+response.throwForStatus();
+
+<span class="hljs-keyword">if</span> (options.raw === <span class="hljs-literal">false</span>) { <span class="hljs-comment">// (default)</span>
+  <span class="hljs-comment">// If you&apos;re core v10+</span>
+  response.data; <span class="hljs-comment">// same as...</span>
+  z.JSON.parse(response.content); <span class="hljs-comment">// or...</span>
+  querystring.parse(response.content);
+
+  <span class="hljs-comment">// If you&apos;re core v9 or older...</span>
+  response.json;  <span class="hljs-comment">// same as</span>
+  z.JSON.parse(response.content);
+} <span class="hljs-keyword">else</span> {
+  <span class="hljs-keyword">const</span> buf = <span class="hljs-keyword">await</span> response.buffer();
+  buf.toString();
+
+  <span class="hljs-keyword">const</span> text = <span class="hljs-keyword">await</span> response.text();
+
+  <span class="hljs-keyword">const</span> json = <span class="hljs-keyword">await</span> response.json();
+
+  response.body.pipe(otherStream);
+}
 </code></pre>
     </div>
   </div>
@@ -3588,11 +3610,17 @@ zapier env 1.0.0
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> getMovieDetails = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> url = <span class="hljs-string">`https://example.com/movies/<span class="hljs-subst">${bundle.inputData.id}</span>.json`</span>;
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(url);
-  <span class="hljs-keyword">return</span> response.data;
+
+  <span class="hljs-comment">// reponse.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> movieList = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/movies.json&apos;</span>);
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
   <span class="hljs-keyword">return</span> response.data.map(<span class="hljs-function">(<span class="hljs-params">movie</span>) =&gt;</span> {
     <span class="hljs-comment">// so maybe /movies.json is thin content but /movies/:id.json has more</span>
     <span class="hljs-comment">// details we want...</span>
@@ -3716,6 +3744,10 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 
 <span class="hljs-keyword">const</span> pdfList = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/pdfs.json&apos;</span>);
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-comment">// response.json.map if you&apos;re using core v9 or older</span>
   <span class="hljs-keyword">return</span> response.data.map(<span class="hljs-function">(<span class="hljs-params">pdf</span>) =&gt;</span> {
     <span class="hljs-comment">// Lazily convert a secret_download_url to a stashed url</span>
     <span class="hljs-comment">// zapier won&apos;t do this until we need it</span>
@@ -3921,7 +3953,7 @@ have incomprehensible messages for end users, or possibly go uncaught.</p><p>Zap
 <code>afterResponse</code> middleware (<a href="#using-http-middleware">docs</a>), which provides a hook for
 processing all responses from HTTP calls. Second is <code>response.throwForStatus()</code>
 (<a href="#http-response-object">docs</a>), which throws an error if the response status indicates
-an error (status &gt;= 400). We automatically call this method before returning the
+an error (status &gt;= 400). Since v10.0.0, we automatically call this method before returning the
 response, unless you set <code>skipThrowForStatus</code> on the request or response object. The
 last tool is the collection of errors in <code>z.errors</code> (<a href="#zerrors">docs</a>), which control
 the behavior of Zaps when various kinds of errors occur.</p>
@@ -4532,7 +4564,7 @@ npm run zapier-push
 <li><a href="https://github.com/jhuckaby/pixl-xml">pixl-xml</a></li>
 <li><a href="https://github.com/Leonidas-from-XIV/node-xml2js">xml2js</a></li>
 <li><a href="https://github.com/NaturalIntelligence/fast-xml-parser">fast-xml-parser</a></li>
-</ul><p>For <a href="shorthand-http-requests">shorthand requests</a>, use an <code>afterResponse</code> <a href="using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed XML:</p>
+</ul><p>Since core v10, it&apos;s possible for <a href="shorthand-http-requests">shorthand requests</a> to parse XML. Use an <code>afterResponse</code> <a href="using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed XML:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> xml = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;pixl-xml&apos;</span>);
@@ -4541,6 +4573,7 @@ npm run zapier-push
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">afterResponse</span>: [
     <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
+      <span class="hljs-comment">// Only works on core v10+!</span>
       response.throwForStatus();
       response.data = xml.parse(response.content);
       <span class="hljs-keyword">return</span> response;
@@ -4637,7 +4670,7 @@ npm run zapier-push
     },
   });
 
-  <span class="hljs-keyword">let</span> results = response.data;
+  <span class="hljs-keyword">let</span> results = response.data; <span class="hljs-comment">// response.json if you&apos;re using core v9 or older</span>
 
   <span class="hljs-comment">// keep paging until the last item was created over two hours ago</span>
   <span class="hljs-comment">// then we know we almost certainly haven&apos;t missed anything and can let</span>
@@ -4709,7 +4742,7 @@ npm run zapier-push
       <span class="hljs-attr">offset</span>: <span class="hljs-number">100</span> * bundle.meta.page
     }
   });
-  <span class="hljs-keyword">return</span> response.data;
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json you&apos;re using core v9 or older</span>
 };
 </code></pre>
     </div>
@@ -4819,7 +4852,7 @@ npm run zapier-push
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
-<span class="hljs-keyword">let</span> items = response.data.items;
+<span class="hljs-keyword">let</span> items = response.data.items; <span class="hljs-comment">// or response.json.items if you&apos;re using core v9 or older</span>
 <span class="hljs-keyword">return</span> items.map(<span class="hljs-function">(<span class="hljs-params">item</span>) =&gt;</span> {
   item.id = item.contactId;
   <span class="hljs-keyword">return</span> item;

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,9 +402,9 @@ a code {
       <p align="center">
   <a href="https://www.npmjs.com/package/zapier-platform-cli"><img src="https://img.shields.io/npm/v/zapier-platform-cli.svg" alt="npm version"></a>
 </p><p>Zapier is a platform for creating integrations and workflows. This CLI is your gateway to creating custom applications on the Zapier platform.</p><p>You may find docs duplicate or outdated across the Zapier site. The most up-to-date contents are always available on GitHub:</p><ul>
-<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md">CLI Docs</a></li>
-<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md">CLI Reference</a></li>
-<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md">Schema Docs</a></li>
+<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md">Latest CLI Docs</a></li>
+<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md">Latest CLI Reference</a></li>
+<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md">Latest Schema Docs</a></li>
 </ul><p>This doc decribes the latest CLI version <strong>10.0.0</strong>, as of this writing. If you&apos;re using an older version of the CLI, you may want to check out these historical releases:</p><ul>
 <li>CLI Docs: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
 <li>CLI Reference: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
@@ -3418,8 +3418,7 @@ zapier env 1.0.0
   <span class="hljs-comment">// Prevent `throwForStatus` from throwing for a certain status.</span>
   <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
     response.skipThrowForStatus = <span class="hljs-literal">true</span>;
-  }
-  <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
+  } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
     <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.data.message, response.data.code);
   }
 };

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -14,9 +14,9 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 
 You may find docs duplicate or outdated across the Zapier site. The most up-to-date contents are always available on GitHub:
 
-- [CLI Docs](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md)
-- [CLI Reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
-- [Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
+- [Latest CLI Docs](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md)
+- [Latest CLI Reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
+- [Latest Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
 
 This doc decribes the latest CLI version **PACKAGE_VERSION**, as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,9 +16,9 @@ Zapier is a platform for creating integrations and workflows. This CLI is your g
 
 You may find docs duplicate or outdated across the Zapier site. The most up-to-date contents are always available on GitHub:
 
-- [CLI Docs](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md)
-- [CLI Reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
-- [Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
+- [Latest CLI Docs](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md)
+- [Latest CLI Reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
+- [Latest Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
 
 This doc decribes the latest CLI version **10.0.0**, as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
 
@@ -2018,8 +2018,7 @@ const handleErrors = (response, z) => {
   // Prevent `throwForStatus` from throwing for a certain status.
   if (response.status === 456) {
     response.skipThrowForStatus = true;
-  }
-  else if (response.status === 200 && response.data.success === false) {
+  } else if (response.status === 200 && response.data.success === false) {
     throw new z.errors.Error(response.data.message, response.data.code);
   }
 };

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1301,10 +1301,11 @@ zapier convert 1234 --version 1.0.1 my-app
     },
   });
 
-  <span class="hljs-comment">// Call response.throwForStatus() if you&apos;re using a core version &lt; 10</span>
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
 
   <span class="hljs-keyword">return</span> {
     <span class="hljs-attr">sessionKey</span>: response.data.sessionKey,
+    <span class="hljs-comment">// or response.json.sessionKey if you&apos;re using core v9 and older</span>
   };
 };
 
@@ -1948,8 +1949,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeFields = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
 
+  <span class="hljs-comment">// Call reponse.throwForStatus() if you&apos;re using core v9 or older</span>
+
   <span class="hljs-comment">// Should return an array like [{&quot;key&quot;:&quot;field_1&quot;},{&quot;key&quot;:&quot;field_2&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.data;
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -2187,7 +2190,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <span class="hljs-attr">spreadsheet_id</span>: bundle.inputData.spreadsheet_id,
     },
   });
-  <span class="hljs-keyword">return</span> response.data;
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 </code></pre>
@@ -2465,8 +2471,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> recipeOutputFields = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/api/v2/fields.json&apos;</span>);
 
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
   <span class="hljs-comment">// Should return an array like [{&quot;key&quot;:&quot;field_1&quot;,&quot;label&quot;:&quot;Label for Custom Field&quot;}]</span>
-  <span class="hljs-keyword">return</span> response.data;
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re on core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -2706,10 +2714,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><code>z.errors</code> is a collection error classes that you can throw in your code, like <code>throw new z.errors.HaltedError(&apos;...&apos;)</code>.</p><p>The available errors are:</p><ul>
-<li>(<em>New in v9.3.0</em>) Error - Stops the current operation, allowing for (auto) replay. Read more on <a href="#general-errors">General Errors</a></li>
-<li>HaltedError - Stops current operation, but will never turn off Zap. Read more on <a href="#halting-execution">Halting Execution</a></li>
-<li>ExpiredAuthError - Turns off Zap and emails user to manually reconnect. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
-<li>RefreshAuthError - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
+<li><code>Error</code> (<em>new in v9.3.0</em>) - Stops the current operation, allowing for (auto) replay. Read more on <a href="#general-errors">General Errors</a></li>
+<li><code>HaltedError</code> - Stops current operation, but will never turn off Zap. Read more on <a href="#halting-execution">Halting Execution</a></li>
+<li><code>ExpiredAuthError</code> - Turns off Zap and emails user to manually reconnect. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
+<li><code>RefreshAuthError</code> - (OAuth2 or Session Auth) Tells Zapier to refresh credentials and retry operation. Read more on <a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 </ul><p>For more details on error handling in general, see <a href="#error-handling">here</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -2905,7 +2913,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </blockquote><p>There&apos;s also <code>bundle.meta.zap.id</code>, which is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p><p>The user&apos;s Zap ID is available during the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-function">(<span class="hljs-params">z, bundle</span>) =&gt;</span> {
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
 
   <span class="hljs-keyword">const</span> options = {
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks&apos;</span>,
@@ -2916,7 +2924,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     },
   };
 
-  <span class="hljs-keyword">return</span> z.request(options).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> response.data);
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(options);
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-built_in">module</span>.exports = {
@@ -3158,7 +3167,10 @@ zapier env 1.0.0
     <span class="hljs-string">&apos;https://example.com/api/v2/recipes.json&apos;</span>,
     httpOptions
   );
-  <span class="hljs-keyword">return</span> response.data;
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> App = {
@@ -3292,7 +3304,7 @@ zapier env 1.0.0
   };
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(customHttpOptions);
 
-  <span class="hljs-keyword">const</span> recipes = response.data;
+  <span class="hljs-keyword">const</span> recipes = response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
   <span class="hljs-comment">// You can do any custom processing of recipes here...</span>
   <span class="hljs-keyword">return</span> recipes;
 };
@@ -3358,7 +3370,7 @@ zapier env 1.0.0
             );
           }
 
-          <span class="hljs-keyword">return</span> response.data;
+          <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
         },
       },
     },
@@ -3401,18 +3413,18 @@ zapier env 1.0.0
   <span class="hljs-keyword">return</span> request;
 };
 
+<span class="hljs-comment">// This example only works on core v10+!</span>
 <span class="hljs-keyword">const</span> handleErrors = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
   <span class="hljs-comment">// Prevent `throwForStatus` from throwing for a certain status.</span>
   <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
     response.skipThrowForStatus = <span class="hljs-literal">true</span>;
   }
-
-  <span class="hljs-comment">// Throw an error that `throwForStatus` wouldn&apos;t throw (correctly) for.</span>
   <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
     <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.data.message, response.data.code);
   }
 };
 
+<span class="hljs-comment">// This example only works on core v10+!</span>
 <span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
   <span class="hljs-comment">// Parse content that is not JSON</span>
   <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
@@ -3484,11 +3496,11 @@ zapier env 1.0.0
 <li><code>agent</code>: Node.js <code>http.Agent</code> instance, allows custom proxy, certificate etc. Default is <code>null</code>.</li>
 <li><code>timeout</code>: request / response timeout in ms. Set to <code>0</code> to disable (OS limit still applies), timeout reset on <code>redirect</code>. Default is <code>0</code> (disabled).</li>
 <li><code>size</code>: maximum response body size in bytes. Set to <code>0</code> to disable. Default is <code>0</code> (disabled).</li>
-<li><code>skipThrowForStatus</code>: don&apos;t call <code>response.throwForStatus()</code> before resolving the request with <code>response</code>. See <a href="#http-response-object">HTTP Response Object</a>.</li>
+<li><code>skipThrowForStatus</code> (<em>new in v10.0.0</em>): don&apos;t call <code>response.throwForStatus()</code> before resolving the request with <code>response</code>. See <a href="#http-response-object">HTTP Response Object</a>.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">z.request({
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
   <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com&apos;</span>,
   <span class="hljs-attr">method</span>: <span class="hljs-string">&apos;POST&apos;</span>,
   <span class="hljs-attr">headers</span>: {
@@ -3525,38 +3537,48 @@ zapier env 1.0.0
       <p>The response object returned by <code>z.request([url], options)</code> supports the following fields and methods:</p><ul>
 <li><code>status</code>: The response status code, i.e. <code>200</code>, <code>404</code>, etc.</li>
 <li><code>content</code>: The response content as a String. For Buffer, try <code>options.raw = true</code>.</li>
-<li><code>data</code>: The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
-<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated: Use <code>data</code> instead.</li>
+<li><code>data</code> (<em>new in v10.0.0</em>): The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
+<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated since v10.0.0: Use <code>data</code> instead.</li>
 <li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise).</li>
 <li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
-<li><code>skipThrowForStatus</code>: don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
+<li><code>skipThrowForStatus</code> (<em>new in v10.0.0</em>): don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
 <li><code>throwForStatus()</code>: Throw error if 400 &lt;= <code>status</code> &lt; 600.</li>
 <li><code>request</code>: The original request options object (see above).</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">z.request({
-  <span class="hljs-comment">// ..</span>
-}).then(<span class="hljs-function">(<span class="hljs-params">response</span>) =&gt;</span> {
-  <span class="hljs-comment">// a bunch of examples lines for cherry picking</span>
-  response.status;
-  response.headers[<span class="hljs-string">&apos;Content-Type&apos;</span>];
-  response.getHeader(<span class="hljs-string">&apos;content-type&apos;</span>);
-  response.request; <span class="hljs-comment">// original request options</span>
-  response.throwForStatus();
-  <span class="hljs-keyword">if</span> (options.raw === <span class="hljs-literal">false</span>) { <span class="hljs-comment">// (default)</span>
-    response.data; <span class="hljs-comment">// same as...</span>
-    <span class="hljs-built_in">JSON</span>.parse(response.content); <span class="hljs-comment">// or...</span>
-    querystring.parse(response.content);
-  } <span class="hljs-keyword">else</span> {
-    response.buffer().then(<span class="hljs-function"><span class="hljs-params">buf</span> =&gt;</span> buf.toString());
-    response.text().then(<span class="hljs-function"><span class="hljs-params">content</span> =&gt;</span> content);
-    response.json().then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> json);
-    response.body.pipe(otherStream);
-  }
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
+  <span class="hljs-comment">// options</span>
 });
+
+<span class="hljs-comment">// A bunch of examples lines for cherry picking</span>
+response.status;
+response.headers[<span class="hljs-string">&apos;Content-Type&apos;</span>];
+response.getHeader(<span class="hljs-string">&apos;content-type&apos;</span>);
+response.request; <span class="hljs-comment">// original request options</span>
+response.throwForStatus();
+
+<span class="hljs-keyword">if</span> (options.raw === <span class="hljs-literal">false</span>) { <span class="hljs-comment">// (default)</span>
+  <span class="hljs-comment">// If you&apos;re core v10+</span>
+  response.data; <span class="hljs-comment">// same as...</span>
+  z.JSON.parse(response.content); <span class="hljs-comment">// or...</span>
+  querystring.parse(response.content);
+
+  <span class="hljs-comment">// If you&apos;re core v9 or older...</span>
+  response.json;  <span class="hljs-comment">// same as</span>
+  z.JSON.parse(response.content);
+} <span class="hljs-keyword">else</span> {
+  <span class="hljs-keyword">const</span> buf = <span class="hljs-keyword">await</span> response.buffer();
+  buf.toString();
+
+  <span class="hljs-keyword">const</span> text = <span class="hljs-keyword">await</span> response.text();
+
+  <span class="hljs-keyword">const</span> json = <span class="hljs-keyword">await</span> response.json();
+
+  response.body.pipe(otherStream);
+}
 </code></pre>
     </div>
   </div>
@@ -3588,11 +3610,17 @@ zapier env 1.0.0
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> getMovieDetails = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> url = <span class="hljs-string">`https://example.com/movies/<span class="hljs-subst">${bundle.inputData.id}</span>.json`</span>;
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(url);
-  <span class="hljs-keyword">return</span> response.data;
+
+  <span class="hljs-comment">// reponse.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
 };
 
 <span class="hljs-keyword">const</span> movieList = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/movies.json&apos;</span>);
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
   <span class="hljs-keyword">return</span> response.data.map(<span class="hljs-function">(<span class="hljs-params">movie</span>) =&gt;</span> {
     <span class="hljs-comment">// so maybe /movies.json is thin content but /movies/:id.json has more</span>
     <span class="hljs-comment">// details we want...</span>
@@ -3716,6 +3744,10 @@ z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename 
 
 <span class="hljs-keyword">const</span> pdfList = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(<span class="hljs-string">&apos;https://example.com/pdfs.json&apos;</span>);
+
+  <span class="hljs-comment">// response.throwForStatus() if you&apos;re using core v9 or older</span>
+
+  <span class="hljs-comment">// response.json.map if you&apos;re using core v9 or older</span>
   <span class="hljs-keyword">return</span> response.data.map(<span class="hljs-function">(<span class="hljs-params">pdf</span>) =&gt;</span> {
     <span class="hljs-comment">// Lazily convert a secret_download_url to a stashed url</span>
     <span class="hljs-comment">// zapier won&apos;t do this until we need it</span>
@@ -3921,7 +3953,7 @@ have incomprehensible messages for end users, or possibly go uncaught.</p><p>Zap
 <code>afterResponse</code> middleware (<a href="#using-http-middleware">docs</a>), which provides a hook for
 processing all responses from HTTP calls. Second is <code>response.throwForStatus()</code>
 (<a href="#http-response-object">docs</a>), which throws an error if the response status indicates
-an error (status &gt;= 400). We automatically call this method before returning the
+an error (status &gt;= 400). Since v10.0.0, we automatically call this method before returning the
 response, unless you set <code>skipThrowForStatus</code> on the request or response object. The
 last tool is the collection of errors in <code>z.errors</code> (<a href="#zerrors">docs</a>), which control
 the behavior of Zaps when various kinds of errors occur.</p>
@@ -4532,7 +4564,7 @@ npm run zapier-push
 <li><a href="https://github.com/jhuckaby/pixl-xml">pixl-xml</a></li>
 <li><a href="https://github.com/Leonidas-from-XIV/node-xml2js">xml2js</a></li>
 <li><a href="https://github.com/NaturalIntelligence/fast-xml-parser">fast-xml-parser</a></li>
-</ul><p>For <a href="shorthand-http-requests">shorthand requests</a>, use an <code>afterResponse</code> <a href="using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed XML:</p>
+</ul><p>Since core v10, it&apos;s possible for <a href="shorthand-http-requests">shorthand requests</a> to parse XML. Use an <code>afterResponse</code> <a href="using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed XML:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> xml = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;pixl-xml&apos;</span>);
@@ -4541,6 +4573,7 @@ npm run zapier-push
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">afterResponse</span>: [
     <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
+      <span class="hljs-comment">// Only works on core v10+!</span>
       response.throwForStatus();
       response.data = xml.parse(response.content);
       <span class="hljs-keyword">return</span> response;
@@ -4637,7 +4670,7 @@ npm run zapier-push
     },
   });
 
-  <span class="hljs-keyword">let</span> results = response.data;
+  <span class="hljs-keyword">let</span> results = response.data; <span class="hljs-comment">// response.json if you&apos;re using core v9 or older</span>
 
   <span class="hljs-comment">// keep paging until the last item was created over two hours ago</span>
   <span class="hljs-comment">// then we know we almost certainly haven&apos;t missed anything and can let</span>
@@ -4709,7 +4742,7 @@ npm run zapier-push
       <span class="hljs-attr">offset</span>: <span class="hljs-number">100</span> * bundle.meta.page
     }
   });
-  <span class="hljs-keyword">return</span> response.data;
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json you&apos;re using core v9 or older</span>
 };
 </code></pre>
     </div>
@@ -4819,7 +4852,7 @@ npm run zapier-push
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-comment">// ...</span>
-<span class="hljs-keyword">let</span> items = response.data.items;
+<span class="hljs-keyword">let</span> items = response.data.items; <span class="hljs-comment">// or response.json.items if you&apos;re using core v9 or older</span>
 <span class="hljs-keyword">return</span> items.map(<span class="hljs-function">(<span class="hljs-params">item</span>) =&gt;</span> {
   item.id = item.contactId;
   <span class="hljs-keyword">return</span> item;

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -402,9 +402,9 @@ a code {
       <p align="center">
   <a href="https://www.npmjs.com/package/zapier-platform-cli"><img src="https://img.shields.io/npm/v/zapier-platform-cli.svg" alt="npm version"></a>
 </p><p>Zapier is a platform for creating integrations and workflows. This CLI is your gateway to creating custom applications on the Zapier platform.</p><p>You may find docs duplicate or outdated across the Zapier site. The most up-to-date contents are always available on GitHub:</p><ul>
-<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md">CLI Docs</a></li>
-<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md">CLI Reference</a></li>
-<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md">Schema Docs</a></li>
+<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md">Latest CLI Docs</a></li>
+<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md">Latest CLI Reference</a></li>
+<li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md">Latest Schema Docs</a></li>
 </ul><p>This doc decribes the latest CLI version <strong>10.0.0</strong>, as of this writing. If you&apos;re using an older version of the CLI, you may want to check out these historical releases:</p><ul>
 <li>CLI Docs: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
 <li>CLI Reference: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
@@ -3418,8 +3418,7 @@ zapier env 1.0.0
   <span class="hljs-comment">// Prevent `throwForStatus` from throwing for a certain status.</span>
   <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
     response.skipThrowForStatus = <span class="hljs-literal">true</span>;
-  }
-  <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
+  } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">200</span> &amp;&amp; response.data.success === <span class="hljs-literal">false</span>) {
     <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.Error(response.data.message, response.data.code);
   }
 };

--- a/packages/cli/snippets/async-polling.js
+++ b/packages/cli/snippets/async-polling.js
@@ -15,7 +15,7 @@ const asyncExample = async (z, bundle) => {
     },
   });
 
-  let results = response.data;
+  let results = response.data; // response.json if you're using core v9 or older
 
   // keep paging until the last item was created over two hours ago
   // then we know we almost certainly haven't missed anything and can let

--- a/packages/cli/snippets/custom-fields.js
+++ b/packages/cli/snippets/custom-fields.js
@@ -1,8 +1,10 @@
 const recipeFields = async (z, bundle) => {
   const response = await z.request('https://example.com/api/v2/fields.json');
 
+  // Call reponse.throwForStatus() if you're using core v9 or older
+
   // Should return an array like [{"key":"field_1"},{"key":"field_2"}]
-  return response.data;
+  return response.data; // response.json if you're using core v9 or older
 };
 
 const App = {

--- a/packages/cli/snippets/dehydration.js
+++ b/packages/cli/snippets/dehydration.js
@@ -1,11 +1,17 @@
 const getMovieDetails = async (z, bundle) => {
   const url = `https://example.com/movies/${bundle.inputData.id}.json`;
   const response = await z.request(url);
-  return response.data;
+
+  // reponse.throwForStatus() if you're using core v9 or older
+
+  return response.data; // or response.json if you're using core v9 or older
 };
 
 const movieList = async (z, bundle) => {
   const response = await z.request('https://example.com/movies.json');
+
+  // response.throwForStatus() if you're using core v9 or older
+
   return response.data.map((movie) => {
     // so maybe /movies.json is thin content but /movies/:id.json has more
     // details we want...

--- a/packages/cli/snippets/dynamic-dropdowns-five.js
+++ b/packages/cli/snippets/dynamic-dropdowns-five.js
@@ -4,5 +4,8 @@ perform: async (z, bundle) => {
       spreadsheet_id: bundle.inputData.spreadsheet_id,
     },
   });
-  return response.data;
+
+  // response.throwForStatus() if you're using core v9 or older
+
+  return response.data; // or response.json if you're using core v9 or older
 };

--- a/packages/cli/snippets/manual-request.js
+++ b/packages/cli/snippets/manual-request.js
@@ -7,7 +7,7 @@ const listExample = async (z, bundle) => {
   };
   const response = await z.request(customHttpOptions);
 
-  const recipes = response.data;
+  const recipes = response.data; // or response.json if you're using core v9 or older
   // You can do any custom processing of recipes here...
   return recipes;
 };

--- a/packages/cli/snippets/middleware.js
+++ b/packages/cli/snippets/middleware.js
@@ -3,18 +3,17 @@ const addHeader = (request, z, bundle) => {
   return request;
 };
 
+// This example only works on core v10+!
 const handleErrors = (response, z) => {
   // Prevent `throwForStatus` from throwing for a certain status.
   if (response.status === 456) {
     response.skipThrowForStatus = true;
-  }
-
-  // Throw an error that `throwForStatus` wouldn't throw (correctly) for.
-  else if (response.status === 200 && response.data.success === false) {
+  } else if (response.status === 200 && response.data.success === false) {
     throw new z.errors.Error(response.data.message, response.data.code);
   }
 };
 
+// This example only works on core v10+!
 const parseXML = (response, z, bundle) => {
   // Parse content that is not JSON
   // eslint-disable-next-line no-undef

--- a/packages/cli/snippets/output-fields.js
+++ b/packages/cli/snippets/output-fields.js
@@ -1,8 +1,10 @@
 const recipeOutputFields = async (z, bundle) => {
   const response = await z.request('https://example.com/api/v2/fields.json');
 
+  // response.throwForStatus() if you're using core v9 or older
+
   // Should return an array like [{"key":"field_1","label":"Label for Custom Field"}]
-  return response.data;
+  return response.data; // or response.json if you're on core v9 or older
 };
 
 const App = {

--- a/packages/cli/snippets/process-env.js
+++ b/packages/cli/snippets/process-env.js
@@ -8,7 +8,10 @@ const listExample = async (z, bundle) => {
     'https://example.com/api/v2/recipes.json',
     httpOptions
   );
-  return response.data;
+
+  // response.throwForStatus() if you're using core v9 or older
+
+  return response.data; // or response.json if you're using core v9 or older
 };
 
 const App = {

--- a/packages/cli/snippets/put.js
+++ b/packages/cli/snippets/put.js
@@ -28,7 +28,7 @@ const App = {
             );
           }
 
-          return response.data;
+          return response.data; // or response.json if you're using core v9 or older
         },
       },
     },

--- a/packages/cli/snippets/session-auth.js
+++ b/packages/cli/snippets/session-auth.js
@@ -8,10 +8,11 @@ const getSessionKey = async (z, bundle) => {
     },
   });
 
-  // Call response.throwForStatus() if you're using a core version < 10
+  // response.throwForStatus() if you're using core v9 or older
 
   return {
     sessionKey: response.data.sessionKey,
+    // or response.json.sessionKey if you're using core v9 and older
   };
 };
 

--- a/packages/cli/snippets/stash-file.js
+++ b/packages/cli/snippets/stash-file.js
@@ -10,6 +10,10 @@ const stashPDFfunction = (z, bundle) => {
 
 const pdfList = async (z, bundle) => {
   const response = await z.request('https://example.com/pdfs.json');
+
+  // response.throwForStatus() if you're using core v9 or older
+
+  // response.json.map if you're using core v9 or older
   return response.data.map((pdf) => {
     // Lazily convert a secret_download_url to a stashed url
     // zapier won't do this until we need it

--- a/packages/cli/snippets/xml.js
+++ b/packages/cli/snippets/xml.js
@@ -4,6 +4,7 @@ const App = {
   // ...
   afterResponse: [
     (response, z, bundle) => {
+      // Only works on core v10+!
       response.throwForStatus();
       response.data = xml.parse(response.content);
       return response;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Add v10 notes everywhere in the docs, especially with `response.data` and `response.throwForStatus()`, so developers don't get confused if they're still on v9.