### PR TITLE
PDE-1816 fix(legacy-scripting-runner): bundle.request.data should be an object on the second attempt of pre_oauthv2_refresh

### DIFF
--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -179,6 +179,9 @@ const addRequestData = async (event, z, bundle, convertedBundle) => {
       convertedBundle.request.files = files;
       delete convertedBundle.request.headers['Content-Type'];
     }
+  } else if (event.name.startsWith('auth.oauth2.refresh.pre')) {
+    // Make sure bundle.request.data is an object
+    convertedBundle.request.data = convertedBundle.request.data || {};
   } else if (event.name.startsWith('create')) {
     if (
       !_.isEmpty(bundle._unflatInputData) ||

--- a/packages/legacy-scripting-runner/test/bundle.js
+++ b/packages/legacy-scripting-runner/test/bundle.js
@@ -950,8 +950,8 @@ describe('bundleConverter', () => {
   // Authentication
   //
 
-  it('should convert a bundle for pre_oauthv2_token and pre_oauthv2_refresh', async () => {
-    const events = ['auth.oauth2.token.pre', 'auth.oauth2.refresh.pre'];
+  it('should convert a bundle for pre_oauthv2_token', async () => {
+    const eventName = 'auth.oauth2.token.pre';
     const bundle = {
       _legacyUrl: 'https://zapier.com',
       request: { url: 'https://zapier.com' },
@@ -968,7 +968,7 @@ describe('bundleConverter', () => {
           'Content-Type': 'application/json',
         },
         params: {},
-        data: '',
+        data: '', // should be a string for pre_oauthv2_token
       },
       auth_fields: {},
       load: {},
@@ -984,21 +984,50 @@ describe('bundleConverter', () => {
       },
     };
 
-    const results = await Promise.all(
-      events.map((eventName) => {
-        const event = {
-          name: eventName,
-        };
-        return bundleConverter(bundle, event);
-      })
-    );
+    const event = { name: eventName };
+    const result = await bundleConverter(bundle, event);
 
-    _.zip(events, results).forEach(([eventName, result]) => {
-      result.should.eql(
-        expectedBundle,
-        `Expected bundle mismatch for "${eventName}".`
-      );
-    });
+    result.should.eql(expectedBundle);
+  });
+
+  it('should convert a bundle for pre_oauthv2_refresh', async () => {
+    const eventName = 'auth.oauth2.refresh.pre';
+    const bundle = {
+      _legacyUrl: 'https://zapier.com',
+      request: { url: 'https://zapier.com' },
+      inputData: {
+        user: 'Zapier',
+      },
+      authData: {},
+    };
+    const expectedBundle = {
+      request: {
+        method: 'POST',
+        url: 'https://zapier.com',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        params: {},
+        data: {},
+      },
+      auth_fields: {},
+      load: {},
+      meta: {},
+      zap: {
+        id: 0,
+      },
+      url_raw: 'https://zapier.com',
+      raw_url: 'https://zapier.com',
+      oauth_data: {
+        client_id: '1234',
+        client_secret: 'asdf',
+      },
+    };
+
+    const event = { name: eventName };
+    const result = await bundleConverter(bundle, event);
+
+    result.should.eql(expectedBundle);
   });
 
   it('should convert a bundle for post_oauthv2_token', async () => {

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -85,6 +85,29 @@ const legacyScriptingSource = `
         };
       },
 
+      pre_oauthv2_refresh_request_data_retry: function(bundle) {
+        'use strict';
+
+        if (bundle.request.data.client_id) {
+          throw new Error('make it retry');
+        }
+
+        // bundle.request.data should be an object, so this would error in
+        // strict mode if request.data is a string
+        bundle.request.data.foo = 'hello';
+        bundle.request.data.bar = 'world';
+        bundle.request.data = $.param(bundle.request.data);
+
+        bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+
+        return {
+          url: '${HTTPBIN_URL}/post',
+          method: bundle.request.method,
+          headers: bundle.request.headers,
+          data: bundle.request.data
+        };
+      },
+
       pre_oauthv2_refresh_bundle_load: function(bundle) {
         bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = qs.stringify(bundle.load);

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -361,6 +361,39 @@ describe('Integration Test', () => {
       });
     });
 
+    it('pre_oauthv2_refresh, request.data should be an object on retry', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'pre_oauthv2_refresh_request_data_retry',
+        'pre_oauthv2_refresh'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.refreshAccessToken'
+      );
+      input.bundle.authData = {
+        refresh_token: 'my_refresh_token',
+        access_token: 'my_access_token',
+      };
+      return app(input).then((output) => {
+        const data = output.results.form;
+        const params = output.results.args;
+
+        should.deepEqual(data, {
+          bar: ['world'],
+          foo: ['hello'],
+        });
+        should.deepEqual(params, {
+          client_id: [process.env.CLIENT_ID],
+          client_secret: [process.env.CLIENT_SECRET],
+          grant_type: ['refresh_token'],
+          refresh_token: ['my_refresh_token'],
+        });
+      });
+    });
+
     it('pre_oauthv2_refresh, bundle.load', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

`pre_oauthv2_refresh` can be called twice if the first attempt failed. We're already ensuring `bundle.request.data` is an object on the first attempt but NOT on the second attempt.

More context in [PDE-1816](https://zapierorg.atlassian.net/browse/PDE-1816).