### PR TITLE
docs(cli): document the `$HOIST$` property

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -324,6 +324,7 @@ a code {
 </ul>
 </li>
 <li><a href="#dehydration">Dehydration</a><ul>
+<li><a href="#merging-hydrated-data">Merging Hydrated Data</a></li>
 <li><a href="#file-dehydration">File Dehydration</a></li>
 </ul>
 </li>
@@ -365,7 +366,6 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&#39;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
-<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&#39;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -526,6 +526,7 @@ a code {
 </ul>
 </li>
 <li><a href="#dehydration">Dehydration</a><ul>
+<li><a href="#merging-hydrated-data">Merging Hydrated Data</a></li>
 <li><a href="#file-dehydration">File Dehydration</a></li>
 </ul>
 </li>
@@ -567,7 +568,6 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&apos;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
-<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -3704,6 +3704,48 @@ response.throwForStatus();
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="merging-hydrated-data">Merging Hydrated Data</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>As you&apos;ve seen, the usual call to dehydrate will assign the result to an object property:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In this example, all of the movie details will be located in the <code>details</code> property (e.g. <code>details.releaseDate</code>) after hydration occurs. But what if you want these results available at the top-level (e.g. <code>releaseDate</code>)? Zapier supports a specific keyword for this scenario:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.$HOIST$ = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Using <code>$HOIST$</code> as the key will signal to Zapier that the results should be merged into the object containing the <code>$HOIST$</code> key. You can also use this to merge your hydrated data into a property containing &quot;partial&quot; data that exists before dehydration occurs:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = {
+  <span class="hljs-attr">title</span>: movie.title,
+  <span class="hljs-attr">$HOIST$</span>: z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id })
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h3 id="file-dehydration">File Dehydration</h3>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4931,52 +4973,10 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p><p><a id="hoist"></a></p>
+      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h3 id="can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</h3>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>As you&apos;ve seen, the usual call to dehydrate will assign the result to an object property:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">movie.details = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>In this example, all of the move details will be located in the <code>details</code> property (e.g. <code>details.releaseDate</code>) after hydration occurs. But what if you want these results available at the top-level (e.g. <code>releaseDate</code>)? Zapier supports a specific keyword for this scenario:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">movie.$HOIST$ = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Using <code>$HOIST$</code> as the key will signal to Zapier that the results should be merged into the object containing the <code>$HOIST$</code> key. You can also use this to merge your hydrated data into a property containing &quot;partial&quot; data that exists before dehydration occurs:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">movie.details = {
-  <span class="hljs-attr">title</span>: movie.title,
-  <span class="hljs-attr">$HOIST$</span>: z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id })
-};
-</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/docs/index.html
+++ b/docs/index.html
@@ -365,6 +365,7 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&#39;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
+<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&#39;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -566,6 +567,7 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&apos;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
+<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -4929,10 +4931,52 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p>
+      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p><p><a id="hoist"></a></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>As you&apos;ve seen, the usual call to dehydrate will assign the result to an object property:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In this example, all of the move details will be located in the <code>details</code> property (e.g. <code>details.releaseDate</code>) after hydration occurs. But what if you want these results available at the top-level (e.g. <code>releaseDate</code>)? Zapier supports a specific keyword for this scenario:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.$HOIST$ = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Using <code>$HOIST$</code> as the key will signal to Zapier that the results should be merged into the object containing the <code>$HOIST$</code> key. You can also use this to merge your hydrated data into a property containing &quot;partial&quot; data that exists before dehydration occurs:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = {
+  <span class="hljs-attr">title</span>: movie.title,
+  <span class="hljs-attr">$HOIST$</span>: z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id })
+};
+</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1144,6 +1144,28 @@ And in future steps of the Zap - if Zapier encounters a pointer as returned by `
 
 > **Why can't I just load the data immediately?** Isn't it easier? In some cases it can be - but imagine an API that returns 100 records when polling - doing 100x `GET /id.json` aggressive inline HTTP calls when 99% of the time Zapier doesn't _need_ the data yet is wasteful.
 
+### Merging Hydrated Data
+
+As you've seen, the usual call to dehydrate will assign the result to an object property:
+
+```js
+movie.details = z.dehydrate(getMovieDetails, { id: movie.id });
+```
+
+In this example, all of the movie details will be located in the `details` property (e.g. `details.releaseDate`) after hydration occurs. But what if you want these results available at the top-level (e.g. `releaseDate`)? Zapier supports a specific keyword for this scenario:
+
+```js
+movie.$HOIST$ = z.dehydrate(getMovieDetails, { id: movie.id });
+```
+
+Using `$HOIST$` as the key will signal to Zapier that the results should be merged into the object containing the `$HOIST$` key. You can also use this to merge your hydrated data into a property containing "partial" data that exists before dehydration occurs:
+
+```js
+movie.details = {
+  title: movie.title,
+  $HOIST$: z.dehydrate(getMovieDetails, { id: movie.id })
+};
+```
 
 ### File Dehydration
 
@@ -1694,30 +1716,6 @@ Each time a polling Zap runs, Zapier needs to decide which of the items in the r
 For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.
 
 There's a more in-depth explanation [here](https://platform.zapier.com/legacy/dedupe).
-
-<a id="hoist"></a>
-### Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?
-
-As you've seen, the usual call to dehydrate will assign the result to an object property:
-
-```js
-movie.details = z.dehydrate(getMovieDetails, { id: movie.id });
-```
-
-In this example, all of the move details will be located in the `details` property (e.g. `details.releaseDate`) after hydration occurs. But what if you want these results available at the top-level (e.g. `releaseDate`)? Zapier supports a specific keyword for this scenario:
-
-```js
-movie.$HOIST$ = z.dehydrate(getMovieDetails, { id: movie.id });
-```
-
-Using `$HOIST$` as the key will signal to Zapier that the results should be merged into the object containing the `$HOIST$` key. You can also use this to merge your hydrated data into a property containing "partial" data that exists before dehydration occurs:
-
-```js
-movie.details = {
-  title: movie.title,
-  $HOIST$: z.dehydrate(getMovieDetails, { id: movie.id })
-};
-```
 
 ### Why are my triggers complaining if I don't provide an explicit `id` field?
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1695,6 +1695,30 @@ For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` i
 
 There's a more in-depth explanation [here](https://platform.zapier.com/legacy/dedupe).
 
