### PR TITLE
refactor(core): Increase max payload size for hydration

### DIFF
--- a/packages/core/src/tools/wrap-hydrate.js
+++ b/packages/core/src/tools/wrap-hydrate.js
@@ -4,7 +4,9 @@ const crypto = require('crypto');
 
 const { DehydrateError } = require('../errors');
 
-const MAX_PAYLOAD_SIZE = 2048;
+// Max URL length for Node is 8KB (https://stackoverflow.com/a/56954244/)
+// 8 * 1024 * (3 / 4) = 6144 max, minus some room for additional overhead
+const MAX_PAYLOAD_SIZE = 6000;
 
 const wrapHydrate = (payload) => {
   payload = JSON.stringify(payload);

--- a/packages/core/test/hydration.js
+++ b/packages/core/test/hydration.js
@@ -52,8 +52,8 @@ describe('hydration', () => {
       );
     });
 
-    it('should not accept payload size bigger than 2048 bytes.', () => {
-      const inputData = { key: 'a'.repeat(2049) };
+    it('should not accept payload size bigger than 6000 bytes.', () => {
+      const inputData = { key: 'a'.repeat(6001) };
       (() => {
         dehydrate(funcToFind, inputData);
       }).should.throw(/Oops! You passed too much data/);
@@ -91,8 +91,8 @@ describe('hydration', () => {
       );
     });
 
-    it('should not accept payload size bigger than 2048 bytes.', () => {
-      const inputData = { key: 'a'.repeat(2049) };
+    it('should not accept payload size bigger than 6000 bytes.', () => {
+      const inputData = { key: 'a'.repeat(6001) };
       (() => {
         dehydrateFile(funcToFind, inputData);
       }).should.throw(/Oops! You passed too much data/);


### PR DESCRIPTION
Original commit message:

The maximum URL size in Node 10+ is 8KB. We're setting a much lower limit for hydration payloads (2KB). This commit bumps that limit to get it much closer to the true upper bound.

Why not go for the true max of 6144 bytes? We add some additional overhead when converting from 'hydrate|||...|||hydrate'. There's a domain, a signature, other request headers, etc. 6000 pre-base64 is a nice, round number to cut off at.

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

--- 

On testing this out, I came to the realization that long `hydrate|||...|||hydrate` strings don't necessarily correlate to long URLs. The only time hydration really concerns a URL is after the results of `z.dehydrateFile`, which has a pretty standard length as far as I can tell. So I'm not sure we actually have a hard limit on how large of a payload to pass to `z.dehydrate` / `z.dehydrateFile` has to be (maybe 5 MB because of AWS restrictions?). I think 6kB should be _plenty_ of space for a `z.dehydrate` / `z.dehydrateFile` call though. 