### PR TITLE
[SUPPORTESC-115] fix(cli): Fix phrasing of what the specific version links do

### DIFF
--- a/packages/cli/src/oclif/commands/users/links.js
+++ b/packages/cli/src/oclif/commands/users/links.js
@@ -21,7 +21,7 @@ class UsersLinksCommand extends ZapierBaseCommand {
     this.log(`\n${cyan(inviteUrl)}\n`);
 
     this.log(
-      'You can invite users to specific an integration version using the following links:'
+      'You can invite users to a specific integration version using the following links:'
     );
     this.logTable({
       rows: Object.entries(versionInviteUrls).map(([version, url]) => ({


### PR DESCRIPTION
Change the phrasing of what the link does to invite to "a specific integration".