### PR TITLE
docs(cli): remove legacy reference to bundle.meta.zap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2997,7 +2997,35 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p><code>bundle.targetUrl</code> is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods for webhooks.</p>
-</blockquote><p>This the URL to which you should send hook data. It&apos;ll look something like <code>https://hooks.zapier.com/1234/abcd</code>. We provide it so you can make a POST request to your server. Your server should store this URL and use is as a destination when there&apos;s new data to report.</p><p>Read more in the <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js">REST hook example</a>.</p>
+</blockquote><p>This the URL to which you should send hook data. It&apos;ll look something like <code>https://hooks.zapier.com/1234/abcd</code>. We provide it so you can make a POST request to your server. Your server should store this URL and use is as a destination when there&apos;s new data to report.</p><p>For example:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+
+  <span class="hljs-keyword">const</span> options = {
+    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks&apos;</span>,
+    <span class="hljs-attr">method</span>: <span class="hljs-string">&apos;POST&apos;</span>,
+    <span class="hljs-attr">body</span>: {
+      <span class="hljs-attr">url</span>: bundle.targetUrl, <span class="hljs-comment">// bundle.targetUrl has the Hook URL this app should call</span>
+    },
+  };
+
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(options);
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
+};
+
+<span class="hljs-built_in">module</span>.exports = {
+  <span class="hljs-comment">// ...</span>
+  <span class="hljs-attr">performSubscribe</span>: subscribeHook,
+  <span class="hljs-comment">// ...</span>
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Read more in the <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js">REST hook example</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -2916,30 +2916,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Before v8.0.0, the information in <code>bundle.meta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> for the previous values and <a href="https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
-</blockquote><p>There&apos;s also <code>bundle.meta.zap.id</code>, which is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p><p>The user&apos;s Zap ID is available during the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
+</blockquote>
     </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
-
-  <span class="hljs-keyword">const</span> options = {
-    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks&apos;</span>,
-    <span class="hljs-attr">method</span>: <span class="hljs-string">&apos;POST&apos;</span>,
-    <span class="hljs-attr">body</span>: {
-      <span class="hljs-attr">url</span>: bundle.targetUrl, <span class="hljs-comment">// bundle.targetUrl has the Hook URL this app should call</span>
-      <span class="hljs-attr">zap_id</span>: bundle.meta.zap.id,
-    },
-  };
-
-  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(options);
-  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
-};
-
-<span class="hljs-built_in">module</span>.exports = {
-  <span class="hljs-comment">// ... see our rest hook example for additional details: https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js</span>
-  <span class="hljs-attr">performSubscribe</span>: subscribeHook,
-  <span class="hljs-comment">// ...</span>
-};
-</code></pre>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2916,10 +2916,27 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Before v8.0.0, the information in <code>bundle.meta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> for the previous values and <a href="https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
-</blockquote>
+</blockquote><p>Here&apos;s an example of a polling trigger that is also used to power a dynamic dropdown:</p>
     </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> perform = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+  <span class="hljs-keyword">const</span> params = { <span class="hljs-attr">per_page</span>: <span class="hljs-number">100</span> }; <span class="hljs-comment">// poll for the most recent 100 teams</span>
+
+  <span class="hljs-keyword">if</span> (bundle.meta.isFillingDynamicDropdown) {
+    <span class="hljs-comment">// dynamic dropdowns support pagination</span>
+    params.per_page = <span class="hljs-number">30</span>;
+    params.offset = params.per_page * bundle.meta.page;
+  }
+
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
+    <span class="hljs-attr">url</span>: <span class="hljs-string">`<span class="hljs-subst">${API_BASE_URL}</span>/teams`</span>,
+    params,
+  });
+
+  <span class="hljs-keyword">return</span> response.json;
+};
+  <span class="hljs-comment">// ...</span>
+</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -773,34 +773,7 @@ This object holds the user's auth details and the data for the API requests.
 
 > Before v8.0.0, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes) for a mapping of old values to new.
 
-There's also `bundle.meta.zap.id`, which is only available in the `performSubscribe` and `performUnsubscribe` methods.
 
-The user's Zap ID is available during the [subscribe and unsubscribe](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#basichookoperationschema) methods.
-
-For example - you could do:
-
-```js
-const subscribeHook = async (z, bundle) => {
-
-  const options = {
-    url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks',
-    method: 'POST',
-    body: {
-      url: bundle.targetUrl, // bundle.targetUrl has the Hook URL this app should call
-      zap_id: bundle.meta.zap.id,
-    },
-  };
-
-  const response = await z.request(options);
-  return response.data; // or response.json if you're using core v9 or older
-};
-
-module.exports = {
-  // ... see our rest hook example for additional details: https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js
-  performSubscribe: subscribeHook,
-  // ...
-};
-```
 
 ### `bundle.rawRequest`
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -773,6 +773,28 @@ This object holds the user's auth details and the data for the API requests.
 
 > Before v8.0.0, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes) for a mapping of old values to new.
 
