### PR TITLE
PDE-1918: fix(legacy-scripting-runner): better choose between ResponseError and script error

### DIFF
--- a/packages/legacy-scripting-runner/exceptions.js
+++ b/packages/legacy-scripting-runner/exceptions.js
@@ -58,4 +58,9 @@ const exceptions = {
   DehydrateException: cliErrors.DehydrateError,
 };
 
-module.exports = exceptions;
+const DEFINED_ERROR_NAMES = ['ErrorException', ...names];
+
+module.exports = {
+  ...exceptions,
+  DEFINED_ERROR_NAMES,
+};

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -575,6 +575,10 @@ const legacyScriptingSource = `
         return z.JSON.parse(bundle.response.content);
       },
 
+      movie_post_write_bad_code: function(bundle) {
+        throw new TypeError("You shouldn't see this if bundle.response is an error");
+      },
+
       movie_pre_write_default_headers: function(bundle) {
         // Copy Accept and Content-Type to request body so we know they're
         // already available in pre_write

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2207,6 +2207,26 @@ describe('Integration Test', () => {
       );
     });
 
+    it('KEY_post_write, response error overrules script error', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_write_intercept_error',
+        'movie_pre_write'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_write_bad_code',
+        'movie_post_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).should.be.rejectedWith(/I'm a teapot/);
+    });
+
     it('KEY_pre_write & KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This handles the case where:

1) we get an error response (status code is 4xx or 5xx), and
2) the `KEY_post_(poll|write|search)` method also throws an error

Which one should we throw, the response error (1) or script error (2)?

WB chooses the error based on the script error type. If the script error is one of the Zapier-defined exception classes, throw the script error; throw the response error otherwise.

More details can be found in [PDE-1918](https://zapierorg.atlassian.net/browse/PDE-1918).