### PR TITLE
PDE-1982: fix(core): ResponseError shouldn't assume response.content is always present

### DIFF
--- a/packages/core/src/errors.js
+++ b/packages/core/src/errors.js
@@ -19,13 +19,21 @@ class AppError extends Error {
 
 class ResponseError extends Error {
   constructor(response) {
+    let content;
+    try {
+      content = response.content;
+    } catch (err) {
+      // Stream request (z.request({raw: true})) doesn't have response.content
+      content = null;
+    }
+
     super(
       JSON.stringify({
         status: response.status,
         headers: {
           'content-type': response.headers.get('content-type'),
         },
-        content: response.content,
+        content,
         request: {
           url: response.request.url,
         },

--- a/packages/core/test/errors.js
+++ b/packages/core/test/errors.js
@@ -44,5 +44,30 @@ describe('errors', () => {
         `{"status":400,"headers":{"content-type":"text/html; charset=utf-8"},"content":"","request":{"url":"${HTTPBIN_URL}/status/400"}}`
       );
     });
+
+    it('should work with stream request', async () => {
+      const response = {
+        status: 401,
+        headers: {
+          get: () => 'application/json',
+        },
+        request: {
+          url: 'https://example.com',
+        },
+      };
+      Object.defineProperty(response, 'content', {
+        get: function () {
+          throw new Error('stream request does not have content');
+        },
+      });
+
+      const error = new errors.ResponseError(response);
+
+      error.should.instanceOf(errors.ResponseError);
+      error.name.should.eql('ResponseError');
+      error.message.should.eql(
+        `{"status":401,"headers":{"content-type":"application/json"},"content":null,"request":{"url":"https://example.com"}}`
+      );
+    });
   });
 });

--- a/packages/core/test/tools/file-stasher.js
+++ b/packages/core/test/tools/file-stasher.js
@@ -121,7 +121,7 @@ describe('file upload', () => {
     });
     stashFile(file)
       .catch((err) => {
-        should(err.message).containEql('Received 401 code from');
+        should(err.message).containEql('"status":401');
         done();
       })
       .catch(done);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

`z.request({raw: true})`, usually used for file dehydration, is failing to raise a proper `ResponseError` when it gets an error response. This is because the `ResponseError` class assumes `response.content` is always available, which is not true. In the `prepareResponse` middleware, we make `reponse.content` [throw an error](https://github.com/zapier/zapier-platform/blob/4f4f9383d92a9c43a6308bc564b18e989f18fda9/packages/core/src/http-middlewares/after/prepare-response.js#L20-L24).

The fix is to be more defensive in `ResponseError`. When `response.content` throws an error, we simply keep `ResponseError.content` null.

---

fixes https://github.com/zapier/zapier-platform/pull/315