+Here's an example of a polling trigger that is also used to power a dynamic dropdown:
+
+```js
+const perform = async (z, bundle) => {
+  const params = { per_page: 100 }; // poll for the most recent 100 teams
+
+  if (bundle.meta.isFillingDynamicDropdown) {
+    // dynamic dropdowns support pagination
+    params.per_page = 30;
+    params.offset = params.per_page * bundle.meta.page;
+  }
+
+  const response = await z.request({
+    url: `${API_BASE_URL}/teams`,
+    params,
+  });
+
+  return response.json;
+};
+  // ...
+```
+
 
 
 ### `bundle.rawRequest`

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -822,6 +822,30 @@ This object holds the user's auth details and the data for the API requests.
 
 This the URL to which you should send hook data. It'll look something like `https://hooks.zapier.com/1234/abcd`. We provide it so you can make a POST request to your server. Your server should store this URL and use is as a destination when there's new data to report.
 
+For example:
+
+```js
+const subscribeHook = async (z, bundle) => {
+
+  const options = {
+    url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks',
+    method: 'POST',
+    body: {
+      url: bundle.targetUrl, // bundle.targetUrl has the Hook URL this app should call
+    },
+  };
+
+  const response = await z.request(options);
+  return response.data; // or response.json if you're using core v9 or older
+};
+
+module.exports = {
+  // ...
+  performSubscribe: subscribeHook,
+  // ...
+};
+```
+
 Read more in the [REST hook example](https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js).
 
 ### `bundle.subscribeData`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1679,34 +1679,7 @@ This object holds the user's auth details and the data for the API requests.
 
 > Before v8.0.0, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes) for a mapping of old values to new.
 
-There's also `bundle.meta.zap.id`, which is only available in the `performSubscribe` and `performUnsubscribe` methods.
 
-The user's Zap ID is available during the [subscribe and unsubscribe](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#basichookoperationschema) methods.
-
-For example - you could do:
-
-```js
-const subscribeHook = async (z, bundle) => {
-
-  const options = {
-    url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks',
-    method: 'POST',
-    body: {
-      url: bundle.targetUrl, // bundle.targetUrl has the Hook URL this app should call
-      zap_id: bundle.meta.zap.id,
-    },
-  };
-
-  const response = await z.request(options);
-  return response.data; // or response.json if you're using core v9 or older
-};
-
-module.exports = {
-  // ... see our rest hook example for additional details: https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js
-  performSubscribe: subscribeHook,
-  // ...
-};
-```
 
 ### `bundle.rawRequest`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1679,6 +1679,28 @@ This object holds the user's auth details and the data for the API requests.
 
 > Before v8.0.0, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes) for a mapping of old values to new.
 
+Here's an example of a polling trigger that is also used to power a dynamic dropdown:
+
+```js
+const perform = async (z, bundle) => {
+  const params = { per_page: 100 }; // poll for the most recent 100 teams
+
+  if (bundle.meta.isFillingDynamicDropdown) {
+    // dynamic dropdowns support pagination
+    params.per_page = 30;
+    params.offset = params.per_page * bundle.meta.page;
+  }
+
+  const response = await z.request({
+    url: `${API_BASE_URL}/teams`,
+    params,
+  });
+
+  return response.json;
+};
+  // ...
+```
+
 
 
 ### `bundle.rawRequest`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1728,6 +1728,30 @@ This object holds the user's auth details and the data for the API requests.
 
 This the URL to which you should send hook data. It'll look something like `https://hooks.zapier.com/1234/abcd`. We provide it so you can make a POST request to your server. Your server should store this URL and use is as a destination when there's new data to report.
 
