### PR TITLE
docs(cli): Add "fallback sample" info

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -267,6 +267,7 @@ a code {
 </li>
 <li><a href="#triggerssearchescreates">Triggers/Searches/Creates</a><ul>
 <li><a href="#return-types">Return Types</a></li>
+<li><a href="#fallback-sample">Fallback Sample</a></li>
 </ul>
 </li>
 <li><a href="#input-fields">Input Fields</a><ul>
@@ -471,6 +472,7 @@ a code {
 </li>
 <li><a href="#triggerssearchescreates">Triggers/Searches/Creates</a><ul>
 <li><a href="#return-types">Return Types</a></li>
+<li><a href="#fallback-sample">Fallback Sample</a></li>
 </ul>
 </li>
 <li><a href="#input-fields">Input Fields</a><ul>
@@ -1884,6 +1886,28 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="fallback-sample">Fallback Sample</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In cases where Zapier needs to show an example record to the user, but we are unable to get a live example from the API, Zapier will fallback to this hard-coded sample. This should reflect the data structure of the Trigger&apos;s perform method, and have dummy values that we can show to any user.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">,<span class="hljs-attr">sample</span>: {
+  <span class="hljs-attr">dummydata_field1</span>: <span class="hljs-string">&apos;This will be compared against your perform method output&apos;</span>
+  <span class="hljs-attr">style</span>: <span class="hljs-string">&apos;mediterranean&apos;</span>
+}
+</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -516,6 +516,16 @@ Each of the 3 types of function expects a certain type of object. As of core v1.
 | Search  | Array       | 0 or more objects. If len > 0, put the best match first                                                              |
 | Action  | Object      | Return values are evaluated by [`isPlainObject`](https://lodash.com/docs#isPlainObject)                              |
 
+### Fallback Sample
+In cases where Zapier needs to show an example record to the user, but we are unable to get a live example from the API, Zapier will fallback to this hard-coded sample. This should reflect the data structure of the Trigger's perform method, and have dummy values that we can show to any user.
+
+```js
+,sample: {
+  dummydata_field1: 'This will be compared against your perform method output'
+  style: 'mediterranean'
+}
+```
+
 ## Input Fields
 
 On each trigger, search, or create in the `operation` directive - you can provide an array of objects as fields under the `inputFields`. Input Fields are what your users would see in the main Zapier user interface. For example, you might have a "Create Contact" action with fields like "First name", "Last name", "Email", etc. These fields will be able to accept input from previous steps in a Zap, for example:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,6 +57,7 @@ This doc decribes the latest CLI version **10.1.1**, as of this writing. If you'
   * [Resource Definition](#resource-definition)
 - [Triggers/Searches/Creates](#triggerssearchescreates)
   * [Return Types](#return-types)
+  * [Fallback Sample](#fallback-sample)
 - [Input Fields](#input-fields)
   * [Custom/Dynamic Fields](#customdynamic-fields)
   * [Dynamic Dropdowns](#dynamic-dropdowns)
@@ -1006,6 +1007,16 @@ Each of the 3 types of function expects a certain type of object. As of core v1.
 | Trigger | Array       | 0 or more objects that will be passed to the [deduper](https://zapier.com/developer/documentation/v2/deduplication/) |
 | Search  | Array       | 0 or more objects. If len > 0, put the best match first                                                              |
 | Action  | Object      | Return values are evaluated by [`isPlainObject`](https://lodash.com/docs#isPlainObject)                              |
+
+### Fallback Sample
+In cases where Zapier needs to show an example record to the user, but we are unable to get a live example from the API, Zapier will fallback to this hard-coded sample. This should reflect the data structure of the Trigger's perform method, and have dummy values that we can show to any user.
+
+```js
+,sample: {
+  dummydata_field1: 'This will be compared against your perform method output'
+  style: 'mediterranean'
+}
+```
 
 ## Input Fields
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -267,6 +267,7 @@ a code {
 </li>
 <li><a href="#triggerssearchescreates">Triggers/Searches/Creates</a><ul>
 <li><a href="#return-types">Return Types</a></li>
+<li><a href="#fallback-sample">Fallback Sample</a></li>
 </ul>
 </li>
 <li><a href="#input-fields">Input Fields</a><ul>
@@ -471,6 +472,7 @@ a code {
 </li>
 <li><a href="#triggerssearchescreates">Triggers/Searches/Creates</a><ul>
 <li><a href="#return-types">Return Types</a></li>
+<li><a href="#fallback-sample">Fallback Sample</a></li>
 </ul>
 </li>
 <li><a href="#input-fields">Input Fields</a><ul>
@@ -1884,6 +1886,28 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="fallback-sample">Fallback Sample</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In cases where Zapier needs to show an example record to the user, but we are unable to get a live example from the API, Zapier will fallback to this hard-coded sample. This should reflect the data structure of the Trigger&apos;s perform method, and have dummy values that we can show to any user.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js">,<span class="hljs-attr">sample</span>: {
+  <span class="hljs-attr">dummydata_field1</span>: <span class="hljs-string">&apos;This will be compared against your perform method output&apos;</span>
+  <span class="hljs-attr">style</span>: <span class="hljs-string">&apos;mediterranean&apos;</span>
+}
+</code></pre>
     </div>
   </div>
 </div><div class="row">


### PR DESCRIPTION
Added some information about Fallback sample

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
