### PR TITLE
fix(legacy-scripting-runner): make response headers case-insensitive

### DIFF
--- a/packages/legacy-scripting-runner/middleware-factory.js
+++ b/packages/legacy-scripting-runner/middleware-factory.js
@@ -233,7 +233,7 @@ const proxyHeaders = (headers) => {
       }
       try {
         // try to retrieve the header via the get() function
-        return target.get(prop); // try to retrieve the header via the get() function
+        return target.get(prop);
       } catch {
         // otherwise, default to original target[prop] value
         return original;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -460,6 +460,13 @@ const legacyScriptingSource = `
         });
       },
 
+      movie_post_poll_header_case: function(bundle) {
+        var movies = z.JSON.parse(bundle.response.content);
+        var contentType = bundle.response.headers['CONTENT-type'];
+        movies[0].contentType = contentType;
+        return movies;
+      },
+
       /*
        * Create/Action
        */

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -487,6 +487,27 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_poll, header case', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_header_case',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      return _app(input).then((output) => {
+        const movies = output.results;
+        should.equal(movies[0].contentType, 'application/json; charset=utf-8');
+      });
+    });
+
     it('KEY_poll, default headers', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes [PDE-1561](https://zapierorg.atlassian.net/browse/PDE-1561).

A `KEY_post` method may access the response header like this:

```js
function KEY_post_poll(bundle) {
  var name = bundle.response.headers['My-Name'];
  // ...
}
```

However, in CLI/VB world, our HTTP client is `node-fetch` and it lowercases response headers for us, so the above header accessing will break. It needs to be changed to `bundle.response.headers['my-name']`.

This PR adds an `afterResponse` middleware to make header keys case-insensitive, so both `my-name` and `My-Name`, or even `mY-NaMe` are going to work.

Stole from @codebycaleb's commit https://github.com/zapier/zapier-platform/commit/f0575398887a980f57207b0cff8b4ace3284de6c.