### PR TITLE
[SUPPORTESC-101] docs(cli): Change 90-day limit for callbacks to 30-day

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2848,7 +2848,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>The app will have a maximum of 90 days to <code>POST</code> to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.</p>
+<p>The app will have a maximum of 30 days to <code>POST</code> to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -780,7 +780,7 @@ const performResume = async (z, bundle) => {
 };
 ```
 
-> The app will have a maximum of 90 days to `POST` to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.
+> The app will have a maximum of 30 days to `POST` to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.
 
 
 ## Bundle Object

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1690,7 +1690,7 @@ const performResume = async (z, bundle) => {
 };
 ```
 
-> The app will have a maximum of 90 days to `POST` to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.
+> The app will have a maximum of 30 days to `POST` to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.
 
 
 ## Bundle Object

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2848,7 +2848,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>The app will have a maximum of 90 days to <code>POST</code> to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.</p>
+<p>The app will have a maximum of 30 days to <code>POST</code> to the callback URL. If a user deletes or modifies the Zap or Task in the meantime, we will not resume the task.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">


### PR DESCRIPTION
We believe that due to tasks no longer being saved for 90 days, a callback posting after 30 days has a risk of failing, so the documentation should state 30 days as the max.