+For example:
+
+```js
+const subscribeHook = async (z, bundle) => {
+
+  const options = {
+    url: 'https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks',
+    method: 'POST',
+    body: {
+      url: bundle.targetUrl, // bundle.targetUrl has the Hook URL this app should call
+    },
+  };
+
+  const response = await z.request(options);
+  return response.data; // or response.json if you're using core v9 or older
+};
+
+module.exports = {
+  // ...
+  performSubscribe: subscribeHook,
+  // ...
+};
+```
+
 Read more in the [REST hook example](https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js).
 
 ### `bundle.subscribeData`

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2997,7 +2997,35 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p><code>bundle.targetUrl</code> is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods for webhooks.</p>
-</blockquote><p>This the URL to which you should send hook data. It&apos;ll look something like <code>https://hooks.zapier.com/1234/abcd</code>. We provide it so you can make a POST request to your server. Your server should store this URL and use is as a destination when there&apos;s new data to report.</p><p>Read more in the <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js">REST hook example</a>.</p>
+</blockquote><p>This the URL to which you should send hook data. It&apos;ll look something like <code>https://hooks.zapier.com/1234/abcd</code>. We provide it so you can make a POST request to your server. Your server should store this URL and use is as a destination when there&apos;s new data to report.</p><p>For example:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+
+  <span class="hljs-keyword">const</span> options = {
+    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks&apos;</span>,
+    <span class="hljs-attr">method</span>: <span class="hljs-string">&apos;POST&apos;</span>,
+    <span class="hljs-attr">body</span>: {
+      <span class="hljs-attr">url</span>: bundle.targetUrl, <span class="hljs-comment">// bundle.targetUrl has the Hook URL this app should call</span>
+    },
+  };
+
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(options);
+  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
+};
+
+<span class="hljs-built_in">module</span>.exports = {
+  <span class="hljs-comment">// ...</span>
+  <span class="hljs-attr">performSubscribe</span>: subscribeHook,
+  <span class="hljs-comment">// ...</span>
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Read more in the <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js">REST hook example</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2916,30 +2916,10 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Before v8.0.0, the information in <code>bundle.meta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> for the previous values and <a href="https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
-</blockquote><p>There&apos;s also <code>bundle.meta.zap.id</code>, which is only available in the <code>performSubscribe</code> and <code>performUnsubscribe</code> methods.</p><p>The user&apos;s Zap ID is available during the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#basichookoperationschema">subscribe and unsubscribe</a> methods.</p><p>For example - you could do:</p>
+</blockquote>
     </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> subscribeHook = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
-
-  <span class="hljs-keyword">const</span> options = {
-    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://57b20fb546b57d1100a3c405.mockapi.io/api/hooks&apos;</span>,
-    <span class="hljs-attr">method</span>: <span class="hljs-string">&apos;POST&apos;</span>,
-    <span class="hljs-attr">body</span>: {
-      <span class="hljs-attr">url</span>: bundle.targetUrl, <span class="hljs-comment">// bundle.targetUrl has the Hook URL this app should call</span>
-      <span class="hljs-attr">zap_id</span>: bundle.meta.zap.id,
-    },
-  };
-
-  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(options);
-  <span class="hljs-keyword">return</span> response.data; <span class="hljs-comment">// or response.json if you&apos;re using core v9 or older</span>
-};
-
-<span class="hljs-built_in">module</span>.exports = {
-  <span class="hljs-comment">// ... see our rest hook example for additional details: https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js</span>
-  <span class="hljs-attr">performSubscribe</span>: subscribeHook,
-  <span class="hljs-comment">// ...</span>
-};
-</code></pre>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2916,10 +2916,27 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Before v8.0.0, the information in <code>bundle.meta</code> was different. See <a href="https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta">the old docs</a> for the previous values and <a href="https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes">the wiki</a> for a mapping of old values to new.</p>
-</blockquote>
+</blockquote><p>Here&apos;s an example of a polling trigger that is also used to power a dynamic dropdown:</p>
     </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-keyword">const</span> perform = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+  <span class="hljs-keyword">const</span> params = { <span class="hljs-attr">per_page</span>: <span class="hljs-number">100</span> }; <span class="hljs-comment">// poll for the most recent 100 teams</span>
+
+  <span class="hljs-keyword">if</span> (bundle.meta.isFillingDynamicDropdown) {
+    <span class="hljs-comment">// dynamic dropdowns support pagination</span>
+    params.per_page = <span class="hljs-number">30</span>;
+    params.offset = params.per_page * bundle.meta.page;
+  }
+
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
+    <span class="hljs-attr">url</span>: <span class="hljs-string">`<span class="hljs-subst">${API_BASE_URL}</span>/teams`</span>,
+    params,
+  });
+
+  <span class="hljs-keyword">return</span> response.json;
+};
+  <span class="hljs-comment">// ...</span>
+</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -337,13 +337,11 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  {
-    label: 'New Thing',
+  { label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true
-  }
+    important: true }
   ```
 
 #### Anti-Examples
@@ -453,48 +451,38 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
-  }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -674,12 +662,7 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{
-  key: 'abc',
-  children: [
-    { key: 'def', children: [ { key: 'dhi' } ] }
-  ]
-}`
+* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -966,29 +949,19 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Create Tag',
-      description: 'Create a new Tag in your account.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1013,25 +986,19 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Properties
@@ -1056,29 +1023,19 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: {
-      type: 'hook',
-      perform: '$func$0$f$',
-      sample: { id: 385, name: 'proactive enable ROI' }
-    }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Properties
@@ -1103,38 +1060,24 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: {
-      perform: { url: 'https://fake-crm.getsandbox.com/users' },
-      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
-    }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation:
+     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
+       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.',
-      hidden: true
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display:
+     { label: 'New User',
+       description: 'Trigger when a new User is created in your account.',
+       hidden: true },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Properties
@@ -1159,31 +1102,21 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  {
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1208,81 +1141,55 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 
 #### Properties
@@ -1389,36 +1296,26 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1465,35 +1362,25 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-  }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
-    display: {
-      label: 'New Recipe',
-      description: 'Triggers when a new recipe is added.',
-      hidden: true
-    },
-    operation: { type: 'polling', perform: '$func$0$f$' }
-  }
+    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
+    operation: { type: 'polling', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' }
-  }
+    operation: { perform: '$func$0$f$' } }
   ```
 
 #### Properties


### PR DESCRIPTION
We should not rely on the bundle.meta.zap object in a CLI App, so we should remove the reference in the documentation. Slack discussion https://zapier.slack.com/archives/CH0SN5V0V/p1596691855293400