### PR TITLE
feat(core): Add bulkReads as a qualified user of the cursor storage

### DIFF
--- a/packages/core/src/tools/create-app-tester.js
+++ b/packages/core/src/tools/create-app-tester.js
@@ -20,7 +20,8 @@ const shouldPaginate = (appRaw, method) => {
   if (
     method.endsWith('perform') &&
     ((methodParts[0] === 'resources' && methodParts[2] === 'list') ||
-      methodParts[0] === 'triggers')
+      methodParts[0] === 'triggers' ||
+      methodParts[0] === 'bulkReads')
   ) {
     methodParts.pop();
     return get(appRaw, [...methodParts, 'canPaginate']);


### PR DESCRIPTION
While trying to leverage the paging cursor in the new `bulkReads` actions, I noticed the system was claiming the tokens being passed up were null. Found this check and modified to accommodate for `bulkReads`

I looked into adding tests, but it doesn't seem this restriction is tested anywhere. Not sure where a good place would be to add one, or if we're cool w this point change.