### PR TITLE
PDE-1966: fix(core): allow redirecting from https to http while disabling SSL checks

### DIFF
--- a/packages/core/src/http-middlewares/before/disable-ssl-cert-check.js
+++ b/packages/core/src/http-middlewares/before/disable-ssl-cert-check.js
@@ -1,12 +1,20 @@
 'use strict';
 
+const http = require('http');
 const https = require('https');
+
+const httpAgent = new http.Agent({ rejectUnauthorized: false });
+const httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
 const disableSSLCertCheck = (req) => {
   if (req.agent) {
     req.agent.options.rejectUnauthorized = false;
   } else if (req.url.startsWith('https://')) {
-    req.agent = new https.Agent({ rejectUnauthorized: false });
+    // Need to dynamically choose a different agent because redirection can be
+    // across HTTPS and HTTP.
+    // See https://github.com/node-fetch/node-fetch/tree/6ee9d318#custom-agent
+    req.agent = (parsedURL) =>
+      parsedURL.protocol === 'http:' ? httpAgent : httpsAgent;
   }
   return req;
 };

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -364,6 +364,17 @@ describe('request client', () => {
     });
   });
 
+  it('should be able to redirect from https to http while disabling SSL certificate checks', () => {
+    const newInput = _.cloneDeep(input);
+    newInput._zapier.event.verifySSL = false;
+    const request = createAppRequestClient(newInput);
+    return request(`${HTTPBIN_URL}/redirect-to?url=http://example.com`).then(
+      (response) => {
+        response.status.should.eql(200);
+      }
+    );
+  });
+
   it('should allow unencrypted requests when SSL checks are disabled', () => {
     const newInput = _.cloneDeep(input);
     newInput._zapier.event.verifySSL = false;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Steps to reproduce

1. Disable SSL certificate checks in your [advance settings](https://zapier.com/app/settings/advanced).
2. Create a CLI/VB app with a trigger that redirects a request from an `https` URL to `http`. You can use a URL like `https://httpbin.zapier-tooling.com/redirect-to?url=http://example.com` to do that.

## Expected behavior

Successfully redirected to the `http` URL.

## Actual behavior

Error: `Protocol "http:" not supported. Expected "https:"`