### PR TITLE
chore(cli,schema,core,legacy-scripting-runner): copy licenses and add them to package.json

### DIFF
--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,4 @@
+Copyright (c) Zapier, Inc.
+
+This repository is part of Zapier Platform, of which license terms can be found at
+https://zapier.com/platform/tos.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,8 +4,8 @@
   "description": "The CLI for managing integrations in Zapier Developer Platform.",
   "repository": "zapier/zapier-platform-cli",
   "homepage": "https://zapier.com/",
-  "author": "Bryan Helmig <bryan@zapier.com>",
-  "license": "UNLICENSED",
+  "author": "Zapier Engineering <contact@zapier.com>",
+  "license": "SEE LICENSE IN LICENSE",
   "main": "./src/index.js",
   "files": [
     "/src/*.js",

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,4 @@
+Copyright (c) Zapier, Inc.
+
+This repository is part of Zapier Platform, of which license terms can be found at
+https://zapier.com/platform/tos.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,8 +4,8 @@
   "description": "The core SDK for CLI apps in the Zapier Developer Platform.",
   "repository": "zapier/zapier-platform-core",
   "homepage": "https://zapier.com/",
-  "author": "Bryan Helmig <bryan@zapier.com>",
-  "license": "UNLICENSED",
+  "author": "Zapier Engineering <contact@zapier.com>",
+  "license": "SEE LICENSE IN LICENSE",
   "main": "index.js",
   "typings": "index.d.ts",
   "files": [

--- a/packages/legacy-scripting-runner/LICENSE
+++ b/packages/legacy-scripting-runner/LICENSE
@@ -1,0 +1,4 @@
+Copyright (c) Zapier, Inc.
+
+This repository is part of Zapier Platform, of which license terms can be found at
+https://zapier.com/platform/tos.

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -4,8 +4,8 @@
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform-legacy-scripting-runner",
   "homepage": "https://zapier.com/",
-  "author": "Zapier <partners@zapier.com>",
-  "license": "UNLICENSED",
+  "author": "Zapier Engineering <contact@zapier.com>",
+  "license": "SEE LICENSE IN LICENSE",
   "main": "index.js",
   "files": [
     "/*.js"

--- a/packages/schema/LICENSE
+++ b/packages/schema/LICENSE
@@ -1,0 +1,4 @@
+Copyright (c) Zapier, Inc.
+
+This repository is part of Zapier Platform, of which license terms can be found at
+https://zapier.com/platform/tos.

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -451,24 +451,29 @@ How will Zapier fetch resources from your application?
 
 * **Type** - `object`
 * **Pattern** - _n/a_
-* **Source Code** - [lib/schemas/BulkReadSchema.js](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@10.1.0/packages/schema/lib/schemas/BulkReadSchema.js)
+* **Source Code** - [lib/schemas/BulkReadSchema.js](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@10.1.1/packages/schema/lib/schemas/BulkReadSchema.js)
 
 #### Examples
 
 * ```
-  { key: 'recipes',
+  {
+    key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation:
-     { perform: '$func$0$f$',
-       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
+    operation: {
+      perform: '$func$0$f$',
+      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get User', description: 'Retrieve an a user.' },
-    operation: { description: 'Define how this search method will work.' } }
+  {
+    display: { label: 'Get User', description: 'Retrieve an a user.' },
+    operation: { description: 'Define how this search method will work.' }
+  }
   ```
 
 #### Properties
@@ -490,7 +495,7 @@ Enumerates the bulk reads your app exposes.
 
 * **Type** - `object`
 * **Pattern** - _n/a_
-* **Source Code** - [lib/schemas/BulkReadsSchema.js](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@10.1.0/packages/schema/lib/schemas/BulkReadsSchema.js)
+* **Source Code** - [lib/schemas/BulkReadsSchema.js](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@10.1.1/packages/schema/lib/schemas/BulkReadsSchema.js)
 
 
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -4,8 +4,8 @@
   "description": "Schema definition for CLI apps in the Zapier Developer Platform.",
   "repository": "zapier/zapier-platform-schema",
   "homepage": "https://zapier.com/",
-  "author": "Bryan Helmig <bryan@zapier.com>",
-  "license": "UNLICENSED",
+  "author": "Zapier Engineering <contact@zapier.com>",
+  "license": "SEE LICENSE IN LICENSE",
   "main": "schema.js",
   "files": [
     "/exported-schema.json",


### PR DESCRIPTION
I manually copied the root license file into individual subfolders (since `npm` doesn't follow symlinks 😞 ). We could add that step to the build process, but I don't anticipate these files changing often, so it wasn't worth it for now. 

The odd `package.json` syntax is from [the npm docs](https://docs.npmjs.com/files/package.json#license), where it says we should point to a license file via `"SEE LICENSE IN <filename>"`. 

For more context, see ([slack](https://zapier.slack.com/archives/C5Z9BP4U9/p1599606761202900?thread_ts=1598480207.066400&cid=C5Z9BP4U9)) and https://github.com/zapier/zapier/pull/43703