### PR TITLE
docs(cli): update "outdated" command references in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -946,7 +946,7 @@ npm install
 zapier register <span class="hljs-string">&quot;Zapier Example&quot;</span>
 
 <span class="hljs-comment"># list your apps</span>
-zapier apps
+zapier integrations
 </code></pre>
     </div>
   </div>
@@ -1044,10 +1044,10 @@ zapier versions
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># sends an email this user to let them view the app version 1.0.0 in the UI privately</span>
-zapier invite user@example.com 1.0.0
+zapier users:add user@example.com 1.0.0
 
 <span class="hljs-comment"># sends an email this user to let them admin the app (make changes just like you)</span>
-zapier collaborate user@example.com
+zapier team:add user@example.com
 </code></pre>
     </div>
   </div>
@@ -1404,8 +1404,8 @@ zapier convert 1234 --version 1.0.1 my-app
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_ID=1234
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_SECRET=abcd
 
 <span class="hljs-comment"># and when running tests locally, don&apos;t forget to define them in .env or in the command!</span>
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</span>
@@ -1536,8 +1536,8 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_ID=1234
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_SECRET=abcd
 
 <span class="hljs-comment"># and when running tests locally, don&apos;t forget to define them in .env or in the command!</span>
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</span>
@@ -3109,7 +3109,7 @@ made to one version&apos;s environment will not affect the other versions.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># Will set the environment variable on Zapier.com</span>
-zapier env 1.0.0 MY_SECRET_VALUE 1234
+zapier env:<span class="hljs-built_in">set</span> 1.0.0 MY_SECRET_VALUE=1234
 </code></pre>
     </div>
   </div>
@@ -3137,7 +3137,7 @@ zapier env 1.0.0 MY_SECRET_VALUE 1234
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is depreated but will continue to work for backward compatibility.</p>
+<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is deprecated but will continue to work for backward compatibility.</p>
 </blockquote><p>And then in your <code>test/basic.js</code> file:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -3157,7 +3157,7 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
       <blockquote>
 <p>This is a popular way to provide <code>process.env.ACCESS_TOKEN || bundle.authData.access_token</code> for convenient testing.</p>
 </blockquote><blockquote>
-<p><strong>NOTE</strong> Variables defined via <code>zapier env</code> will <em>always</em> be uppercased. For example, you would access the variable defined by <code>zapier env 1.0.0 foo_bar 1234</code> with <code>process.env.FOO_BAR</code>.</p>
+<p><strong>NOTE</strong> Variables defined via <code>zapier env:set</code> will <em>always</em> be uppercased. For example, you would access the variable defined by <code>zapier env:set 1.0.0 foo_bar=1234</code> with <code>process.env.FOO_BAR</code>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -3180,14 +3180,14 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># Will print a table listing the variables for this version</span>
-zapier env 1.0.0
+zapier env:get 1.0.0
 </code></pre>
     </div>
   </div>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Within your app, you can access the environment via the standard <code>process.env</code> - any values set via local <code>export</code> or <code>zapier env</code> will be there.</p><p>For example, you can access the <code>process.env</code> in your perform functions and in templates:</p>
+      <p>Within your app, you can access the environment via the standard <code>process.env</code> - any values set via local <code>export</code> or <code>zapier env:set</code> will be there.</p><p>For example, you can access the <code>process.env</code> in your perform functions and in templates:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> listExample = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
@@ -4196,7 +4196,7 @@ refresh:</p>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You can write unit tests for your Zapier app that run locally, outside of the zapier editor.
+      <p>You can write unit tests for your Zapier app that run locally, outside of the Zapier editor.
 You can run these tests in a CI tool like <a href="https://travis-ci.com/">Travis</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4683,7 +4683,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You will see both <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Expression_interpolation">template literal placeholders</a> <code>${var}</code> and (double) &quot;curlies&quot; <code>{{var}}</code> used in examples.</p><p>In general, use <code>${var}</code> within functions and use <code>{{var}}</code> anywhere else.</p><p>Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use <code>${process.env.VAR}</code> in a trigger configuration, <code>zapier push</code> will substitute it with your local environment&apos;s value for <code>VAR</code> when it builds your app and the value set via <code>zapier env</code> will not be used.</p><blockquote>
