### PR TITLE
PDE-1948: fix(legacy-scripting-runner): Fix chooseBetterError for ErrorException errors

### DIFF
--- a/packages/legacy-scripting-runner/exceptions.js
+++ b/packages/legacy-scripting-runner/exceptions.js
@@ -58,7 +58,7 @@ const exceptions = {
   DehydrateException: cliErrors.DehydrateError,
 };
 
-const DEFINED_ERROR_NAMES = ['ErrorException', ...names];
+const DEFINED_ERROR_NAMES = ['AppError', ...names];
 
 module.exports = {
   ...exceptions,

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -543,7 +543,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
   const chooseBetterError = (responseError, scriptError) => {
     if (scriptError) {
-      if (DEFINED_ERROR_NAMES.includes(scriptError.name)) {
+      if (!responseError || DEFINED_ERROR_NAMES.includes(scriptError.name)) {
         return scriptError;
       }
     }

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -570,7 +570,7 @@ const legacyScriptingSource = `
 
       movie_post_write_intercept_error: function(bundle) {
         if (bundle.response.status_code == 418) {
-          throw new HaltedException('teapot here, go find a coffee machine');
+          throw new ErrorException('teapot here, go find a coffee machine');
         }
         return z.JSON.parse(bundle.response.content);
       },


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

ErrorException errors have a name property of 'AppError' which failed the check in chooseBetterError. Now DEFINED_ERROR_NAMES will contain the proper ErrorException name property. Additionally, this updates chooseBetterError to always throw the scriptError if no responseError is present.