### PR TITLE
fix(legacy-scripting-runner) env vars not being resolved correctly in urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ typings/
 
 example-apps/*/yarn.lock
 example-apps/*/package-lock.json
+example-apps/typescript/lib
 
 boilerplate/build
 

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -664,7 +664,11 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         await addFilesToRequestBodyFromBody(request, bundle);
       }
 
-      request.url = new URL(request.url).toString();
+      // encode everything, but retain curlies - those are replaced in z.request
+      // important to maintain case here; new URL lowercases everything
+      request.url = encodeURI(request.url)
+        .replace(/%7B/g, '{')
+        .replace(/%7D/g, '}');
       request.headers = cleanHeaders(request.headers);
       request.allowGetBody = true;
       request.serializeValueForCurlies = serializeValueForCurlies;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -282,6 +282,11 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_env_var: function(bundle) {
+        bundle.request.url = 'https://{{process.env.SECRET_HTTPBIN_URL}}/get';
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -884,6 +884,35 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, env in url', () => {
+      process.env.SECRET_HTTPBIN_URL = HTTPBIN_URL.slice(8); // remove the protocol
+
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_env_var',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+
+      delete process.env.MY_SECRET;
+
+      return _app(input).then((output) => {
+        const result = output.results[0];
+        should.equal(result.url, 'https://httpbin.zapier-tooling.com/get');
+      });
+    });
+
     it('KEY_post_poll, jQuery utils', () => {
       const input = createTestInput(
         compiledApp,

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -337,13 +337,11 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  {
-    label: 'New Thing',
+  { label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true
-  }
+    important: true }
   ```
 
 #### Anti-Examples
@@ -453,48 +451,38 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
-  }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -674,12 +662,7 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{
-  key: 'abc',
-  children: [
-    { key: 'def', children: [ { key: 'dhi' } ] }
-  ]
-}`
+* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -966,29 +949,19 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Create Tag',
-      description: 'Create a new Tag in your account.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1013,25 +986,19 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Properties
@@ -1056,29 +1023,19 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: {
-      type: 'hook',
-      perform: '$func$0$f$',
-      sample: { id: 385, name: 'proactive enable ROI' }
-    }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Properties
@@ -1103,38 +1060,24 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: {
-      perform: { url: 'https://fake-crm.getsandbox.com/users' },
-      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
-    }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation:
+     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
+       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.',
-      hidden: true
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display:
+     { label: 'New User',
+       description: 'Trigger when a new User is created in your account.',
+       hidden: true },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Properties
@@ -1159,31 +1102,21 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  {
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1208,81 +1141,55 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 
 #### Properties
@@ -1389,36 +1296,26 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1465,35 +1362,25 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-  }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
-    display: {
-      label: 'New Recipe',
-      description: 'Triggers when a new recipe is added.',
-      hidden: true
-    },
-    operation: { type: 'polling', perform: '$func$0$f$' }
-  }
+    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
+    operation: { type: 'polling', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' }
-  }
+    operation: { perform: '$func$0$f$' } }
   ```
 
 #### Properties


### PR DESCRIPTION
`new URL(url)` correctly encoded non-english characters, but downcased everything. as a result, `{{process.env.THING}}` became `{{process.env.thing}}` and wasn't correctly resolved later.