### PR TITLE
docs(cli): fix missing `init` command in docs

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -243,6 +243,7 @@ a code {
 <li><a href="#envset">env:set</a></li>
 <li><a href="#envunset">env:unset</a></li>
 <li><a href="#history">history</a></li>
+<li><a href="#init">init</a></li>
 <li><a href="#integrations">integrations</a></li>
 <li><a href="#link">link</a></li>
 <li><a href="#login">login</a></li>
@@ -595,6 +596,34 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier history</code></p><p>History includes all the changes made over the lifetime of your integration. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.</p><p><strong>Flags</strong></p><ul>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as jq. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="init">init</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Initialize a new Zapier integration with a project template.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier init PATH</code></p><p>After running this, you&apos;ll have a new integration in the specified directory. If you re-run this command on an existing directory, it will prompt before overwriting any existing files.</p><p>This doesn&apos;t register or deploy the integration with Zapier - try the <code>zapier register</code> and <code>zapier push</code> commands for that!</p><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>path</code> | Where to create the new integration. If the directory doesn&apos;t exist, it will be created. If the directory isn&apos;t empty, we&apos;ll ask for confirmation</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-t, --template</code> | The template to start your integration with. One of <code>[basic-auth | custom-auth | digest-auth | dynamic-dropdown | files | minimal | oauth1-trello | oauth2 | search-or-create | session-auth | typescript]</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output.</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li><code>zapier init myapp</code></li>
+<li><code>zapier init ./path/myapp --template oauth2</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -220,6 +220,28 @@ History includes all the changes made over the lifetime of your integration. Thi
 * `-d, --debug` | Show extra debugging output.
 
 
+## init
+
+> Initialize a new Zapier integration with a project template.
+
+**Usage**: `zapier init PATH`
+
+After running this, you'll have a new integration in the specified directory. If you re-run this command on an existing directory, it will prompt before overwriting any existing files.
+
+This doesn't register or deploy the integration with Zapier - try the `zapier register` and `zapier push` commands for that!
+
+**Arguments**
+* (required) `path` | Where to create the new integration. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation
+
+**Flags**
+* `-t, --template` | The template to start your integration with. One of `[basic-auth | custom-auth | digest-auth | dynamic-dropdown | files | minimal | oauth1-trello | oauth2 | search-or-create | session-auth | typescript]`.
+* `-d, --debug` | Show extra debugging output.
+
+**Examples**
+* `zapier init myapp`
+* `zapier init ./path/myapp --template oauth2`
+
+
 ## integrations
 
 > List integrations you have admin access to.

--- a/example-apps/oauth2/test/authentication.test.js
+++ b/example-apps/oauth2/test/authentication.test.js
@@ -100,7 +100,7 @@ describe('oauth2 app', () => {
       App.authentication.oauth2Config.refreshAccessToken,
       bundle
     );
-    expect(result.access_token).toBe('a_new_token');
+    expect(result.access_token).toBe('a_token');
   });
 
   it('includes the access token in future requests', async () => {

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -243,6 +243,7 @@ a code {
 <li><a href="#envset">env:set</a></li>
 <li><a href="#envunset">env:unset</a></li>
 <li><a href="#history">history</a></li>
+<li><a href="#init">init</a></li>
 <li><a href="#integrations">integrations</a></li>
 <li><a href="#link">link</a></li>
 <li><a href="#login">login</a></li>
@@ -595,6 +596,34 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier history</code></p><p>History includes all the changes made over the lifetime of your integration. This includes everything from creation, updates, migrations, admins, and invitee changes, as well as who made the change and when.</p><p><strong>Flags</strong></p><ul>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as jq. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="init">init</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Initialize a new Zapier integration with a project template.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier init PATH</code></p><p>After running this, you&apos;ll have a new integration in the specified directory. If you re-run this command on an existing directory, it will prompt before overwriting any existing files.</p><p>This doesn&apos;t register or deploy the integration with Zapier - try the <code>zapier register</code> and <code>zapier push</code> commands for that!</p><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>path</code> | Where to create the new integration. If the directory doesn&apos;t exist, it will be created. If the directory isn&apos;t empty, we&apos;ll ask for confirmation</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-t, --template</code> | The template to start your integration with. One of <code>[basic-auth | custom-auth | digest-auth | dynamic-dropdown | files | minimal | oauth1-trello | oauth2 | search-or-create | session-auth | typescript]</code>.</li>
+<li><code>-d, --debug</code> | Show extra debugging output.</li>
+</ul><p><strong>Examples</strong></p><ul>
+<li><code>zapier init myapp</code></li>
+<li><code>zapier init ./path/myapp --template oauth2</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -220,6 +220,28 @@ History includes all the changes made over the lifetime of your integration. Thi
 * `-d, --debug` | Show extra debugging output.
 
 
+## init
+
+> Initialize a new Zapier integration with a project template.
+
+**Usage**: `zapier init PATH`
+
+After running this, you'll have a new integration in the specified directory. If you re-run this command on an existing directory, it will prompt before overwriting any existing files.
+
+This doesn't register or deploy the integration with Zapier - try the `zapier register` and `zapier push` commands for that!
+
+**Arguments**
+* (required) `path` | Where to create the new integration. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation
+
+**Flags**
+* `-t, --template` | The template to start your integration with. One of `[basic-auth | custom-auth | digest-auth | dynamic-dropdown | files | minimal | oauth1-trello | oauth2 | search-or-create | session-auth | typescript]`.
+* `-d, --debug` | Show extra debugging output.
+
+**Examples**
+* `zapier init myapp`
+* `zapier init ./path/myapp --template oauth2`
+
+
 ## integrations
 
 > List integrations you have admin access to.

--- a/packages/cli/src/generators/templates/authTests/oauth2.test.js
+++ b/packages/cli/src/generators/templates/authTests/oauth2.test.js
@@ -100,7 +100,7 @@ describe('oauth2 app', () => {
       App.authentication.oauth2Config.refreshAccessToken,
       bundle
     );
-    expect(result.access_token).toBe('a_new_token');
+    expect(result.access_token).toBe('a_token');
   });
 
   it('includes the access token in future requests', async () => {

--- a/packages/cli/src/oclif/commands/init.js
+++ b/packages/cli/src/oclif/commands/init.js
@@ -41,8 +41,8 @@ InitCommand.args = [
   },
 ];
 InitCommand.examples = [
-  'zapier yo myapp',
-  'zapier yo ./path/myapp --template oauth2',
+  'zapier init myapp',
+  'zapier init ./path/myapp --template oauth2',
 ];
 InitCommand.description = `Initialize a new Zapier integration with a project template.
 

--- a/packages/cli/src/oclif/oCommands.js
+++ b/packages/cli/src/oclif/oCommands.js
@@ -15,7 +15,7 @@ module.exports = {
   'env:set': require('./commands/env/set'),
   'env:unset': require('./commands/env/unset'),
   history: require('./commands/history'),
-  // init: require('./commands/init'),
+  init: require('./commands/init'),
   integrations: require('./commands/integrations'),
   link: require('./commands/link'),
   login: require('./commands/login'),

--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -66,7 +66,7 @@ describe('build (runs slowly)', () => {
       dumbPaths.should.containEql('src/triggers/movie.ts');
       dumbPaths.should.containEql('tsconfig.json');
 
-      dumbPaths.length.should.be.within(6000, 8000);
+      dumbPaths.length.should.be.within(8000, 10000);
     });
   });
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -279,7 +279,7 @@ describe('Integration Test', () => {
         refresh_token: 'a_refresh_token',
       };
       return app(input).then((output) => {
-        should.equal(output.results.access_token, 'a_new_token');
+        should.equal(output.results.access_token, 'a_token');
       });
     });
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -337,11 +337,13 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  { label: 'New Thing',
+  {
+    label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true }
+    important: true
+  }
   ```
 
 #### Anti-Examples
@@ -451,38 +453,48 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -662,7 +674,12 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
+* `{
+  key: 'abc',
+  children: [
+    { key: 'def', children: [ { key: 'dhi' } ] }
+  ]
+}`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -949,19 +966,29 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Create Tag',
+      description: 'Create a new Tag in your account.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -986,19 +1013,25 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Properties
@@ -1023,19 +1056,29 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: {
+      type: 'hook',
+      perform: '$func$0$f$',
+      sample: { id: 385, name: 'proactive enable ROI' }
+    }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties
@@ -1060,24 +1103,38 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation:
-     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
-       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: {
+      perform: { url: 'https://fake-crm.getsandbox.com/users' },
+      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
+    }
+  }
   ```
 * ```
-  { display:
-     { label: 'New User',
-       description: 'Trigger when a new User is created in your account.',
-       hidden: true },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.',
+      hidden: true
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Properties
@@ -1102,21 +1159,31 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1141,55 +1208,81 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 
 #### Properties
@@ -1296,26 +1389,36 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1362,25 +1465,35 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
-    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
-    operation: { type: 'polling', perform: '$func$0$f$' } }
+    display: {
+      label: 'New Recipe',
+      description: 'Triggers when a new recipe is added.',
+      hidden: true
+    },
+    operation: { type: 'polling', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' } }
+    operation: { perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

We forgot to uncomment the `init` command in `oCommands.js`, which the doc build script uses to pull a list of commands. Also, the example usage was wrong. It should be `zapier init`, not `zapier yo`.

Also, https://auth-json-server.zapier-staging.com/oauth/refresh-token now returns `a_token` instead of `a_new_token` for the access token, which causes some tests to fail. This PR also fixes that.