### PR TITLE
PDE-1915: fix(legacy-scripting-runner): shouldn't double encode when pre method also encodes the URL

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.7
+
+- :bug: Shouldn't double encode when `pre` method also encodes the URL ([#304](https://github.com/zapier/zapier-platform/pull/304))
+
 ## 3.7.6
 
 - :bug: `bundle.request.data` should always be an object in `pre_oauthv2_refresh` ([#294](https://github.com/zapier/zapier-platform/pull/294))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -665,8 +665,10 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       }
 
       // encode everything, but retain curlies - those are replaced in z.request
-      // important to maintain case here; new URL lowercases everything
+      // important to maintain case here; `new URL()` lowercases the hostname,
+      // which may contain a variable like '{{process.env.URL}}'
       request.url = encodeURI(request.url)
+        .replace(/%25/g, '%') // fixes double encoding
         .replace(/%7B/g, '{')
         .replace(/%7D/g, '}');
       request.headers = cleanHeaders(request.headers);

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.6",
+  "version": "3.7.7",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform-legacy-scripting-runner",
   "homepage": "https://zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -269,6 +269,11 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_urlencode: function(bundle) {
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/echo?url=' + encodeURIComponent('https://example.com');
+        return bundle.request;
+      },
+
       getMovesUrl: function() {
         return '${AUTH_JSON_SERVER_URL}/movies';
       },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -769,6 +769,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, hash in headers', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_urlencode',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        const echoed = output.results[0];
+        should.equal(echoed.query.url, 'https://example.com');
+      });
+    });
+
     it('KEY_pre_poll, this binding', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -215,16 +215,20 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { getRequestToken: { require: 'some/path/to/file.js' },
+  {
+    getRequestToken: { require: 'some/path/to/file.js' },
     authorizeUrl: { require: 'some/path/to/file2.js' },
-    getAccessToken: { require: 'some/path/to/file3.js' } }
+    getAccessToken: { require: 'some/path/to/file3.js' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { getRequestToken: { require: 'some/path/to/file.js' },
-    authorizeUrl: { require: 'some/path/to/file2.js' } }
+  {
+    getRequestToken: { require: 'some/path/to/file.js' },
+    authorizeUrl: { require: 'some/path/to/file2.js' }
+  }
   ```
   _Missing required key._
 
@@ -252,15 +256,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { authorizeUrl: { require: 'some/path/to/file.js' },
-    getAccessToken: { require: 'some/path/to/file2.js' } }
+  {
+    authorizeUrl: { require: 'some/path/to/file.js' },
+    getAccessToken: { require: 'some/path/to/file2.js' }
+  }
   ```
 * ```
-  { authorizeUrl: { require: 'some/path/to/file.js' },
+  {
+    authorizeUrl: { require: 'some/path/to/file.js' },
     getAccessToken: { require: 'some/path/to/file2.js' },
     refreshAccessToken: { require: 'some/path/to/file3.js' },
     scope: 'read/write',
-    autoRefresh: true }
+    autoRefresh: true
+  }
   ```
 
 #### Anti-Examples
@@ -422,11 +430,13 @@ Key | Required | Type | Description
 * `{ hidden: true }`
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  { label: 'New Thing',
+  {
+    label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true }
+    important: true
+  }
   ```
 
 #### Anti-Examples
@@ -463,22 +473,26 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { type: 'hook',
+  {
+    type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
     performUnsubscribe: { require: 'some/path/to/file4.js' },
-    sample: { id: 42, name: 'Hooli' } }
+    sample: { id: 42, name: 'Hooli' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { type: 'hook',
+  {
+    type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
-    performUnsubscribe: { require: 'some/path/to/file4.js' } }
+    performUnsubscribe: { require: 'some/path/to/file4.js' }
+  }
   ```
   _Missing required key: sample. Note - This is only invalid if `display` is not explicitly set to true and if it does not belong to a resource that has a sample._
 
@@ -565,19 +579,24 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'recipes',
+  {
+    key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation:
-     { perform: '$func$0$f$',
-       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
+    operation: {
+      perform: '$func$0$f$',
+      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get User', description: 'Retrieve a user.' },
-    operation: { description: 'Define how this search method will work.' } }
+  {
+    display: { label: 'Get User', description: 'Retrieve a user.' },
+    operation: { description: 'Define how this search method will work.' }
+  }
   ```
   _Missing required keys: key and noun_
 
@@ -601,25 +620,33 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { recipes:
-     { key: 'recipes',
-       noun: 'Recipes',
-       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-       operation:
-        { perform: '$func$0$f$',
-          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
+  {
+    recipes: {
+      key: 'recipes',
+      noun: 'Recipes',
+      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+      operation: {
+        perform: '$func$0$f$',
+        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { readRecipes:
-     { key: 'recipes',
-       noun: 'Recipes',
-       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-       operation:
-        { perform: '$func$0$f$',
-          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
+  {
+    readRecipes: {
+      key: 'recipes',
+      noun: 'Recipes',
+      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+      operation: {
+        perform: '$func$0$f$',
+        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+      }
+    }
+  }
   ```
   _Key must match the key of the associated BulkReadSchema_
 
@@ -646,39 +673,49 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
+  }
   ```
   _Invalid value for key on operation: shouldLock_
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing required key on operation: sample. Note - this is valid if the resource has defined a sample._
 
@@ -702,36 +739,48 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { createRecipe:
-     { key: 'createRecipe',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    createRecipe: {
+      key: 'createRecipe',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
 * ```
-  { Create_Recipe_01:
-     { key: 'Create_Recipe_01',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    Create_Recipe_01: {
+      key: 'Create_Recipe_01',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { '01_Create_Recipe':
-     { key: '01_Create_Recipe',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    '01_Create_Recipe': {
+      key: '01_Create_Recipe',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
   _Key must start with a letter_
 * ```
-  { Create_Recipe:
-     { key: 'createRecipe',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    Create_Recipe: {
+      key: 'createRecipe',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
   _Key must match the key field in CreateSchema_
 
@@ -1209,19 +1258,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Create Tag',
+      description: 'Create a new Tag in your account.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1246,19 +1305,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1283,19 +1348,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: {
+      type: 'hook',
+      perform: '$func$0$f$',
+      sample: { id: 385, name: 'proactive enable ROI' }
+    }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1320,24 +1395,38 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation:
-     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
-       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: {
+      perform: { url: 'https://fake-crm.getsandbox.com/users' },
+      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
+    }
+  }
   ```
 * ```
-  { display:
-     { label: 'New User',
-       description: 'Trigger when a new User is created in your account.',
-       hidden: true },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.',
+      hidden: true
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1362,21 +1451,31 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1408,43 +1507,61 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1468,36 +1585,50 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { tag:
-     { key: 'tag',
-       noun: 'Tag',
-       get:
-        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-          operation:
-           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-             sample: { id: 385, name: 'proactive enable ROI' } } } } }
+  {
+    tag: {
+      key: 'tag',
+      noun: 'Tag',
+      get: {
+        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+        operation: {
+          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' }
+        }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { getTag:
-     { key: 'tag',
-       noun: 'Tag',
-       get:
-        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-          operation:
-           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-             sample: { id: 385, name: 'proactive enable ROI' } } } } }
+  {
+    getTag: {
+      key: 'tag',
+      noun: 'Tag',
+      get: {
+        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+        operation: {
+          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' }
+        }
+      }
+    }
+  }
   ```
   _Key does not match key for associated /ResourceSchema_
 * ```
-  { tag:
-     { key: 'tag',
-       noun: 'Tag',
-       get:
-        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-          operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } } }
+  {
+    tag: {
+      key: 'tag',
+      noun: 'Tag',
+      get: {
+        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+        operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+      }
+    }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1545,38 +1676,47 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'searchOrCreateWidgets',
-    display:
-     { label: 'Search or Create Widgets',
-       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-       important: true,
-       hidden: false },
+  {
+    key: 'searchOrCreateWidgets',
+    display: {
+      label: 'Search or Create Widgets',
+      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+      important: true,
+      hidden: false
+    },
     search: 'searchWidgets',
-    create: 'createWidget' }
+    create: 'createWidget'
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: '01_Search_or_Create_Widgets',
-    display:
-     { label: 'Search or Create Widgets',
-       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-       important: true,
-       hidden: false },
+  {
+    key: '01_Search_or_Create_Widgets',
+    display: {
+      label: 'Search or Create Widgets',
+      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+      important: true,
+      hidden: false
+    },
     search: 'searchWidgets',
-    create: 'createWidget' }
+    create: 'createWidget'
+  }
   ```
   _Invalid value for key: key (must start with a letter)_
 * ```
-  { key: 'searchOrCreateWidgets',
-    display:
-     { label: 'Search or Create Widgets',
-       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-       important: true,
-       hidden: false },
+  {
+    key: 'searchOrCreateWidgets',
+    display: {
+      label: 'Search or Create Widgets',
+      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+      important: true,
+      hidden: false
+    },
     search: { require: 'path/to/some/file.js' },
-    create: { require: 'path/to/some/file.js' } }
+    create: { require: 'path/to/some/file.js' }
+  }
   ```
   _Invalid values for keys: search and create (must be a string that matches the key of a registered search or create)_
 
@@ -1600,29 +1740,37 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { searchOrCreateWidgets:
-     { key: 'searchOrCreateWidgets',
-       display:
-        { label: 'Search or Create Widgets',
-          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-          important: true,
-          hidden: false },
-       search: 'searchWidgets',
-       create: 'createWidget' } }
+  {
+    searchOrCreateWidgets: {
+      key: 'searchOrCreateWidgets',
+      display: {
+        label: 'Search or Create Widgets',
+        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+        important: true,
+        hidden: false
+      },
+      search: 'searchWidgets',
+      create: 'createWidget'
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { searchOrCreateWidgets:
-     { key: 'socWidgets',
-       display:
-        { label: 'Search or Create Widgets',
-          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-          important: true,
-          hidden: false },
-       search: 'searchWidgets',
-       create: 'createWidget' } }
+  {
+    searchOrCreateWidgets: {
+      key: 'socWidgets',
+      display: {
+        label: 'Search or Create Widgets',
+        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+        important: true,
+        hidden: false
+      },
+      search: 'searchWidgets',
+      create: 'createWidget'
+    }
+  }
   ```
   _Key must match the key of the associated /SearchOrCreateSchema_
 
@@ -1649,26 +1797,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing required key in operation: sample. Note - this is valid if the associated resource has defined a sample._
 
@@ -1692,21 +1850,35 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { recipe:
-     { key: 'recipe',
-       noun: 'Recipe',
-       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-       operation: { perform: '$func$2$f$' } } }
+  {
+    recipe: {
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Find a Recipe',
+        description: 'Search for recipe by cuisine style.',
+        hidden: true
+      },
+      operation: { perform: '$func$2$f$' }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { searchRecipe:
-     { key: 'recipe',
-       noun: 'Recipe',
-       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-       operation: { perform: '$func$2$f$' } } }
+  {
+    searchRecipe: {
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Find a Recipe',
+        description: 'Search for recipe by cuisine style.',
+        hidden: true
+      },
+      operation: { perform: '$func$2$f$' }
+    }
+  }
   ```
   _Key must match the key of the associated /SearchSchema_
 
@@ -1733,25 +1905,35 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
-    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
-    operation: { type: 'polling', perform: '$func$0$f$' } }
+    display: {
+      label: 'New Recipe',
+      description: 'Triggers when a new recipe is added.',
+      hidden: true
+    },
+    operation: { type: 'polling', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' } }
+    operation: { perform: '$func$0$f$' }
+  }
   ```
   _Missing required key from operation: sample. Note - this is valid if the Recipe resource has defined a sample._
 
@@ -1775,21 +1957,27 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { newRecipe:
-     { key: 'newRecipe',
-       noun: 'Recipe',
-       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
+  {
+    newRecipe: {
+      key: 'newRecipe',
+      noun: 'Recipe',
+      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { newRecipe:
-     { key: 'new_recipe',
-       noun: 'Recipe',
-       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
+  {
+    newRecipe: {
+      key: 'new_recipe',
+      noun: 'Recipe',
+      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+    }
+  }
   ```
   _Key must match the key on the associated /TriggerSchema_
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes an issue where a `pre` method (including `KEY_pre_poll`, `KEY_pre_write`, `pre_subscribe`, etc.) encodes the URL and causes the URL to be double encoded. The test should demonstrate how to reproduce.