### PR TITLE
docs(examples): fixing a documentation typo (PDE-1821)

### DIFF
--- a/example-apps/babel/src/authentication.js
+++ b/example-apps/babel/src/authentication.js
@@ -12,7 +12,7 @@ const Authentication = {
   type: 'basic',
 
   // The test method allows Zapier to verify that the credentials a user provides are valid. We'll execute this
-  // method whenver a user connects their account for the first time.
+  // method whenever a user connects their account for the first time.
   test,
   // assuming "username" is a key returned from the test
   connectionLabel: '{{username}}',

--- a/example-apps/basic-auth/authentication.js
+++ b/example-apps/basic-auth/authentication.js
@@ -35,7 +35,7 @@ module.exports = {
     fields: [],
 
     // The test method allows Zapier to verify that the credentials a user provides
-    // are valid. We'll execute this method whenver a user connects their account for
+    // are valid. We'll execute this method whenever a user connects their account for
     // the first time.
     test,
 

--- a/example-apps/custom-auth/authentication.js
+++ b/example-apps/custom-auth/authentication.js
@@ -50,7 +50,7 @@ module.exports = {
     fields: [{ key: 'apiKey', label: 'API Key', required: true }],
 
     // The test method allows Zapier to verify that the credentials a user provides
-    // are valid. We'll execute this method whenver a user connects their account for
+    // are valid. We'll execute this method whenever a user connects their account for
     // the first time.
     test,
 

--- a/example-apps/digest-auth/authentication.js
+++ b/example-apps/digest-auth/authentication.js
@@ -37,7 +37,7 @@ module.exports = {
     fields: [],
 
     // The test method allows Zapier to verify that the credentials a user provides
-    // are valid. We'll execute this method whenver a user connects their account for
+    // are valid. We'll execute this method whenever a user connects their account for
     // the first time.
     test,
 

--- a/example-apps/oauth1-trello/authentication.js
+++ b/example-apps/oauth1-trello/authentication.js
@@ -93,7 +93,7 @@ module.exports = {
     fields: [],
 
     // The test method allows Zapier to verify that the credentials a user provides
-    // are valid. We'll execute this method whenver a user connects their account for
+    // are valid. We'll execute this method whenever a user connects their account for
     // the first time.
     test,
 

--- a/example-apps/oauth2/authentication.js
+++ b/example-apps/oauth2/authentication.js
@@ -97,7 +97,7 @@ module.exports = {
     fields: [],
 
     // The test method allows Zapier to verify that the credentials a user provides
-    // are valid. We'll execute this method whenver a user connects their account for
+    // are valid. We'll execute this method whenever a user connects their account for
     // the first time.
     test,
 

--- a/example-apps/session-auth/authentication.js
+++ b/example-apps/session-auth/authentication.js
@@ -59,7 +59,7 @@ module.exports = {
     ],
 
     // The test method allows Zapier to verify that the credentials a user provides
-    // are valid. We'll execute this method whenver a user connects their account for
+    // are valid. We'll execute this method whenever a user connects their account for
     // the first time.
     test,
 

--- a/packages/cli/src/utils/auth-files-codegen.js
+++ b/packages/cli/src/utils/auth-files-codegen.js
@@ -58,7 +58,7 @@ const authFileExport = (
           ),
           objProperty('fields', arr(...authFields)),
           comment(
-            "The test method allows Zapier to verify that the credentials a user provides are valid. We'll execute this method whenver a user connects their account for the first time."
+            "The test method allows Zapier to verify that the credentials a user provides are valid. We'll execute this method whenever a user connects their account for the first time."
           ),
           test,
           comment(


### PR DESCRIPTION
`whenver` to `whenever`