### PR TITLE
fix(cli): ensure test files can be run out of the box with jest

### DIFF
--- a/packages/cli/scaffold/test.template.js
+++ b/packages/cli/scaffold/test.template.js
@@ -1,18 +1,19 @@
-/* globals describe it */
-const should = require('should');
+/* globals describe, expect, test, it */
 
 const zapier = require('zapier-platform-core');
 
 // Use this to make test calls into your app:
 const App = require('../../index');
 const appTester = zapier.createAppTester(App);
+// read the `.env` file into the environment, if available
 zapier.tools.env.inject();
 
-describe('My App', () => {
-  it('should run <%= ACTION_PLURAL %>.<%= KEY %>', async () => {
+describe('<%= ACTION_PLURAL %>.<%= KEY %>', () => {
+  it('should run', async () => {
     const bundle = { inputData: {} };
 
     const results = await appTester(App.<%= ACTION_PLURAL %>.<%= KEY %>.<%= MAYBE_RESOURCE %>operation.perform, bundle);
-    should.exist(results);
+    expect(results).toBeDefined();
+    // TODO: add more assertions
   });
 });

--- a/packages/cli/src/oclif/commands/scaffold.js
+++ b/packages/cli/src/oclif/commands/scaffold.js
@@ -29,8 +29,8 @@ const getLocalFilePath = (directory, actionKey) =>
 const getFullActionFilePath = (directory, actionKey) =>
   path.join(process.cwd(), getLocalFilePath(directory, actionKey));
 
-const getFullActionFilePathWithExtension = (directory, actionKey) =>
-  `${getFullActionFilePath(directory, actionKey)}.js`;
+const getFullActionFilePathWithExtension = (directory, actionKey, isTest) =>
+  `${getFullActionFilePath(directory, actionKey)}${isTest ? '.test' : ''}.js`;
 
 class ScaffoldCommand extends BaseCommand {
   async perform() {
@@ -86,7 +86,7 @@ class ScaffoldCommand extends BaseCommand {
     await writeTemplateFile(
       'test',
       templateContext,
-      getFullActionFilePathWithExtension(newTestActionDir, actionKey),
+      getFullActionFilePathWithExtension(newTestActionDir, actionKey, true),
       preventOverwrite
     );
     this.stopSpinner();

--- a/packages/cli/src/smoke-tests/smoke-tests.js
+++ b/packages/cli/src/smoke-tests/smoke-tests.js
@@ -158,7 +158,12 @@ describe('smoke tests - setup will take some time', () => {
     const newTrigger = path.join(newAppDir, 'triggers', 'neat.js');
     fs.existsSync(newTrigger).should.be.true();
 
-    const newTriggerTest = path.join(newAppDir, 'test', 'triggers', 'neat.js');
+    const newTriggerTest = path.join(
+      newAppDir,
+      'test',
+      'triggers',
+      'neat.test.js'
+    );
     fs.existsSync(newTriggerTest).should.be.true();
 
     const pkg = JSON.parse(


### PR DESCRIPTION
Test files were still using a `mocha` setup instead of `jest`. Now newly-scaffolded tests will run correctly.

[PDE-1907](https://zapierorg.atlassian.net/browse/PDE-1907)