### PR TITLE
PDE-1980: fix(docs): fix typos in README

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -413,7 +413,7 @@ a code {
 <li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md">Latest CLI Docs</a></li>
 <li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md">Latest CLI Reference</a></li>
 <li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md">Latest Schema Docs</a></li>
-</ul><p>This doc decribes the latest CLI version <strong>10.1.3</strong>, as of this writing. If you&apos;re using an older version of the CLI, you may want to check out these historical releases:</p><ul>
+</ul><p>This doc describes the latest CLI version <strong>10.1.3</strong>, as of this writing. If you&apos;re using an older version of the CLI, you may want to check out these historical releases:</p><ul>
 <li>CLI Docs: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
 <li>CLI Reference: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
 <li>Schema Docs: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@9.4.0/packages/schema/docs/build/schema.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@8.4.2/packages/schema/docs/build/schema.md">8.4.2</a></li>
@@ -3212,7 +3212,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Apps can define environment variables that are available when the app&apos;s code executes. They work just like environment
 variables defined on the command line. They are useful when you have data like an OAuth client ID and secret that you
-don&apos;t want to commit to source control. Environment variables can also be used as a quick way to toggle between a
+don&apos;t want to commit to source control. Environment variables can also be used as a quick way to toggle between
 a staging and production environment during app development.</p><p>It is important to note that <strong>variables are defined on a per-version basis!</strong> When you push a new version, the
 existing variables from the previous version are copied, so you don&apos;t have to manually add them. However, edits
 made to one version&apos;s environment will not affect the other versions.</p>
@@ -3763,7 +3763,7 @@ response.throwForStatus();
 <li><code>func</code> - the function to call to fetch the extra data. Can be any raw <code>function</code>, defined in the file doing the dehydration or imported from another part of your app. You must also register the function in the app&apos;s <code>hydrators</code> property</li>
 <li><code>inputData</code> - this is an object that contains things like a <code>path</code> or <code>id</code> - whatever you need to load data on the other side</li>
 </ul><blockquote>
-<p><strong>Why do I need to register my functions?</strong> Because of how Javascript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to &quot;automagically&quot; (and sometimes incorrectly) infer code locations.</p>
+<p><strong>Why do I need to register my functions?</strong> Because of how JavaScript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to &quot;automagically&quot; (and sometimes incorrectly) infer code locations.</p>
 </blockquote><p>Here is an example that pulls in extra data for a movie:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -4506,7 +4506,7 @@ zapier.tools.env.inject(); <span class="hljs-comment">// inject() can take a fil
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is depreated but will continue to work for backward compatibility.</p>
+<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is deprecated but will continue to work for backward compatibility.</p>
 </blockquote><blockquote>
 <p>Remember: <strong>NEVER</strong> add your secrets file to version control!</p>
 </blockquote><p>Additionally, you can provide them dynamically at runtime:</p>
@@ -4603,7 +4603,7 @@ zapier <span class="hljs-built_in">test</span>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This creates a <em>breakpoint</em> in while <code>inspect</code>ing, or a starting point for our manual inspection.</p><p>Next, you&apos;ll need an inspection client. The most available one is probably the Google Chrome browser, but there are <a href="https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients">lots of options</a>. We&apos;ll use Chrome for this example. In your terminal (and in your integration&apos;s root directory), run <code>yarn test:debug</code> (or <code>npm run test:debug</code>). You should see the following:</p>
+      <p>This creates a <em>breakpoint</em> while <code>inspect</code>ing, or a starting point for our manual inspection.</p><p>Next, you&apos;ll need an inspection client. The most available one is probably the Google Chrome browser, but there are <a href="https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients">lots of options</a>. We&apos;ll use Chrome for this example. In your terminal (and in your integration&apos;s root directory), run <code>yarn test:debug</code> (or <code>npm run test:debug</code>). You should see the following:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code>% yarn test:debug
@@ -4617,7 +4617,7 @@ For help, see: https://nodejs.org/en/docs/inspector
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Now in Chrome, go to chrome://inspect. Make sure <code>Discover Network Targets</code> is checked and you should see a path to your <code>jest</code> file on your local machine:</p><p><img src="https://cdn.zappy.app/e2836d2950e1f8a03e3621a22452c3cd.png" alt></p><p>Click <code>inspect</code>. A new window will open. Next, click the little blue arrow in the top right to actually run the code:</p><p><img src="https://cdn.zappy.app/a64e7963a7090e9730d9c8e7b3595a6a.png" alt></p><p>After a few seconds, you&apos;ll see your code, the <code>debugger</code> statement, and info about the current environment on the right panel. You should see familiar data in the <code>Locals</code> section, such as the <code>response</code> variable, and the <code>z</code> object.</p><p><img src="https://cdn.zappy.app/4bfdfe079a344ab7aced64ad7728bc6a.png" alt></p><p>Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier ingration in smooth working order.</p>
+      <p>Now in Chrome, go to chrome://inspect. Make sure <code>Discover Network Targets</code> is checked and you should see a path to your <code>jest</code> file on your local machine:</p><p><img src="https://cdn.zappy.app/e2836d2950e1f8a03e3621a22452c3cd.png" alt></p><p>Click <code>inspect</code>. A new window will open. Next, click the little blue arrow in the top right to actually run the code:</p><p><img src="https://cdn.zappy.app/a64e7963a7090e9730d9c8e7b3595a6a.png" alt></p><p>After a few seconds, you&apos;ll see your code, the <code>debugger</code> statement, and info about the current environment on the right panel. You should see familiar data in the <code>Locals</code> section, such as the <code>response</code> variable, and the <code>z</code> object.</p><p><img src="https://cdn.zappy.app/4bfdfe079a344ab7aced64ad7728bc6a.png" alt></p><p>Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier integration in smooth working order.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -18,7 +18,7 @@ You may find docs duplicate or outdated across the Zapier site. The most up-to-d
 - [Latest CLI Reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
 - [Latest Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
 
-This doc decribes the latest CLI version **PACKAGE_VERSION**, as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
+This doc describes the latest CLI version **PACKAGE_VERSION**, as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
 
 - CLI Docs: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
 - CLI Reference: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
@@ -956,7 +956,7 @@ Read more in the [REST hook example](https://github.com/zapier/zapier-platform/b
 
 Apps can define environment variables that are available when the app's code executes. They work just like environment
 variables defined on the command line. They are useful when you have data like an OAuth client ID and secret that you
-don't want to commit to source control. Environment variables can also be used as a quick way to toggle between a
+don't want to commit to source control. Environment variables can also be used as a quick way to toggle between
 a staging and production environment during app development.
 
 It is important to note that **variables are defined on a per-version basis!** When you push a new version, the
@@ -1206,7 +1206,7 @@ The method `z.dehydrate(func, inputData)` has two required arguments:
 * `func` - the function to call to fetch the extra data. Can be any raw `function`, defined in the file doing the dehydration or imported from another part of your app. You must also register the function in the app's `hydrators` property
 * `inputData` - this is an object that contains things like a `path` or `id` - whatever you need to load data on the other side
 
-> **Why do I need to register my functions?** Because of how Javascript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to "automagically" (and sometimes incorrectly) infer code locations.
+> **Why do I need to register my functions?** Because of how JavaScript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to "automagically" (and sometimes incorrectly) infer code locations.
 
 Here is an example that pulls in extra data for a movie:
 
@@ -1517,7 +1517,7 @@ zapier.tools.env.inject(); // inject() can take a filename; defaults to ".env"
 // now process.env has all the values in your .env file
 ```
 
-> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is depreated but will continue to work for backward compatibility.
+> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is deprecated but will continue to work for backward compatibility.
 
 > Remember: **NEVER** add your secrets file to version control!
 
@@ -1584,7 +1584,7 @@ const perform = async (z, bundle) => {
 };
 ```
 
-This creates a _breakpoint_ in while `inspect`ing, or a starting point for our manual inspection.
+This creates a _breakpoint_ while `inspect`ing, or a starting point for our manual inspection.
 
 Next, you'll need an inspection client. The most available one is probably the Google Chrome browser, but there are [lots of options](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients). We'll use Chrome for this example. In your terminal (and in your integration's root directory), run `yarn test:debug` (or `npm run test:debug`). You should see the following:
 
@@ -1608,7 +1608,7 @@ After a few seconds, you'll see your code, the `debugger` statement, and info ab
 
 ![](https://cdn.zappy.app/4bfdfe079a344ab7aced64ad7728bc6a.png)
 
-Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier ingration in smooth working order.
+Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier integration in smooth working order.
 
 ## Using `npm` Modules
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,7 +20,7 @@ You may find docs duplicate or outdated across the Zapier site. The most up-to-d
 - [Latest CLI Reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
 - [Latest Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
 
-This doc decribes the latest CLI version **10.1.3**, as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
+This doc describes the latest CLI version **10.1.3**, as of this writing. If you're using an older version of the CLI, you may want to check out these historical releases:
 
 - CLI Docs: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
 - CLI Reference: [9.4.0](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md), [8.4.2](https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md)
@@ -1867,7 +1867,7 @@ Read more in the [REST hook example](https://github.com/zapier/zapier-platform/b
 
 Apps can define environment variables that are available when the app's code executes. They work just like environment
 variables defined on the command line. They are useful when you have data like an OAuth client ID and secret that you
-don't want to commit to source control. Environment variables can also be used as a quick way to toggle between a
+don't want to commit to source control. Environment variables can also be used as a quick way to toggle between
 a staging and production environment during app development.
 
 It is important to note that **variables are defined on a per-version basis!** When you push a new version, the
@@ -2257,7 +2257,7 @@ The method `z.dehydrate(func, inputData)` has two required arguments:
 * `func` - the function to call to fetch the extra data. Can be any raw `function`, defined in the file doing the dehydration or imported from another part of your app. You must also register the function in the app's `hydrators` property
 * `inputData` - this is an object that contains things like a `path` or `id` - whatever you need to load data on the other side
 
-> **Why do I need to register my functions?** Because of how Javascript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to "automagically" (and sometimes incorrectly) infer code locations.
+> **Why do I need to register my functions?** Because of how JavaScript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to "automagically" (and sometimes incorrectly) infer code locations.
 
 Here is an example that pulls in extra data for a movie:
 
@@ -2735,7 +2735,7 @@ zapier.tools.env.inject(); // inject() can take a filename; defaults to ".env"
 // now process.env has all the values in your .env file
 ```
 
-> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is depreated but will continue to work for backward compatibility.
+> `.env` is the new recommended name for the environment file since v5.1.0. The old name `.environment` is deprecated but will continue to work for backward compatibility.
 
 > Remember: **NEVER** add your secrets file to version control!
 
@@ -2802,7 +2802,7 @@ const perform = async (z, bundle) => {
 };
 ```
 
-This creates a _breakpoint_ in while `inspect`ing, or a starting point for our manual inspection.
+This creates a _breakpoint_ while `inspect`ing, or a starting point for our manual inspection.
 
 Next, you'll need an inspection client. The most available one is probably the Google Chrome browser, but there are [lots of options](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients). We'll use Chrome for this example. In your terminal (and in your integration's root directory), run `yarn test:debug` (or `npm run test:debug`). You should see the following:
 
@@ -2826,7 +2826,7 @@ After a few seconds, you'll see your code, the `debugger` statement, and info ab
 
 ![](https://cdn.zappy.app/4bfdfe079a344ab7aced64ad7728bc6a.png)
 
-Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier ingration in smooth working order.
+Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier integration in smooth working order.
 
 ## Using `npm` Modules
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -413,7 +413,7 @@ a code {
 <li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md">Latest CLI Docs</a></li>
 <li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md">Latest CLI Reference</a></li>
 <li><a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md">Latest Schema Docs</a></li>
-</ul><p>This doc decribes the latest CLI version <strong>10.1.3</strong>, as of this writing. If you&apos;re using an older version of the CLI, you may want to check out these historical releases:</p><ul>
+</ul><p>This doc describes the latest CLI version <strong>10.1.3</strong>, as of this writing. If you&apos;re using an older version of the CLI, you may want to check out these historical releases:</p><ul>
 <li>CLI Docs: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
 <li>CLI Reference: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@9.4.0/packages/cli/README.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-cli@8.4.2/packages/cli/README.md">8.4.2</a></li>
 <li>Schema Docs: <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@9.4.0/packages/schema/docs/build/schema.md">9.4.0</a>, <a href="https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@8.4.2/packages/schema/docs/build/schema.md">8.4.2</a></li>
@@ -3212,7 +3212,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Apps can define environment variables that are available when the app&apos;s code executes. They work just like environment
 variables defined on the command line. They are useful when you have data like an OAuth client ID and secret that you
-don&apos;t want to commit to source control. Environment variables can also be used as a quick way to toggle between a
+don&apos;t want to commit to source control. Environment variables can also be used as a quick way to toggle between
 a staging and production environment during app development.</p><p>It is important to note that <strong>variables are defined on a per-version basis!</strong> When you push a new version, the
 existing variables from the previous version are copied, so you don&apos;t have to manually add them. However, edits
 made to one version&apos;s environment will not affect the other versions.</p>
@@ -3763,7 +3763,7 @@ response.throwForStatus();
 <li><code>func</code> - the function to call to fetch the extra data. Can be any raw <code>function</code>, defined in the file doing the dehydration or imported from another part of your app. You must also register the function in the app&apos;s <code>hydrators</code> property</li>
 <li><code>inputData</code> - this is an object that contains things like a <code>path</code> or <code>id</code> - whatever you need to load data on the other side</li>
 </ul><blockquote>
-<p><strong>Why do I need to register my functions?</strong> Because of how Javascript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to &quot;automagically&quot; (and sometimes incorrectly) infer code locations.</p>
+<p><strong>Why do I need to register my functions?</strong> Because of how JavaScript works with its module system, we need an explicit handle on the function that can be accessed from the App definition without trying to &quot;automagically&quot; (and sometimes incorrectly) infer code locations.</p>
 </blockquote><p>Here is an example that pulls in extra data for a movie:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -4506,7 +4506,7 @@ zapier.tools.env.inject(); <span class="hljs-comment">// inject() can take a fil
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is depreated but will continue to work for backward compatibility.</p>
+<p><code>.env</code> is the new recommended name for the environment file since v5.1.0. The old name <code>.environment</code> is deprecated but will continue to work for backward compatibility.</p>
 </blockquote><blockquote>
 <p>Remember: <strong>NEVER</strong> add your secrets file to version control!</p>
 </blockquote><p>Additionally, you can provide them dynamically at runtime:</p>
@@ -4603,7 +4603,7 @@ zapier <span class="hljs-built_in">test</span>
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This creates a <em>breakpoint</em> in while <code>inspect</code>ing, or a starting point for our manual inspection.</p><p>Next, you&apos;ll need an inspection client. The most available one is probably the Google Chrome browser, but there are <a href="https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients">lots of options</a>. We&apos;ll use Chrome for this example. In your terminal (and in your integration&apos;s root directory), run <code>yarn test:debug</code> (or <code>npm run test:debug</code>). You should see the following:</p>
+      <p>This creates a <em>breakpoint</em> while <code>inspect</code>ing, or a starting point for our manual inspection.</p><p>Next, you&apos;ll need an inspection client. The most available one is probably the Google Chrome browser, but there are <a href="https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients">lots of options</a>. We&apos;ll use Chrome for this example. In your terminal (and in your integration&apos;s root directory), run <code>yarn test:debug</code> (or <code>npm run test:debug</code>). You should see the following:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code>% yarn test:debug
@@ -4617,7 +4617,7 @@ For help, see: https://nodejs.org/en/docs/inspector
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Now in Chrome, go to chrome://inspect. Make sure <code>Discover Network Targets</code> is checked and you should see a path to your <code>jest</code> file on your local machine:</p><p><img src="https://cdn.zappy.app/e2836d2950e1f8a03e3621a22452c3cd.png" alt></p><p>Click <code>inspect</code>. A new window will open. Next, click the little blue arrow in the top right to actually run the code:</p><p><img src="https://cdn.zappy.app/a64e7963a7090e9730d9c8e7b3595a6a.png" alt></p><p>After a few seconds, you&apos;ll see your code, the <code>debugger</code> statement, and info about the current environment on the right panel. You should see familiar data in the <code>Locals</code> section, such as the <code>response</code> variable, and the <code>z</code> object.</p><p><img src="https://cdn.zappy.app/4bfdfe079a344ab7aced64ad7728bc6a.png" alt></p><p>Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier ingration in smooth working order.</p>
+      <p>Now in Chrome, go to chrome://inspect. Make sure <code>Discover Network Targets</code> is checked and you should see a path to your <code>jest</code> file on your local machine:</p><p><img src="https://cdn.zappy.app/e2836d2950e1f8a03e3621a22452c3cd.png" alt></p><p>Click <code>inspect</code>. A new window will open. Next, click the little blue arrow in the top right to actually run the code:</p><p><img src="https://cdn.zappy.app/a64e7963a7090e9730d9c8e7b3595a6a.png" alt></p><p>After a few seconds, you&apos;ll see your code, the <code>debugger</code> statement, and info about the current environment on the right panel. You should see familiar data in the <code>Locals</code> section, such as the <code>response</code> variable, and the <code>z</code> object.</p><p><img src="https://cdn.zappy.app/4bfdfe079a344ab7aced64ad7728bc6a.png" alt></p><p>Using debugging in combination with thorough unit tests, you will hopefully be able to keep your Zapier integration in smooth working order.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes typos that I found when [copying](https://github.com/zapier/visual-builder/pull/172) the contents to the platform.zapier.com doc site.