### PR TITLE
fix(core): Add callback_url fallback for testing

### DIFF
--- a/packages/core/src/tools/create-app-tester.js
+++ b/packages/core/src/tools/create-app-tester.js
@@ -67,6 +67,7 @@ const createAppTester = (appRaw, { customStoreKey } = {}) => {
       method,
       bundle,
       storeKey,
+      callback_url: 'https://auth-json-server.zapier-staging.com/echo',
     };
 
     if (process.env.LOG_TO_STDOUT) {

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -340,11 +340,13 @@ Represents user information for a trigger, search, or create.
 
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  { label: 'New Thing',
+  {
+    label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true }
+    important: true
+  }
   ```
 
 #### Anti-Examples
@@ -454,19 +456,24 @@ How will Zapier fetch resources from your application?
 #### Examples
 
 * ```
-  { key: 'recipes',
+  {
+    key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation:
-     { perform: '$func$0$f$',
-       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
+    operation: {
+      perform: '$func$0$f$',
+      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get User', description: 'Retrieve an a user.' },
-    operation: { description: 'Define how this search method will work.' } }
+  {
+    display: { label: 'Get User', description: 'Retrieve an a user.' },
+    operation: { description: 'Define how this search method will work.' }
+  }
   ```
 
 #### Properties
@@ -513,38 +520,48 @@ How will Zapier create a new object?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -724,7 +741,12 @@ Defines a field an app either needs as input, or gives as output. In addition to
 * `{ key: 'abc', type: 'loltype' }`
 * `{ key: 'abc', children: [], helpText: '' }`
 * `{ key: 'abc', children: [ { key: 'def', children: [] } ] }`
-* `{ key: 'abc', children: [ { key: 'def', children: [ { key: 'dhi' } ] } ] }`
+* `{
+  key: 'abc',
+  children: [
+    { key: 'def', children: [ { key: 'dhi' } ] }
+  ]
+}`
 * `{ key: 'abc', children: [ '$func$2$f$' ] }`
 
 #### Properties
@@ -1011,19 +1033,29 @@ How will we find create a specific object given inputs? Will be turned into a cr
 #### Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Create Tag',
+      description: 'Create a new Tag in your account.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1048,19 +1080,25 @@ How will we get a single object given a unique identifier/id?
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Properties
@@ -1085,19 +1123,29 @@ How will we get notified of new objects? Will be turned into a trigger automatic
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: {
+      type: 'hook',
+      perform: '$func$0$f$',
+      sample: { id: 385, name: 'proactive enable ROI' }
+    }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties
@@ -1122,24 +1170,38 @@ How will we get a list of new objects? Will be turned into a trigger automatical
 #### Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation:
-     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
-       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: {
+      perform: { url: 'https://fake-crm.getsandbox.com/users' },
+      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
+    }
+  }
   ```
 * ```
-  { display:
-     { label: 'New User',
-       description: 'Trigger when a new User is created in your account.',
-       hidden: true },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.',
+      hidden: true
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Properties
@@ -1164,21 +1226,31 @@ How will we find a specific object given filters or search terms? Will be turned
 #### Examples
 
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1203,55 +1275,81 @@ Represents a resource, which will in turn power triggers, searches, or creates.
 #### Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 
 #### Properties
@@ -1358,26 +1456,36 @@ How will Zapier search for existing objects?
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'`
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Properties
@@ -1424,25 +1532,35 @@ How will Zapier get notified of new objects?
 #### Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
-    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
-    operation: { type: 'polling', perform: '$func$0$f$' } }
+    display: {
+      label: 'New Recipe',
+      description: 'Triggers when a new recipe is added.',
+      hidden: true
+    },
+    operation: { type: 'polling', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' } }
+    operation: { perform: '$func$0$f$' }
+  }
   ```
 
 #### Properties


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

`z.generateCallbackUrl()` presently returns `undefined` when called via `AppTester`. This commit adds a placeholder value to be returned by `z.generateCallbackUrl()` - `'auth-json-server.zapier-staging.com/echo'`.