### PR TITLE
fix(cli): _zapier-build should be optional

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -300,7 +300,7 @@ const maybeRunBuildScript = async (options = {}) => {
       'package.json'
     ));
 
-    if (_.get(pJson, 'scripts', ZAPIER_BUILD_KEY)) {
+    if (_.get(pJson, ['scripts', ZAPIER_BUILD_KEY])) {
       startSpinner(`Running ${ZAPIER_BUILD_KEY} script`);
       await runCommand('npm', ['run', ZAPIER_BUILD_KEY], options);
       endSpinner();

--- a/packages/core/smoke-test/smoke-test.js
+++ b/packages/core/smoke-test/smoke-test.js
@@ -13,13 +13,13 @@ const CORE_PACKAGE_NAME = 'zapier-platform-core';
 
 const TEST_APPS = [
   'basic-auth',
-  // 'create',
+  'create',
   // 'custom-auth',
   // 'oauth2',
   // 'resource',
   // 'search',
   // 'session-auth',
-  // 'trigger',
+  'trigger',
 ];
 
 const setupZapierRC = () => {

--- a/packages/core/smoke-test/smoke-test.js
+++ b/packages/core/smoke-test/smoke-test.js
@@ -13,13 +13,13 @@ const CORE_PACKAGE_NAME = 'zapier-platform-core';
 
 const TEST_APPS = [
   'basic-auth',
-  'create',
+  // 'create',
   // 'custom-auth',
   // 'oauth2',
   // 'resource',
   // 'search',
   // 'session-auth',
-  'trigger',
+  // 'trigger',
 ];
 
 const setupZapierRC = () => {
@@ -56,10 +56,14 @@ const setupZapierAppRC = (workdir) => {
   return hasAppRC;
 };
 
-const getSchemaDir = () => path.resolve(path.dirname(process.cwd()), 'schema');
+const getPackageDir = (dirname) =>
+  path.resolve(path.dirname(process.cwd()), dirname);
 
-const npmPackSchema = (schemaDir) => {
-  const proc = spawnSync('npm', ['pack'], { encoding: 'utf8', cwd: schemaDir });
+const npmPack = (workingDir) => {
+  const proc = spawnSync('npm', ['pack'], {
+    encoding: 'utf8',
+    cwd: workingDir,
+  });
   const lines = proc.stdout.split('\n');
   let filename;
   for (let i = lines.length - 1; i >= 0; i--) {
@@ -127,7 +131,7 @@ const copyTestApps = (workdir) => {
   });
 };
 
-const npmInstalls = (coreZipPath, workdir) => {
+const npmInstalls = (coreZipPath, cliZipPath, workdir) => {
   // When releasing a new core version, example apps would have bumped their
   // core before the new core version is published to npm. So we need to patch
   // example app's package.json to use local core temporarily to avoid `npm
@@ -144,7 +148,7 @@ const npmInstalls = (coreZipPath, workdir) => {
       encoding: 'utf8',
       cwd: workdir,
     });
-    spawnSync('npm', ['install', '--no-save', 'zapier-platform-cli'], {
+    spawnSync('npm', ['install', '--no-save', cliZipPath], {
       encoding: 'utf8',
       cwd: workdir,
     });
@@ -164,6 +168,10 @@ describe('smoke tests - setup will take some time', () => {
       filename: null,
       path: null,
     },
+    cliPackage: {
+      filename: null,
+      path: null,
+    },
     workRepoDir: null,
     workAppDir: null,
     cliBin: null,
@@ -174,8 +182,12 @@ describe('smoke tests - setup will take some time', () => {
   before(async () => {
     context.hasRC = setupZapierRC();
 
-    const schemaDir = getSchemaDir();
-    context.schemaPackage.filename = npmPackSchema(schemaDir);
+    const cliDir = getPackageDir('cli');
+    context.cliPackage.filename = npmPack(cliDir);
+    context.cliPackage.path = path.join(cliDir, context.cliPackage.filename);
+
+    const schemaDir = getPackageDir('schema');
+    context.schemaPackage.filename = npmPack(schemaDir);
     context.schemaPackage.path = path.join(
       schemaDir,
       context.schemaPackage.filename
@@ -193,6 +205,7 @@ describe('smoke tests - setup will take some time', () => {
   });
 
   after(() => {
+    fs.unlinkSync(context.cliPackage.path);
     fs.unlinkSync(context.corePackage.path);
     fs.unlinkSync(context.schemaPackage.path);
     fs.removeSync(context.workRepoDir);
@@ -221,7 +234,11 @@ describe('smoke tests - setup will take some time', () => {
     describe(appName, () => {
       before(async () => {
         context.workAppDir = path.join(context.workRepoDir, appName);
-        npmInstalls(context.corePackage.path, context.workAppDir);
+        npmInstalls(
+          context.corePackage.path,
+          context.cliPackage.path,
+          context.workAppDir
+        );
 
         context.hasAppRC = setupZapierAppRC(context.workAppDir);
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -337,13 +337,11 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  {
-    label: 'New Thing',
+  { label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true
-  }
+    important: true }
   ```
 
 #### Anti-Examples
@@ -453,48 +451,38 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
-  }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -674,12 +662,7 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{
-  key: 'abc',
-  children: [
-    { key: 'def', children: [ { key: 'dhi' } ] }
-  ]
-}`
+* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -966,29 +949,19 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Create Tag',
-      description: 'Create a new Tag in your account.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1013,25 +986,19 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Properties
@@ -1056,29 +1023,19 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: {
-      type: 'hook',
-      perform: '$func$0$f$',
-      sample: { id: 385, name: 'proactive enable ROI' }
-    }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Properties
@@ -1103,38 +1060,24 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: {
-      perform: { url: 'https://fake-crm.getsandbox.com/users' },
-      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
-    }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation:
+     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
+       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.',
-      hidden: true
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display:
+     { label: 'New User',
+       description: 'Trigger when a new User is created in your account.',
+       hidden: true },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Properties
@@ -1159,31 +1102,21 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  {
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1208,81 +1141,55 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 
 #### Properties
@@ -1389,36 +1296,26 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Properties
@@ -1465,35 +1362,25 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-  }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
-    display: {
-      label: 'New Recipe',
-      description: 'Triggers when a new recipe is added.',
-      hidden: true
-    },
-    operation: { type: 'polling', perform: '$func$0$f$' }
-  }
+    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
+    operation: { type: 'polling', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' }
-  }
+    operation: { perform: '$func$0$f$' } }
   ```
 
 #### Properties

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -337,11 +337,13 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  { label: 'New Thing',
+  {
+    label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true }
+    important: true
+  }
   ```
 
 #### Anti-Examples
@@ -451,38 +453,48 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -662,7 +674,12 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
+* `{
+  key: 'abc',
+  children: [
+    { key: 'def', children: [ { key: 'dhi' } ] }
+  ]
+}`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -949,19 +966,29 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Create Tag',
+      description: 'Create a new Tag in your account.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -986,19 +1013,25 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Properties
@@ -1023,19 +1056,29 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: {
+      type: 'hook',
+      perform: '$func$0$f$',
+      sample: { id: 385, name: 'proactive enable ROI' }
+    }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties
@@ -1060,24 +1103,38 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation:
-     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
-       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: {
+      perform: { url: 'https://fake-crm.getsandbox.com/users' },
+      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
+    }
+  }
   ```
 * ```
-  { display:
-     { label: 'New User',
-       description: 'Trigger when a new User is created in your account.',
-       hidden: true },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.',
+      hidden: true
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Properties
@@ -1102,21 +1159,31 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1141,55 +1208,81 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 
 #### Properties
@@ -1296,26 +1389,36 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1362,25 +1465,35 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
-    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
-    operation: { type: 'polling', perform: '$func$0$f$' } }
+    display: {
+      label: 'New Recipe',
+      description: 'Triggers when a new recipe is added.',
+      hidden: true
+    },
+    operation: { type: 'polling', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' } }
+    operation: { perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

CLI 10.1.0 incorrectly requires `_zapier-build` script to defined. To reproduce:

```
$ zapier -v
zapier-platform-cli/10.1.0 darwin-x64 node-v12.16.3

$ zapier init myapp --template minimal
...

$ cd myapp
$ yarn
...

$ zapier build
✖ Running _zapier-build script
 ›   Error: npm ERR! missing script: _zapier-build
 ›
 ›   npm ERR! A complete log of this run can be found in:
 ›   npm ERR!     /Users/eliang/.npm/_logs/2020-09-01T03_28_19_771Z-debug.log
 ›
 ›
 ›   re-run this command with `--debug` for more info
```

This is because of a misuse of `_.get()`. The diff should be self-explanatory.

Found this bug because the smoke tests were [failing](https://travis-ci.com/github/zapier/zapier-platform/jobs/379667535#L268). I'm not sure why the tests didn't catch that in https://github.com/zapier/zapier-platform/pull/262...