### PR TITLE
PDE-1974: chore(core): Add trigger_subscription_id to SAFE_LOG_KEYS array

### DIFF
--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -52,6 +52,7 @@ const SAFE_LOG_KEYS = [
   'response_status_code',
   'selected_api',
   'timestamp',
+  'trigger_subscription_id',
 ];
 const STATUSES = {
   CALLBACK: 'CALLBACK',


### PR DESCRIPTION
This key was being filtered out because it wasn't a part of the SAFE_LOG_KEYS array. Support needs this key for troubleshooting, so I've added it in.