+      <p>You will see both <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Expression_interpolation">template literal placeholders</a> <code>${var}</code> and (double) &quot;curlies&quot; <code>{{var}}</code> used in examples.</p><p>In general, use <code>${var}</code> within functions and use <code>{{var}}</code> anywhere else.</p><p>Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use <code>${process.env.VAR}</code> in a trigger configuration, <code>zapier push</code> will substitute it with your local environment&apos;s value for <code>VAR</code> when it builds your app and the value set via <code>zapier env:set</code> will not be used.</p><blockquote>
 <p>If you&apos;re not familiar with <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>, know that <code>const val = &quot;a&quot; + b + &quot;c&quot;</code> is essentially the same as <code>const val = `a${b}c`</code>.</p>
 </blockquote>
     </div>
@@ -5140,7 +5140,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The Zapier platform and its tools are under active development. While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforeseen circumstances, all released platform versions will continue to work for the forseeable future. While you never <em>have</em> to upgrade your app&apos;s <code>zapier-platform-core</code> dependency, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md">changelog</a> to see what new features and bux fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <strong>10.1.1</strong>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://www.npmjs.com/package/zapier-platform-core?activeTab=versions">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
+      <p>The Zapier platform and its tools are under active development. While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforeseen circumstances, all released platform versions will continue to work for the foreseeable future. While you never <em>have</em> to upgrade your app&apos;s <code>zapier-platform-core</code> dependency, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md">changelog</a> to see what new features and bug fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <strong>10.1.1</strong>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://www.npmjs.com/package/zapier-platform-core?activeTab=versions">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -204,7 +204,7 @@ Registering your App with Zapier is a necessary first step which only enables ba
 zapier register "Zapier Example"
 
 # list your apps
-zapier apps
+zapier integrations
 ```
 
 > Note: This doesn't put your app in the editor - see the docs on pushing an App Version to do that!
@@ -254,10 +254,10 @@ This is how you would share your app with friends, co-workers or clients. This i
 
 ```bash
 # sends an email this user to let them view the app version 1.0.0 in the UI privately
-zapier invite user@example.com 1.0.0
+zapier users:add user@example.com 1.0.0
 
 # sends an email this user to let them admin the app (make changes just like you)
-zapier collaborate user@example.com
+zapier team:add user@example.com
 ```
 
 You can also invite anyone on the internet to your app by using the links from `zapier users:links`. The link should look something like `https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/`. You can put this in your help docs, post it to Twitter, add it to your email campaign, etc. You can choose an invite link specific to an app version or for the entire app (i.e. all app versions).
@@ -381,8 +381,8 @@ You'll also likely need to set your `CLIENT_ID` and `CLIENT_SECRET` as environme
 
 ```bash
 # setting the environment variables on Zapier.com
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:set 1.0.0 CLIENT_ID=1234
+$ zapier env:set 1.0.0 CLIENT_SECRET=abcd
 
 # and when running tests locally, don't forget to define them in .env or in the command!
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
@@ -414,8 +414,8 @@ You are required to define the authorization URL and the API call to fetch the a
 
 ```bash
 # setting the environment variables on Zapier.com
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:set 1.0.0 CLIENT_ID=1234
+$ zapier env:set 1.0.0 CLIENT_SECRET=abcd
 
 # and when running tests locally, don't forget to define them in .env or in the command!
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
@@ -895,7 +895,7 @@ To define an environment variable, use the `env` command:
 
 ```bash
 # Will set the environment variable on Zapier.com
