### PR TITLE
PDE-1918: Release legacy-scripting-runner 3.7.8

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.8
+
+- :bug: Better choose between `ResponseError` and script error ([#305](https://github.com/zapier/zapier-platform/pull/305))
+
 ## 3.7.7
 
 - :bug: Shouldn't double encode when `pre` method also encodes the URL ([#304](https://github.com/zapier/zapier-platform/pull/304))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.7",
+  "version": "3.7.8",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform-legacy-scripting-runner",
   "homepage": "https://zapier.com/",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
