### PR TITLE
fix(legacy-scripting-runner): encode URL path before sending a request

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1,9 +1,10 @@
-const { promisify } = require('util');
 const querystring = require('querystring');
+const { promisify } = require('util');
+const { URL } = require('url');
 
 const _ = require('lodash');
-const FormData = require('form-data');
 const flatten = require('flat');
+const FormData = require('form-data');
 
 const {
   recurseReplaceBank,
@@ -663,6 +664,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         await addFilesToRequestBodyFromBody(request, bundle);
       }
 
+      request.url = new URL(request.url).toString();
       request.headers = cleanHeaders(request.headers);
       request.allowGetBody = true;
       request.serializeValueForCurlies = serializeValueForCurlies;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -277,6 +277,11 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_non_ascii_url: function(bundle) {
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/中文';
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -860,6 +860,30 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, non-ascii URL', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_non_ascii_url',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        const result = output.results[0];
+        should.equal(result.hello, '你好');
+      });
+    });
+
     it('KEY_post_poll, jQuery utils', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Use `new URL(url).toString()` to encode any unescaped characters before calling `z.request`. This would prevent node-fetch from throwing an error saying `Request path contains unescaped characters`.