### PR TITLE
chore(cli): move docs script

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "docs": "ZAPIER_BASE_ENDPOINT='' node src/bin/docs.js && cp -r docs ../..",
+    "docs": "ZAPIER_BASE_ENDPOINT='' node scripts/docs.js && cp -r docs ../..",
     "preversion": "git pull && yarn validate",
     "prepack": "oclif-dev manifest",
     "postpack": "rm -f oclif.manifest.json",

--- a/packages/cli/scripts/docs.js
+++ b/packages/cli/scripts/docs.js
@@ -4,23 +4,25 @@
 const fs = require('fs');
 const path = require('path');
 
-const _ = require('lodash');
-
 const toc = require('markdown-toc');
 const litdoc = require('litdoc');
-const commands = require('../oclif/oCommands');
+const commands = require('../src/oclif/oCommands');
 
-const { LAMBDA_VERSION, PACKAGE_VERSION } = require('../constants');
+const { LAMBDA_VERSION, PACKAGE_VERSION } = require('../src/constants');
 
 // Takes all the cmd.docs and puts them into a big md file.
 const generateCliMarkdown = () => {
-  return _.orderBy(Object.keys(commands))
-    .filter((name) => !_.isBoolean(commands[name]))
-    .filter((name) => !commands[name].hide)
-    .map((name) => {
-      return commands[name].markdownHelp(name);
-    })
-    .join('\n\n\n');
+  return (
+    Object.keys(commands)
+      .sort()
+      // topics (such as `env` are listed as "true" in the commands so aliases play nice, but they don't need to be in docs
+      .filter((name) => commands[name] !== true)
+      .filter((name) => !commands[name].hide)
+      .map((name) => {
+        return commands[name].markdownHelp(name);
+      })
+      .join('\n\n\n')
+  );
 };
 
 // Writes out a big markdown file for the cli.
@@ -51,7 +53,7 @@ ${docs}
 const maybeInsertSnippet = (line) => {
   const m = line.match(/\[insert-file:(.+)\]/);
   if (m) {
-    const file = path.resolve(__dirname, '../..', m[1]);
+    const file = path.resolve(__dirname, '..', m[1]);
     return fs.readFileSync(file, 'utf8');
   }
   return line;
@@ -67,8 +69,8 @@ const fillPackageVersion = (line) => {
 
 // Inserts code snippets from README-source.md into README.md
 const buildReadme = () => {
-  const readmeSrc = path.resolve(__dirname, '../../README-source.md');
-  const readmeDst = path.resolve(__dirname, '../../README.md');
+  const readmeSrc = path.resolve(__dirname, '../README-source.md');
+  const readmeDst = path.resolve(__dirname, '../README.md');
 
   const lines = fs.readFileSync(readmeSrc, 'utf8').split('\n');
   const newLines = lines
@@ -91,16 +93,16 @@ writeCliDocs({
 
 litdoc({
   title: 'Zapier Platform CLI Documentation',
-  markdownPath: path.join(__dirname, '../../README.md'),
-  outputPath: path.join(__dirname, '../../docs/index.html'),
-  templatePath: path.join(__dirname, '../../docs/template.jst'),
+  markdownPath: path.join(__dirname, '../README.md'),
+  outputPath: path.join(__dirname, '../docs/index.html'),
+  templatePath: path.join(__dirname, '../docs/template.jst'),
 });
 
 // TODO: toc(../../docs/README.md) to ../../README.md
 
 litdoc({
   title: 'Zapier Platform CLI Reference',
-  markdownPath: path.join(__dirname, '../../docs/cli.md'),
-  outputPath: path.join(__dirname, '../../docs/cli.html'),
-  templatePath: path.join(__dirname, '../../docs/template.jst'),
+  markdownPath: path.join(__dirname, '../docs/cli.md'),
+  outputPath: path.join(__dirname, '../docs/cli.html'),
+  templatePath: path.join(__dirname, '../docs/template.jst'),
 });


### PR DESCRIPTION
This started as a PR to reduce our usage of `lodash` for size reasons, but I don't think it's worth the time right now. 

In any case, we don't actually have to ship this file as part of the CLI, so I moved it! 