### PR TITLE
PDE-1816: Release legacy-scripting-runner 3.7.6

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.6
+
+- :bug: `bundle.request.data` should always be an object in `pre_oauthv2_refresh` ([#294](https://github.com/zapier/zapier-platform/pull/294))
+
 ## 3.7.5
 
 - :bug: Make response headers case-insensitive ([#253](https://github.com/zapier/zapier-platform/pull/253))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform-legacy-scripting-runner",
   "homepage": "https://zapier.com/",

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -49,18 +49,18 @@ const ensureMainPackageVersionsAreSame = () => {
   }
 };
 
-const confirmIfNotMasterBranch = async () => {
+const confirmIfMasterBranch = async () => {
   const result = spawnSync('git', ['branch', '--show-current'], {
     encoding: 'utf8',
   });
   const branch = (result.stdout || '').trim();
-  if (branch !== 'master') {
+  if (branch === 'master' || branch === 'main') {
     const answer = await inquirer.prompt([
       {
         type: 'confirm',
         name: 'continue',
         message:
-          'This was supposed to be run on master branch. ' +
+          'This was supposed to be run on a feature branch. ' +
           `You want to proceed with branch ${underline(branch)} anyway?`,
         default: false,
       },
@@ -278,7 +278,7 @@ const gitTag = (versionsToBump) => {
 const main = async () => {
   try {
     ensureMainPackageVersionsAreSame();
-    await confirmIfNotMasterBranch();
+    await confirmIfMasterBranch();
     ensureNoUncommittedChanges();
   } catch (err) {
     console.error(err.message);

--- a/scripts/bump.js
+++ b/scripts/bump.js
@@ -320,7 +320,7 @@ const main = async () => {
   console.log(
     `\nDone! Review the change with ${bold.underline(
       'git diff HEAD~1..HEAD'
-    )} then ${bold.underline('git push origin master --tags')}.`
+    )} then ${bold.underline('git push origin HEAD --tags')}.`
   );
   return 0;
 };


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
