### PR TITLE
docs: update readme to reflect change presented in AP-137

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3185,7 +3185,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>bundle.subscribeData</code> is only available in the <code>performUnsubscribe</code> method for webhooks.</p>
+<p><code>bundle.subscribeData</code> is available in the <code>perform</code> and <code>performUnsubscribe</code> method for webhooks.</p>
 </blockquote><p>This is an object that contains the data you returned from the <code>performSubscribe</code> function. It should contain whatever information you need send a <code>DELETE</code> request to your server to stop sending webhooks to Zapier.</p><p>Read more in the <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js">REST hook example</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -938,7 +938,7 @@ Read more in the [REST hook example](https://github.com/zapier/zapier-platform/b
 
 ### `bundle.subscribeData`
 
-> `bundle.subscribeData` is only available in the `performUnsubscribe` method for webhooks.
+> `bundle.subscribeData` is available in the `perform` and `performUnsubscribe` method for webhooks.
 
 This is an object that contains the data you returned from the `performSubscribe` function. It should contain whatever information you need send a `DELETE` request to your server to stop sending webhooks to Zapier.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1848,7 +1848,7 @@ Read more in the [REST hook example](https://github.com/zapier/zapier-platform/b
 
 ### `bundle.subscribeData`
 
-> `bundle.subscribeData` is only available in the `performUnsubscribe` method for webhooks.
+> `bundle.subscribeData` is available in the `perform` and `performUnsubscribe` method for webhooks.
 
 This is an object that contains the data you returned from the `performSubscribe` function. It should contain whatever information you need send a `DELETE` request to your server to stop sending webhooks to Zapier.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1848,7 +1848,7 @@ Read more in the [REST hook example](https://github.com/zapier/zapier-platform/b
 
 ### `bundle.subscribeData`
 
-> `bundle.subscribeData` is available in the `perform` and `performUnsubscribe` method for webhooks.
+> `bundle.subscribeData` is only available in the `performUnsubscribe` method for webhooks.
 
 This is an object that contains the data you returned from the `performSubscribe` function. It should contain whatever information you need send a `DELETE` request to your server to stop sending webhooks to Zapier.
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3185,7 +3185,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>bundle.subscribeData</code> is only available in the <code>performUnsubscribe</code> method for webhooks.</p>
+<p><code>bundle.subscribeData</code> is available in the <code>perform</code> and <code>performUnsubscribe</code> method for webhooks.</p>
 </blockquote><p>This is an object that contains the data you returned from the <code>performSubscribe</code> function. It should contain whatever information you need send a <code>DELETE</code> request to your server to stop sending webhooks to Zapier.</p><p>Read more in the <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/rest-hooks/triggers/recipe.js">REST hook example</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -215,20 +215,16 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    getRequestToken: { require: 'some/path/to/file.js' },
+  { getRequestToken: { require: 'some/path/to/file.js' },
     authorizeUrl: { require: 'some/path/to/file2.js' },
-    getAccessToken: { require: 'some/path/to/file3.js' }
-  }
+    getAccessToken: { require: 'some/path/to/file3.js' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    getRequestToken: { require: 'some/path/to/file.js' },
-    authorizeUrl: { require: 'some/path/to/file2.js' }
-  }
+  { getRequestToken: { require: 'some/path/to/file.js' },
+    authorizeUrl: { require: 'some/path/to/file2.js' } }
   ```
   _Missing required key._
 
@@ -256,19 +252,15 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    authorizeUrl: { require: 'some/path/to/file.js' },
-    getAccessToken: { require: 'some/path/to/file2.js' }
-  }
+  { authorizeUrl: { require: 'some/path/to/file.js' },
+    getAccessToken: { require: 'some/path/to/file2.js' } }
   ```
 * ```
-  {
-    authorizeUrl: { require: 'some/path/to/file.js' },
+  { authorizeUrl: { require: 'some/path/to/file.js' },
     getAccessToken: { require: 'some/path/to/file2.js' },
     refreshAccessToken: { require: 'some/path/to/file3.js' },
     scope: 'read/write',
-    autoRefresh: true
-  }
+    autoRefresh: true }
   ```
 
 #### Anti-Examples
@@ -430,13 +422,11 @@ Key | Required | Type | Description
 * `{ hidden: true }`
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  {
-    label: 'New Thing',
+  { label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true
-  }
+    important: true }
   ```
 
 #### Anti-Examples
@@ -473,26 +463,22 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    type: 'hook',
+  { type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
     performUnsubscribe: { require: 'some/path/to/file4.js' },
-    sample: { id: 42, name: 'Hooli' }
-  }
+    sample: { id: 42, name: 'Hooli' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    type: 'hook',
+  { type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
-    performUnsubscribe: { require: 'some/path/to/file4.js' }
-  }
+    performUnsubscribe: { require: 'some/path/to/file4.js' } }
   ```
   _Missing required key: sample. Note - This is only invalid if `display` is not explicitly set to true and if it does not belong to a resource that has a sample._
 
@@ -579,24 +565,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipes',
+  { key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation: {
-      perform: '$func$0$f$',
-      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-    }
-  }
+    operation:
+     { perform: '$func$0$f$',
+       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get User', description: 'Retrieve a user.' },
-    operation: { description: 'Define how this search method will work.' }
-  }
+  { display: { label: 'Get User', description: 'Retrieve a user.' },
+    operation: { description: 'Define how this search method will work.' } }
   ```
   _Missing required keys: key and noun_
 
@@ -620,33 +601,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    recipes: {
-      key: 'recipes',
-      noun: 'Recipes',
-      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-      operation: {
-        perform: '$func$0$f$',
-        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-      }
-    }
-  }
+  { recipes:
+     { key: 'recipes',
+       noun: 'Recipes',
+       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+       operation:
+        { perform: '$func$0$f$',
+          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    readRecipes: {
-      key: 'recipes',
-      noun: 'Recipes',
-      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-      operation: {
-        perform: '$func$0$f$',
-        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-      }
-    }
-  }
+  { readRecipes:
+     { key: 'recipes',
+       noun: 'Recipes',
+       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+       operation:
+        { perform: '$func$0$f$',
+          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
   ```
   _Key must match the key of the associated BulkReadSchema_
 
@@ -673,49 +646,39 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
-  }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
   ```
   _Invalid value for key on operation: shouldLock_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing required key on operation: sample. Note - this is valid if the resource has defined a sample._
 
@@ -739,48 +702,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    createRecipe: {
-      key: 'createRecipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { createRecipe:
+     { key: 'createRecipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
 * ```
-  {
-    Create_Recipe_01: {
-      key: 'Create_Recipe_01',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { Create_Recipe_01:
+     { key: 'Create_Recipe_01',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    '01_Create_Recipe': {
-      key: '01_Create_Recipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { '01_Create_Recipe':
+     { key: '01_Create_Recipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
   _Key must start with a letter_
 * ```
-  {
-    Create_Recipe: {
-      key: 'createRecipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { Create_Recipe:
+     { key: 'createRecipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
   _Key must match the key field in CreateSchema_
 
@@ -1258,29 +1209,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Create Tag',
-      description: 'Create a new Tag in your account.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1305,25 +1246,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1348,29 +1283,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: {
-      type: 'hook',
-      perform: '$func$0$f$',
-      sample: { id: 385, name: 'proactive enable ROI' }
-    }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1395,38 +1320,24 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: {
-      perform: { url: 'https://fake-crm.getsandbox.com/users' },
-      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
-    }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation:
+     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
+       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.',
-      hidden: true
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display:
+     { label: 'New User',
+       description: 'Trigger when a new User is created in your account.',
+       hidden: true },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1451,31 +1362,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1507,61 +1408,43 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1585,50 +1468,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    tag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: {
-          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' }
-        }
-      }
-    }
-  }
+  { tag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation:
+           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+             sample: { id: 385, name: 'proactive enable ROI' } } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    getTag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: {
-          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' }
-        }
-      }
-    }
-  }
+  { getTag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation:
+           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+             sample: { id: 385, name: 'proactive enable ROI' } } } } }
   ```
   _Key does not match key for associated /ResourceSchema_
 * ```
-  {
-    tag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-      }
-    }
-  }
+  { tag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1676,47 +1545,38 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'searchOrCreateWidgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: 'searchOrCreateWidgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: 'searchWidgets',
-    create: 'createWidget'
-  }
+    create: 'createWidget' }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: '01_Search_or_Create_Widgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: '01_Search_or_Create_Widgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: 'searchWidgets',
-    create: 'createWidget'
-  }
+    create: 'createWidget' }
   ```
   _Invalid value for key: key (must start with a letter)_
 * ```
-  {
-    key: 'searchOrCreateWidgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: 'searchOrCreateWidgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: { require: 'path/to/some/file.js' },
-    create: { require: 'path/to/some/file.js' }
-  }
+    create: { require: 'path/to/some/file.js' } }
   ```
   _Invalid values for keys: search and create (must be a string that matches the key of a registered search or create)_
 
@@ -1740,37 +1600,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    searchOrCreateWidgets: {
-      key: 'searchOrCreateWidgets',
-      display: {
-        label: 'Search or Create Widgets',
-        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-        important: true,
-        hidden: false
-      },
-      search: 'searchWidgets',
-      create: 'createWidget'
-    }
-  }
+  { searchOrCreateWidgets:
+     { key: 'searchOrCreateWidgets',
+       display:
+        { label: 'Search or Create Widgets',
+          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+          important: true,
+          hidden: false },
+       search: 'searchWidgets',
+       create: 'createWidget' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    searchOrCreateWidgets: {
-      key: 'socWidgets',
-      display: {
-        label: 'Search or Create Widgets',
-        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-        important: true,
-        hidden: false
-      },
-      search: 'searchWidgets',
-      create: 'createWidget'
-    }
-  }
+  { searchOrCreateWidgets:
+     { key: 'socWidgets',
+       display:
+        { label: 'Search or Create Widgets',
+          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+          important: true,
+          hidden: false },
+       search: 'searchWidgets',
+       create: 'createWidget' } }
   ```
   _Key must match the key of the associated /SearchOrCreateSchema_
 
@@ -1797,36 +1649,26 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing required key in operation: sample. Note - this is valid if the associated resource has defined a sample._
 
@@ -1850,35 +1692,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    recipe: {
-      key: 'recipe',
-      noun: 'Recipe',
-      display: {
-        label: 'Find a Recipe',
-        description: 'Search for recipe by cuisine style.',
-        hidden: true
-      },
-      operation: { perform: '$func$2$f$' }
-    }
-  }
+  { recipe:
+     { key: 'recipe',
+       noun: 'Recipe',
+       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+       operation: { perform: '$func$2$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    searchRecipe: {
-      key: 'recipe',
-      noun: 'Recipe',
-      display: {
-        label: 'Find a Recipe',
-        description: 'Search for recipe by cuisine style.',
-        hidden: true
-      },
-      operation: { perform: '$func$2$f$' }
-    }
-  }
+  { searchRecipe:
+     { key: 'recipe',
+       noun: 'Recipe',
+       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+       operation: { perform: '$func$2$f$' } } }
   ```
   _Key must match the key of the associated /SearchSchema_
 
@@ -1905,35 +1733,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-  }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
-    display: {
-      label: 'New Recipe',
-      description: 'Triggers when a new recipe is added.',
-      hidden: true
-    },
-    operation: { type: 'polling', perform: '$func$0$f$' }
-  }
+    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
+    operation: { type: 'polling', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' }
-  }
+    operation: { perform: '$func$0$f$' } }
   ```
   _Missing required key from operation: sample. Note - this is valid if the Recipe resource has defined a sample._
 
@@ -1957,27 +1775,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    newRecipe: {
-      key: 'newRecipe',
-      noun: 'Recipe',
-      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-    }
-  }
+  { newRecipe:
+     { key: 'newRecipe',
+       noun: 'Recipe',
+       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    newRecipe: {
-      key: 'new_recipe',
-      noun: 'Recipe',
-      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-    }
-  }
+  { newRecipe:
+     { key: 'new_recipe',
+       noun: 'Recipe',
+       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
   ```
   _Key must match the key on the associated /TriggerSchema_
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This updates the README to reflect changes presented in https://github.com/zapier/zapier/pull/46039. We're now exposing the `subscribeData` in `perform` _and_ `performUnsubscribe`.  

Related [JIRA Ticket](https://zapierorg.atlassian.net/browse/AP-137)

Are there any other pieces of documentation that I missed and should be updated? 