### PR TITLE
SUPPORTESC-121: docs(cli): Make file stashing snippets copy-paste-ible

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3907,8 +3907,8 @@ response.throwForStatus();
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> content = <span class="hljs-string">&apos;Hello world!&apos;</span>;
-z.stashFile(content, content.length, <span class="hljs-string">&apos;hello.txt&apos;</span>, <span class="hljs-string">&apos;text/plain&apos;</span>)
-  .then(<span class="hljs-function"><span class="hljs-params">url</span> =&gt;</span> z.console.log(url));
+<span class="hljs-keyword">const</span> url = <span class="hljs-keyword">await</span> z.stashFile(content, content.length, <span class="hljs-string">&apos;hello.txt&apos;</span>, <span class="hljs-string">&apos;text/plain&apos;</span>);
+z.console.log(url);
 <span class="hljs-comment">// https://zapier-dev-files.s3.amazonaws.com/cli-platform/f75e2819-05e2-41d0-b70e-9f8272f9eebf</span>
 </code></pre>
     </div>
@@ -3920,8 +3920,8 @@ z.stashFile(content, content.length, <span class="hljs-string">&apos;hello.txt&a
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> fileRequest = z.request({<span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com/file.pdf&apos;</span>, <span class="hljs-attr">raw</span>: <span class="hljs-literal">true</span>});
-z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream</span>
-  .then(<span class="hljs-function"><span class="hljs-params">url</span> =&gt;</span> z.console.log(url));
+<span class="hljs-keyword">const</span> url = <span class="hljs-keyword">await</span> z.stashFile(fileRequest); <span class="hljs-comment">// knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream</span>
+z.console.log(url);
 <span class="hljs-comment">// https://zapier-dev-files.s3.amazonaws.com/cli-platform/74bc623c-d94d-4cac-81f1-f71d7d517bc7</span>
 </code></pre>
     </div>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1261,8 +1261,8 @@ The interface `z.stashFile(bufferStringStream, [knownLength], [filename], [conte
 
 ```js
 const content = 'Hello world!';
-z.stashFile(content, content.length, 'hello.txt', 'text/plain')
-  .then(url => z.console.log(url));
+const url = await z.stashFile(content, content.length, 'hello.txt', 'text/plain');
+z.console.log(url);
 // https://zapier-dev-files.s3.amazonaws.com/cli-platform/f75e2819-05e2-41d0-b70e-9f8272f9eebf
 ```
 
@@ -1270,8 +1270,8 @@ Most likely you'd want to stream from another URL - note the usage of `z.request
 
 ```js
 const fileRequest = z.request({url: 'https://example.com/file.pdf', raw: true});
-z.stashFile(fileRequest) // knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream
-  .then(url => z.console.log(url));
+const url = await z.stashFile(fileRequest); // knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream
+z.console.log(url);
 // https://zapier-dev-files.s3.amazonaws.com/cli-platform/74bc623c-d94d-4cac-81f1-f71d7d517bc7
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2359,8 +2359,8 @@ The interface `z.stashFile(bufferStringStream, [knownLength], [filename], [conte
 
 ```js
 const content = 'Hello world!';
-z.stashFile(content, content.length, 'hello.txt', 'text/plain')
-  .then(url => z.console.log(url));
+const url = await z.stashFile(content, content.length, 'hello.txt', 'text/plain');
+z.console.log(url);
 // https://zapier-dev-files.s3.amazonaws.com/cli-platform/f75e2819-05e2-41d0-b70e-9f8272f9eebf
 ```
 
@@ -2368,8 +2368,8 @@ Most likely you'd want to stream from another URL - note the usage of `z.request
 
 ```js
 const fileRequest = z.request({url: 'https://example.com/file.pdf', raw: true});
-z.stashFile(fileRequest) // knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream
-  .then(url => z.console.log(url));
+const url = await z.stashFile(fileRequest); // knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream
+z.console.log(url);
 // https://zapier-dev-files.s3.amazonaws.com/cli-platform/74bc623c-d94d-4cac-81f1-f71d7d517bc7
 ```
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3907,8 +3907,8 @@ response.throwForStatus();
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> content = <span class="hljs-string">&apos;Hello world!&apos;</span>;
-z.stashFile(content, content.length, <span class="hljs-string">&apos;hello.txt&apos;</span>, <span class="hljs-string">&apos;text/plain&apos;</span>)
-  .then(<span class="hljs-function"><span class="hljs-params">url</span> =&gt;</span> z.console.log(url));
+<span class="hljs-keyword">const</span> url = <span class="hljs-keyword">await</span> z.stashFile(content, content.length, <span class="hljs-string">&apos;hello.txt&apos;</span>, <span class="hljs-string">&apos;text/plain&apos;</span>);
+z.console.log(url);
 <span class="hljs-comment">// https://zapier-dev-files.s3.amazonaws.com/cli-platform/f75e2819-05e2-41d0-b70e-9f8272f9eebf</span>
 </code></pre>
     </div>
@@ -3920,8 +3920,8 @@ z.stashFile(content, content.length, <span class="hljs-string">&apos;hello.txt&a
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> fileRequest = z.request({<span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com/file.pdf&apos;</span>, <span class="hljs-attr">raw</span>: <span class="hljs-literal">true</span>});
-z.stashFile(fileRequest) <span class="hljs-comment">// knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream</span>
-  .then(<span class="hljs-function"><span class="hljs-params">url</span> =&gt;</span> z.console.log(url));
+<span class="hljs-keyword">const</span> url = <span class="hljs-keyword">await</span> z.stashFile(fileRequest); <span class="hljs-comment">// knownLength and filename will be sniffed from the request. contentType will be binary/octet-stream</span>
+z.console.log(url);
 <span class="hljs-comment">// https://zapier-dev-files.s3.amazonaws.com/cli-platform/74bc623c-d94d-4cac-81f1-f71d7d517bc7</span>
 </code></pre>
     </div>


### PR DESCRIPTION
The old version of these snippets would return an "undefined" result. This change makes copying and pasting more accessible.