-zapier env 1.0.0 MY_SECRET_VALUE 1234
+zapier env:set 1.0.0 MY_SECRET_VALUE=1234
 ```
 
 You will likely also want to set the value locally for testing.
@@ -910,7 +910,7 @@ Alternatively, we provide some extra tooling to work with an `.env` (or `.enviro
 MY_SECRET_VALUE=1234
 ```
 
-> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is depreated but will continue to work for backward compatibility.
+> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is deprecated but will continue to work for backward compatibility.
 
 And then in your `test/basic.js` file:
 
@@ -926,7 +926,7 @@ should('some tests', () => {
 
 > This is a popular way to provide `process.env.ACCESS_TOKEN || bundle.authData.access_token` for convenient testing.
 
-> **NOTE** Variables defined via `zapier env` will _always_ be uppercased. For example, you would access the variable defined by `zapier env 1.0.0 foo_bar 1234` with `process.env.FOO_BAR`.
+> **NOTE** Variables defined via `zapier env:set` will _always_ be uppercased. For example, you would access the variable defined by `zapier env:set 1.0.0 foo_bar=1234` with `process.env.FOO_BAR`.
 
 
 ### Accessing Environment Variables
@@ -935,10 +935,10 @@ To view existing environment variables, use the `env` command.
 
 ```bash
 # Will print a table listing the variables for this version
-zapier env 1.0.0
+zapier env:get 1.0.0
 ```
 
-Within your app, you can access the environment via the standard `process.env` - any values set via local `export` or `zapier env` will be there.
+Within your app, you can access the environment via the standard `process.env` - any values set via local `export` or `zapier env:set` will be there.
 
 For example, you can access the `process.env` in your perform functions and in templates:
 
@@ -1399,7 +1399,7 @@ const yourAfterResponse = (resp) => {
 
 ## Testing
 
-You can write unit tests for your Zapier app that run locally, outside of the zapier editor.
+You can write unit tests for your Zapier app that run locally, outside of the Zapier editor.
 You can run these tests in a CI tool like [Travis](https://travis-ci.com/).
 
 ### Writing Unit Tests
@@ -1623,7 +1623,7 @@ You will see both [template literal placeholders](https://developer.mozilla.org/
 
 In general, use `${var}` within functions and use `{{var}}` anywhere else.
 
-Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use `${process.env.VAR}` in a trigger configuration, `zapier push` will substitute it with your local environment's value for `VAR` when it builds your app and the value set via `zapier env` will not be used.
+Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use `${process.env.VAR}` in a trigger configuration, `zapier push` will substitute it with your local environment's value for `VAR` when it builds your app and the value set via `zapier env:set` will not be used.
 
 > If you're not familiar with [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), know that `const val = "a" + b + "c"` is essentially the same as <code>const val = &#96;a${b}c&#96;</code>.
 
@@ -1803,7 +1803,7 @@ The Zapier Platform consists of 3 npm packages that are released simultaneously 
 
 The Zapier platform and its tools are under active development. While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
 
-Barring unforeseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's `zapier-platform-core` dependency, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
+Barring unforeseen circumstances, all released platform versions will continue to work for the foreseeable future. While you never *have* to upgrade your app's `zapier-platform-core` dependency, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md) to see what new features and bug fixes are available.
 
 <!-- TODO: if we decouple releases, change this -->
 The most recently released version of `cli` and `core` is **PACKAGE_VERSION**. You can see the versions you're working with by running `zapier -v`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -339,7 +339,7 @@ Registering your App with Zapier is a necessary first step which only enables ba
 zapier register "Zapier Example"
 
 # list your apps
-zapier apps
+zapier integrations
 ```
 
 > Note: This doesn't put your app in the editor - see the docs on pushing an App Version to do that!
@@ -389,10 +389,10 @@ This is how you would share your app with friends, co-workers or clients. This i
 
 ```bash
 # sends an email this user to let them view the app version 1.0.0 in the UI privately
-zapier invite user@example.com 1.0.0
+zapier users:add user@example.com 1.0.0
 
 # sends an email this user to let them admin the app (make changes just like you)
-zapier collaborate user@example.com
+zapier team:add user@example.com
 ```
 
 You can also invite anyone on the internet to your app by using the links from `zapier users:links`. The link should look something like `https://zapier.com/platform/public-invite/1/222dcd03aed943a8676dc80e2427a40d/`. You can put this in your help docs, post it to Twitter, add it to your email campaign, etc. You can choose an invite link specific to an app version or for the entire app (i.e. all app versions).
