### PR TITLE
[SUPPORTESC-109] docs(cli): Add details about when dynamic fields are loaded

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1976,7 +1976,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>In some cases, it might be necessary to provide fields that are dynamically generated - especially for custom fields. This is a common pattern for CRMs, form software, databases and more. Basically - you can provide a function instead of a field and we&apos;ll evaluate that function - merging the dynamic fields with the static fields.</p><blockquote>
-<p>You should see <code>bundle.inputData</code> partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (EG: only show issues from the previously selected project).</p>
+<p>You should see <code>bundle.inputData</code> partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (e.g. only show issues from the previously selected project).</p>
 </blockquote><blockquote>
 <p>A function that returns a list of dynamic fields cannot include additional functions in that list to call for dynamic fields.</p>
 </blockquote>
@@ -2063,7 +2063,11 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Only dropdowns support <code>altersDynamicFields</code>.</p>
-</blockquote>
+</blockquote><p>When using dynamic fields, the fields will be retrieved in three different contexts:</p><ul>
+<li>Whenever the value of a field with <code>altersDynamicFields</code> is changed, as described above.</li>
+<li>Whenever Zap Editor opens the &quot;Set up&quot; section for the trigger or action.</li>
+<li>Whenever the Refresh Fields button is used on the trigger or action.</li>
+</ul><p>Be sure to set up your code accordingly - for example, don&apos;t rely on any input fields already having a value, since they won&apos;t have one the first time the &quot;Set up&quot; section loads.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -546,7 +546,7 @@ You can find more details on the different field schema options at [our Field Sc
 
 In some cases, it might be necessary to provide fields that are dynamically generated - especially for custom fields. This is a common pattern for CRMs, form software, databases and more. Basically - you can provide a function instead of a field and we'll evaluate that function - merging the dynamic fields with the static fields.
 
-> You should see `bundle.inputData` partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (EG: only show issues from the previously selected project).
+> You should see `bundle.inputData` partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (e.g. only show issues from the previously selected project).
 
 > A function that returns a list of dynamic fields cannot include additional functions in that list to call for dynamic fields.
 
@@ -561,6 +561,14 @@ Additionally, if there is a field that affects the generation of dynamic fields,
 ```
 
 > Only dropdowns support `altersDynamicFields`.
+
+When using dynamic fields, the fields will be retrieved in three different contexts:
+
+* Whenever the value of a field with `altersDynamicFields` is changed, as described above.
+* Whenever Zap Editor opens the "Set up" section for the trigger or action.
+* Whenever the Refresh Fields button is used on the trigger or action.
+
+Be sure to set up your code accordingly - for example, don't rely on any input fields already having a value, since they won't have one the first time the "Set up" section loads.
 
 ### Dynamic Dropdowns
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1063,7 +1063,7 @@ You can find more details on the different field schema options at [our Field Sc
 
 In some cases, it might be necessary to provide fields that are dynamically generated - especially for custom fields. This is a common pattern for CRMs, form software, databases and more. Basically - you can provide a function instead of a field and we'll evaluate that function - merging the dynamic fields with the static fields.
 
-> You should see `bundle.inputData` partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (EG: only show issues from the previously selected project).
+> You should see `bundle.inputData` partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (e.g. only show issues from the previously selected project).
 
 > A function that returns a list of dynamic fields cannot include additional functions in that list to call for dynamic fields.
 
@@ -1140,6 +1140,14 @@ module.exports = {
 ```
 
 > Only dropdowns support `altersDynamicFields`.
+
+When using dynamic fields, the fields will be retrieved in three different contexts:
+
+* Whenever the value of a field with `altersDynamicFields` is changed, as described above.
+* Whenever Zap Editor opens the "Set up" section for the trigger or action.
+* Whenever the Refresh Fields button is used on the trigger or action.
+
+Be sure to set up your code accordingly - for example, don't rely on any input fields already having a value, since they won't have one the first time the "Set up" section loads.
 
 ### Dynamic Dropdowns
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1976,7 +1976,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>In some cases, it might be necessary to provide fields that are dynamically generated - especially for custom fields. This is a common pattern for CRMs, form software, databases and more. Basically - you can provide a function instead of a field and we&apos;ll evaluate that function - merging the dynamic fields with the static fields.</p><blockquote>
-<p>You should see <code>bundle.inputData</code> partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (EG: only show issues from the previously selected project).</p>
+<p>You should see <code>bundle.inputData</code> partially filled in as users provide data - even in field retrieval. This allows you to build hierarchical relationships into fields (e.g. only show issues from the previously selected project).</p>
 </blockquote><blockquote>
 <p>A function that returns a list of dynamic fields cannot include additional functions in that list to call for dynamic fields.</p>
 </blockquote>
@@ -2063,7 +2063,11 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Only dropdowns support <code>altersDynamicFields</code>.</p>
-</blockquote>
+</blockquote><p>When using dynamic fields, the fields will be retrieved in three different contexts:</p><ul>
+<li>Whenever the value of a field with <code>altersDynamicFields</code> is changed, as described above.</li>
+<li>Whenever Zap Editor opens the &quot;Set up&quot; section for the trigger or action.</li>
+<li>Whenever the Refresh Fields button is used on the trigger or action.</li>
+</ul><p>Be sure to set up your code accordingly - for example, don&apos;t rely on any input fields already having a value, since they won&apos;t have one the first time the &quot;Set up&quot; section loads.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
This docs addition provides more guidance to developers about use contexts when they are working with code for loading dynamic fields.

Relates to: https://github.com/zapier/visual-builder/pull/165