### PR TITLE
fix(cli) properly handle invalid keys during VB conversion

### DIFF
--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -213,7 +213,7 @@ const renderAuthData = (appDefinition) => {
   const fieldKeys = getAuthFieldKeys(appDefinition);
   const lines = _.map(fieldKeys, (key) => {
     const upperKey = _.snakeCase(key).toUpperCase();
-    return `"${key}": process.env["${upperKey}"]`;
+    return `"${key}": process.env.${upperKey}`;
   });
   if (_.isEmpty(lines)) {
     return `{

--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -213,7 +213,7 @@ const renderAuthData = (appDefinition) => {
   const fieldKeys = getAuthFieldKeys(appDefinition);
   const lines = _.map(fieldKeys, (key) => {
     const upperKey = _.snakeCase(key).toUpperCase();
-    return `${key}: process.env.${upperKey}`;
+    return `"${key}": process.env["${upperKey}"]`;
   });
   if (_.isEmpty(lines)) {
     return `{


### PR DESCRIPTION
fixes #234, where an auth key like `X-API-KEY` wasn't handled correctly in the resulting JS.

We could probably refactor this conversion code to use the declarative code we did during the eng retreat, but that's probably fine for now. 