@@ -652,8 +652,8 @@ You'll also likely need to set your `CLIENT_ID` and `CLIENT_SECRET` as environme
 
 ```bash
 # setting the environment variables on Zapier.com
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:set 1.0.0 CLIENT_ID=1234
+$ zapier env:set 1.0.0 CLIENT_SECRET=abcd
 
 # and when running tests locally, don't forget to define them in .env or in the command!
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
@@ -764,8 +764,8 @@ You are required to define the authorization URL and the API call to fetch the a
 
 ```bash
 # setting the environment variables on Zapier.com
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:set 1.0.0 CLIENT_ID=1234
+$ zapier env:set 1.0.0 CLIENT_SECRET=abcd
 
 # and when running tests locally, don't forget to define them in .env or in the command!
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
@@ -1802,7 +1802,7 @@ To define an environment variable, use the `env` command:
 
 ```bash
 # Will set the environment variable on Zapier.com
-zapier env 1.0.0 MY_SECRET_VALUE 1234
+zapier env:set 1.0.0 MY_SECRET_VALUE=1234
 ```
 
 You will likely also want to set the value locally for testing.
@@ -1817,7 +1817,7 @@ Alternatively, we provide some extra tooling to work with an `.env` (or `.enviro
 MY_SECRET_VALUE=1234
 ```
 
-> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is depreated but will continue to work for backward compatibility.
+> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is deprecated but will continue to work for backward compatibility.
 
 And then in your `test/basic.js` file:
 
@@ -1833,7 +1833,7 @@ should('some tests', () => {
 
 > This is a popular way to provide `process.env.ACCESS_TOKEN || bundle.authData.access_token` for convenient testing.
 
-> **NOTE** Variables defined via `zapier env` will _always_ be uppercased. For example, you would access the variable defined by `zapier env 1.0.0 foo_bar 1234` with `process.env.FOO_BAR`.
+> **NOTE** Variables defined via `zapier env:set` will _always_ be uppercased. For example, you would access the variable defined by `zapier env:set 1.0.0 foo_bar=1234` with `process.env.FOO_BAR`.
 
 
 ### Accessing Environment Variables
@@ -1842,10 +1842,10 @@ To view existing environment variables, use the `env` command.
 
 ```bash
 # Will print a table listing the variables for this version
-zapier env 1.0.0
+zapier env:get 1.0.0
 ```
 
-Within your app, you can access the environment via the standard `process.env` - any values set via local `export` or `zapier env` will be there.
+Within your app, you can access the environment via the standard `process.env` - any values set via local `export` or `zapier env:set` will be there.
 
 For example, you can access the `process.env` in your perform functions and in templates:
 
@@ -2543,7 +2543,7 @@ const yourAfterResponse = (resp) => {
 
 ## Testing
 
-You can write unit tests for your Zapier app that run locally, outside of the zapier editor.
+You can write unit tests for your Zapier app that run locally, outside of the Zapier editor.
 You can run these tests in a CI tool like [Travis](https://travis-ci.com/).
 
 ### Writing Unit Tests
@@ -2837,7 +2837,7 @@ You will see both [template literal placeholders](https://developer.mozilla.org/
 
 In general, use `${var}` within functions and use `{{var}}` anywhere else.
 
-Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use `${process.env.VAR}` in a trigger configuration, `zapier push` will substitute it with your local environment's value for `VAR` when it builds your app and the value set via `zapier env` will not be used.
+Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use `${process.env.VAR}` in a trigger configuration, `zapier push` will substitute it with your local environment's value for `VAR` when it builds your app and the value set via `zapier env:set` will not be used.
 
 > If you're not familiar with [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals), know that `const val = "a" + b + "c"` is essentially the same as <code>const val = &#96;a${b}c&#96;</code>.
 
@@ -3165,7 +3165,7 @@ The Zapier Platform consists of 3 npm packages that are released simultaneously 
 
 The Zapier platform and its tools are under active development. While you don't need to install every release, we release new versions because they are better than the last. We do our best to adhere to [Semantic Versioning](https://semver.org/) wherein we won't break your code unless there's a `major` release. Otherwise, we're just fixing bugs (`patch`) and adding features (`minor`).
 
-Barring unforeseen circumstances, all released platform versions will continue to work for the forseeable future. While you never *have* to upgrade your app's `zapier-platform-core` dependency, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md) to see what new features and bux fixes are available.
+Barring unforeseen circumstances, all released platform versions will continue to work for the foreseeable future. While you never *have* to upgrade your app's `zapier-platform-core` dependency, we recommend keeping an eye on the [changelog](https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md) to see what new features and bug fixes are available.
 
 <!-- TODO: if we decouple releases, change this -->
 The most recently released version of `cli` and `core` is **10.1.1**. You can see the versions you're working with by running `zapier -v`.

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -946,7 +946,7 @@ npm install
 zapier register <span class="hljs-string">&quot;Zapier Example&quot;</span>
 
 <span class="hljs-comment"># list your apps</span>
-zapier apps
+zapier integrations
 </code></pre>
     </div>
   </div>
@@ -1044,10 +1044,10 @@ zapier versions
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># sends an email this user to let them view the app version 1.0.0 in the UI privately</span>
-zapier invite user@example.com 1.0.0
+zapier users:add user@example.com 1.0.0
 
 <span class="hljs-comment"># sends an email this user to let them admin the app (make changes just like you)</span>
-zapier collaborate user@example.com
+zapier team:add user@example.com
 </code></pre>
     </div>
   </div>
@@ -1404,8 +1404,8 @@ zapier convert 1234 --version 1.0.1 my-app
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_ID=1234
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_SECRET=abcd
 
 <span class="hljs-comment"># and when running tests locally, don&apos;t forget to define them in .env or in the command!</span>
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</span>
@@ -1536,8 +1536,8 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
-$ zapier env 1.0.0 CLIENT_ID 1234
-$ zapier env 1.0.0 CLIENT_SECRET abcd
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_ID=1234
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_SECRET=abcd
 
 <span class="hljs-comment"># and when running tests locally, don&apos;t forget to define them in .env or in the command!</span>
 $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</span>
@@ -3109,7 +3109,7 @@ made to one version&apos;s environment will not affect the other versions.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># Will set the environment variable on Zapier.com</span>
-zapier env 1.0.0 MY_SECRET_VALUE 1234
+zapier env:<span class="hljs-built_in">set</span> 1.0.0 MY_SECRET_VALUE=1234
 </code></pre>
     </div>
   </div>
@@ -3137,7 +3137,7 @@ zapier env 1.0.0 MY_SECRET_VALUE 1234
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is depreated but will continue to work for backward compatibility.</p>
+<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is deprecated but will continue to work for backward compatibility.</p>
 </blockquote><p>And then in your <code>test/basic.js</code> file:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -3157,7 +3157,7 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
       <blockquote>
 <p>This is a popular way to provide <code>process.env.ACCESS_TOKEN || bundle.authData.access_token</code> for convenient testing.</p>
 </blockquote><blockquote>
-<p><strong>NOTE</strong> Variables defined via <code>zapier env</code> will <em>always</em> be uppercased. For example, you would access the variable defined by <code>zapier env 1.0.0 foo_bar 1234</code> with <code>process.env.FOO_BAR</code>.</p>
+<p><strong>NOTE</strong> Variables defined via <code>zapier env:set</code> will <em>always</em> be uppercased. For example, you would access the variable defined by <code>zapier env:set 1.0.0 foo_bar=1234</code> with <code>process.env.FOO_BAR</code>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -3180,14 +3180,14 @@ should(<span class="hljs-string">&apos;some tests&apos;</span>, () =&gt; {
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># Will print a table listing the variables for this version</span>
-zapier env 1.0.0
+zapier env:get 1.0.0
 </code></pre>
     </div>
   </div>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Within your app, you can access the environment via the standard <code>process.env</code> - any values set via local <code>export</code> or <code>zapier env</code> will be there.</p><p>For example, you can access the <code>process.env</code> in your perform functions and in templates:</p>
+      <p>Within your app, you can access the environment via the standard <code>process.env</code> - any values set via local <code>export</code> or <code>zapier env:set</code> will be there.</p><p>For example, you can access the <code>process.env</code> in your perform functions and in templates:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> listExample = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
@@ -4196,7 +4196,7 @@ refresh:</p>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You can write unit tests for your Zapier app that run locally, outside of the zapier editor.
+      <p>You can write unit tests for your Zapier app that run locally, outside of the Zapier editor.
 You can run these tests in a CI tool like <a href="https://travis-ci.com/">Travis</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4683,7 +4683,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>You will see both <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Expression_interpolation">template literal placeholders</a> <code>${var}</code> and (double) &quot;curlies&quot; <code>{{var}}</code> used in examples.</p><p>In general, use <code>${var}</code> within functions and use <code>{{var}}</code> anywhere else.</p><p>Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use <code>${process.env.VAR}</code> in a trigger configuration, <code>zapier push</code> will substitute it with your local environment&apos;s value for <code>VAR</code> when it builds your app and the value set via <code>zapier env</code> will not be used.</p><blockquote>
+      <p>You will see both <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Expression_interpolation">template literal placeholders</a> <code>${var}</code> and (double) &quot;curlies&quot; <code>{{var}}</code> used in examples.</p><p>In general, use <code>${var}</code> within functions and use <code>{{var}}</code> anywhere else.</p><p>Placeholders get evaluated as soon as the line of code is evaluated. This means that if you use <code>${process.env.VAR}</code> in a trigger configuration, <code>zapier push</code> will substitute it with your local environment&apos;s value for <code>VAR</code> when it builds your app and the value set via <code>zapier env:set</code> will not be used.</p><blockquote>
 <p>If you&apos;re not familiar with <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals">template literals</a>, know that <code>const val = &quot;a&quot; + b + &quot;c&quot;</code> is essentially the same as <code>const val = `a${b}c`</code>.</p>
 </blockquote>
     </div>
@@ -5140,7 +5140,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The Zapier platform and its tools are under active development. While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforeseen circumstances, all released platform versions will continue to work for the forseeable future. While you never <em>have</em> to upgrade your app&apos;s <code>zapier-platform-core</code> dependency, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md">changelog</a> to see what new features and bux fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <strong>10.1.1</strong>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://www.npmjs.com/package/zapier-platform-core?activeTab=versions">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
+      <p>The Zapier platform and its tools are under active development. While you don&apos;t need to install every release, we release new versions because they are better than the last. We do our best to adhere to <a href="https://semver.org/">Semantic Versioning</a> wherein we won&apos;t break your code unless there&apos;s a <code>major</code> release. Otherwise, we&apos;re just fixing bugs (<code>patch</code>) and adding features (<code>minor</code>).</p><p>Barring unforeseen circumstances, all released platform versions will continue to work for the foreseeable future. While you never <em>have</em> to upgrade your app&apos;s <code>zapier-platform-core</code> dependency, we recommend keeping an eye on the <a href="https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md">changelog</a> to see what new features and bug fixes are available.</p><p>The most recently released version of <code>cli</code> and <code>core</code> is <strong>10.1.1</strong>. You can see the versions you&apos;re working with by running <code>zapier -v</code>.</p><p>To update <code>cli</code>, run <code>npm install -g zapier-platform-cli</code>.</p><p>To update the version of <code>core</code> your app depends on, set the <code>zapier-platform-core</code> dependency in your <code>package.json</code> to a version listed <a href="https://www.npmjs.com/package/zapier-platform-core?activeTab=versions">here</a> and run <code>npm install</code>.</p><p>For maximum compatibility, keep the versions of <code>cli</code> and <code>core</code> in sync.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
```
invite -> users:add
collaborate -> team:add
apps -> integrations
env -> env:set / get
```

Additionally, picked up a couple of tiny typos that were present in the surrounding area when I saw them.

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
