### PR TITLE
fix(cli): improve logging for debugging info

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -94,6 +94,7 @@
     ],
     "hooks": {
       "init": [
+        "./src/oclif/hooks/versionInfo",
         "./src/oclif/hooks/deprecated",
         "./src/oclif/hooks/updateNotifier",
         "./src/oclif/hooks/checkValidNodeVersion",

--- a/packages/cli/src/oclif/hooks/versionInfo.js
+++ b/packages/cli/src/oclif/hooks/versionInfo.js
@@ -5,7 +5,7 @@ const { get } = require('lodash');
 const { PLATFORM_PACKAGE } = require('../../constants');
 const path = require('path');
 
-const VERSION_ARGS = ['version', 'v', '--version', '-V'];
+const VERSION_ARGS = ['version', '-v', '--version', '-V'];
 
 module.exports = (options) => {
   const firstArg = options.id;

--- a/packages/cli/src/oclif/hooks/versionInfo.js
+++ b/packages/cli/src/oclif/hooks/versionInfo.js
@@ -1,0 +1,38 @@
+// customize the output of `zapier --version`
+// see: https://github.com/oclif/oclif/issues/254#issuecomment-591433963
+
+const { get } = require('lodash');
+const { PLATFORM_PACKAGE } = require('../../constants');
+const path = require('path');
+
+const VERSION_ARGS = ['version', 'v', '--version', '-V'];
+
+module.exports = (options) => {
+  const firstArg = options.id;
+  if (!VERSION_ARGS.includes(firstArg)) {
+    return;
+  }
+
+  console.log(
+    [
+      `* CLI version: ${options.config.version}`,
+      `* Node.js version: ${process.version}`,
+      `* OS info: ${options.config.platform}-${options.config.arch}`,
+    ].join('\n')
+  );
+
+  try {
+    const pJson = require(path.join(process.cwd(), 'package.json'));
+
+    // are we in an app directory?
+    const maybeCoreDepVersion = get(pJson, ['dependencies', PLATFORM_PACKAGE]);
+    if (maybeCoreDepVersion) {
+      console.log(
+        `* \`zapier-platform-core\` dependency: ${maybeCoreDepVersion}`
+      );
+    }
+  } catch {}
+
+  // very important to exit, this will eventually fail to find a command
+  process.exit(0);
+};

--- a/packages/cli/src/oclif/hooks/versionInfo.js
+++ b/packages/cli/src/oclif/hooks/versionInfo.js
@@ -28,7 +28,7 @@ module.exports = (options) => {
     const maybeCoreDepVersion = get(pJson, ['dependencies', PLATFORM_PACKAGE]);
     if (maybeCoreDepVersion) {
       console.log(
-        `* \`zapier-platform-core\` dependency: ${maybeCoreDepVersion}`
+        `* \`${PLATFORM_PACKAGE}\` dependency: ${maybeCoreDepVersion}`
       );
     }
   } catch {}

--- a/packages/cli/src/smoke-tests/smoke-tests.js
+++ b/packages/cli/src/smoke-tests/smoke-tests.js
@@ -117,9 +117,9 @@ describe('smoke tests - setup will take some time', () => {
   });
 
   it('zapier --version', () => {
-    const firstLine = runCommand(context.cliBin, ['--version']);
-    firstLine
-      .includes(`zapier-platform-cli/${context.package.version}`)
+    const versionOutput = runCommand(context.cliBin, ['--version']);
+    versionOutput
+      .includes(`CLI version: ${context.package.version}`)
       .should.be.true();
   });
 


### PR DESCRIPTION
This is a minor detail that's bugged me for a while - when we converted to `oclif`, we lost the ability to have custom info when `zapier --version` was run (which is explicitly asked for when people file issues). This is [what we used to do](https://github.com/zapier/zapier-platform/blob/3cbaa2f10bb45f5c2f88a7afb229c13b394a1483/packages/cli/src/utils/misc.js#L147-L200).

This restores availability for some of that info, plus allows us to add more later.