+<a id="hoist"></a>
+### Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?
+
+As you've seen, the usual call to dehydrate will assign the result to an object property:
+
+```js
+movie.details = z.dehydrate(getMovieDetails, { id: movie.id });
+```
+
+In this example, all of the move details will be located in the `details` property (e.g. `details.releaseDate`) after hydration occurs. But what if you want these results available at the top-level (e.g. `releaseDate`)? Zapier supports a specific keyword for this scenario:
+
+```js
+movie.$HOIST$ = z.dehydrate(getMovieDetails, { id: movie.id });
+```
+
+Using `$HOIST$` as the key will signal to Zapier that the results should be merged into the object containing the `$HOIST$` key. You can also use this to merge your hydrated data into a property containing "partial" data that exists before dehydration occurs:
+
+```js
+movie.details = {
+  title: movie.title,
+  $HOIST$: z.dehydrate(getMovieDetails, { id: movie.id })
+};
+```
+
 ### Why are my triggers complaining if I don't provide an explicit `id` field?
 
 For deduplication to work, we need to be able to identify and use a unique field. In older, legacy Zapier Web Builder apps, we guessed if `id` wasn't present. In order to ensure we don't guess wrong, we now require that the developers send us an `id` field. If your objects have a differently-named unique field, feel free to adapt this snippet and ensure this test passes:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -127,6 +127,7 @@ This doc decribes the latest CLI version **10.1.1**, as of this writing. If you'
   * [How do search-powered fields relate to dynamic dropdowns and why are they both required together?](#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together)
   * [What's the deal with pagination? When is it used and how does it work?](#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work)
   * [How does deduplication work?](#how-does-deduplication-work)
+  * [Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?](#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property)
   * [Why are my triggers complaining if I don't provide an explicit `id` field?](#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field)
   * [Node X No Longer Supported](#node-x-no-longer-supported)
   * [What Analytics are Collected?](#what-analytics-are-collected)
@@ -3055,6 +3056,30 @@ Each time a polling Zap runs, Zapier needs to decide which of the items in the r
 For example, the initial poll returns objects 4, 5, and 6 (where a higher `id` is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.
 
 There's a more in-depth explanation [here](https://platform.zapier.com/legacy/dedupe).
+
+<a id="hoist"></a>
+### Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?
+
+As you've seen, the usual call to dehydrate will assign the result to an object property:
+
+```js
+movie.details = z.dehydrate(getMovieDetails, { id: movie.id });
+```
+
+In this example, all of the move details will be located in the `details` property (e.g. `details.releaseDate`) after hydration occurs. But what if you want these results available at the top-level (e.g. `releaseDate`)? Zapier supports a specific keyword for this scenario:
+
+```js
+movie.$HOIST$ = z.dehydrate(getMovieDetails, { id: movie.id });
+```
+
+Using `$HOIST$` as the key will signal to Zapier that the results should be merged into the object containing the `$HOIST$` key. You can also use this to merge your hydrated data into a property containing "partial" data that exists before dehydration occurs:
+
+```js
+movie.details = {
+  title: movie.title,
+  $HOIST$: z.dehydrate(getMovieDetails, { id: movie.id })
+};
+```
 
 ### Why are my triggers complaining if I don't provide an explicit `id` field?
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -324,6 +324,7 @@ a code {
 </ul>
 </li>
 <li><a href="#dehydration">Dehydration</a><ul>
+<li><a href="#merging-hydrated-data">Merging Hydrated Data</a></li>
 <li><a href="#file-dehydration">File Dehydration</a></li>
 </ul>
 </li>
@@ -365,7 +366,6 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&#39;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
-<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&#39;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -526,6 +526,7 @@ a code {
 </ul>
 </li>
 <li><a href="#dehydration">Dehydration</a><ul>
+<li><a href="#merging-hydrated-data">Merging Hydrated Data</a></li>
 <li><a href="#file-dehydration">File Dehydration</a></li>
 </ul>
 </li>
@@ -567,7 +568,6 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&apos;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
-<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -3704,6 +3704,48 @@ response.throwForStatus();
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="merging-hydrated-data">Merging Hydrated Data</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>As you&apos;ve seen, the usual call to dehydrate will assign the result to an object property:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In this example, all of the movie details will be located in the <code>details</code> property (e.g. <code>details.releaseDate</code>) after hydration occurs. But what if you want these results available at the top-level (e.g. <code>releaseDate</code>)? Zapier supports a specific keyword for this scenario:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.$HOIST$ = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Using <code>$HOIST$</code> as the key will signal to Zapier that the results should be merged into the object containing the <code>$HOIST$</code> key. You can also use this to merge your hydrated data into a property containing &quot;partial&quot; data that exists before dehydration occurs:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = {
+  <span class="hljs-attr">title</span>: movie.title,
+  <span class="hljs-attr">$HOIST$</span>: z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id })
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h3 id="file-dehydration">File Dehydration</h3>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4931,52 +4973,10 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p><p><a id="hoist"></a></p>
+      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h3 id="can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</h3>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>As you&apos;ve seen, the usual call to dehydrate will assign the result to an object property:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">movie.details = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>In this example, all of the move details will be located in the <code>details</code> property (e.g. <code>details.releaseDate</code>) after hydration occurs. But what if you want these results available at the top-level (e.g. <code>releaseDate</code>)? Zapier supports a specific keyword for this scenario:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">movie.$HOIST$ = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Using <code>$HOIST$</code> as the key will signal to Zapier that the results should be merged into the object containing the <code>$HOIST$</code> key. You can also use this to merge your hydrated data into a property containing &quot;partial&quot; data that exists before dehydration occurs:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js">movie.details = {
-  <span class="hljs-attr">title</span>: movie.title,
-  <span class="hljs-attr">$HOIST$</span>: z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id })
-};
-</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -365,6 +365,7 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&#39;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
+<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&#39;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -566,6 +567,7 @@ a code {
 <li><a href="#how-do-search-powered-fields-relate-to-dynamic-dropdowns-and-why-are-they-both-required-together">How do search-powered fields relate to dynamic dropdowns and why are they both required together?</a></li>
 <li><a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">What&apos;s the deal with pagination? When is it used and how does it work?</a></li>
 <li><a href="#how-does-deduplication-work">How does deduplication work?</a></li>
+<li><a href="#can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</a></li>
 <li><a href="#why-are-my-triggers-complaining-if-i-dont-provide-an-explicit-id-field">Why are my triggers complaining if I don&apos;t provide an explicit <code>id</code> field?</a></li>
 <li><a href="#node-x-no-longer-supported">Node X No Longer Supported</a></li>
 <li><a href="#what-analytics-are-collected">What Analytics are Collected?</a></li>
@@ -4929,10 +4931,52 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p>
+      <p>Each time a polling Zap runs, Zapier needs to decide which of the items in the response should trigger the zap. To do this, we compare the <code>id</code>s to all those we&apos;ve seen before, trigger on new objects, and update the list of seen <code>id</code>s. When a Zap is turned on, we initialize the list of seen <code>id</code>s with a single poll. When it&apos;s turned off, we clear that list. For this reason, it&apos;s important that calls to a polling endpoint always return the newest items.</p><p>For example, the initial poll returns objects 4, 5, and 6 (where a higher <code>id</code> is newer). If a later poll increases the limit and returns objects 1-6, then 1, 2, and 3 will be (incorrectly) treated like new objects.</p><p>There&apos;s a more in-depth explanation <a href="https://platform.zapier.com/legacy/dedupe">here</a>.</p><p><a id="hoist"></a></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="can-i-merge-my-hydrated-data-into-the-top-level-of-an-object-or-does-it-all-have-to-be-assigned-to-an-object-property">Can I merge my hydrated data into the top level of an object, or does it all have to be assigned to an object property?</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>As you&apos;ve seen, the usual call to dehydrate will assign the result to an object property:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In this example, all of the move details will be located in the <code>details</code> property (e.g. <code>details.releaseDate</code>) after hydration occurs. But what if you want these results available at the top-level (e.g. <code>releaseDate</code>)? Zapier supports a specific keyword for this scenario:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.$HOIST$ = z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id });
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Using <code>$HOIST$</code> as the key will signal to Zapier that the results should be merged into the object containing the <code>$HOIST$</code> key. You can also use this to merge your hydrated data into a property containing &quot;partial&quot; data that exists before dehydration occurs:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">movie.details = {
+  <span class="hljs-attr">title</span>: movie.title,
+  <span class="hljs-attr">$HOIST$</span>: z.dehydrate(getMovieDetails, { <span class="hljs-attr">id</span>: movie.id })
+};
+</code></pre>
     </div>
   </div>
 </div><div class="row">


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
We have recommended using the `$HOIST$` keyword when appropriate, but it hasn't been present in any documentation yet. Here's an attempt at succinctly describing the usage of the keyword. 🤞 