### PR TITLE
PDE-2012: fix(legacy-scripting-runner): pre_oauthv2_token and pre_oauthv2_refresh discrepancies

### DIFF
--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -38,16 +38,27 @@ const legacyScriptingSource = `
         };
       },
 
-      pre_oauthv2_token: function(bundle) {
+      pre_oauthv2_token_basic: function(bundle) {
         bundle.request.url += 'token';
+        bundle.request.data = bundle.request.params;
         return bundle.request;
       },
 
-      post_oauthv2_token: function(bundle) {
+      post_oauthv2_token_basic: function(bundle) {
         var data = z.JSON.parse(bundle.response.content);
         data.something_custom += '!!';
         data.name = 'Jane Doe';
         return data;
+      },
+
+      pre_oauthv2_token_payload_only_in_params: function(bundle) {
+        bundle.request.url += 'token';
+        if (bundle.request.params.grant_type) {
+          bundle.request.data = bundle.request.params;
+        } else {
+          throw new Error('should not reach here');
+        }
+        return bundle.request;
       },
 
       pre_oauthv2_refresh_auth_json_server: function(bundle) {
@@ -85,27 +96,12 @@ const legacyScriptingSource = `
         };
       },
 
-      pre_oauthv2_refresh_request_data_retry: function(bundle) {
-        'use strict';
-
+      pre_oauthv2_refresh_does_not_retry: function(bundle) {
         if (bundle.request.data.client_id) {
-          throw new Error('make it retry');
+          bundle.request.url = '${HTTPBIN_URL}/post';
+          return bundle.request;
         }
-
-        // bundle.request.data should be an object, so this would error in
-        // strict mode if request.data is a string
-        bundle.request.data.foo = 'hello';
-        bundle.request.data.bar = 'world';
-        bundle.request.data = $.param(bundle.request.data);
-
-        bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-
-        return {
-          url: '${HTTPBIN_URL}/post',
-          method: bundle.request.method,
-          headers: bundle.request.headers,
-          data: bundle.request.data
-        };
+        throw new Error('should not reach here');
       },
 
       pre_oauthv2_refresh_bundle_load: function(bundle) {

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -195,8 +195,8 @@ describe('Integration Test', () => {
     it('pre_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
-        'post_oauthv2_token',
-        'dont_care'
+        'pre_oauthv2_token_basic',
+        'pre_oauthv2_token'
       );
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
@@ -219,8 +219,8 @@ describe('Integration Test', () => {
     it('post_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
-        'pre_oauthv2_token',
-        'dont_care'
+        'post_oauthv2_token_basic',
+        'post_oauthv2_token'
       );
       appDefWithAuth.legacy.authentication.oauth2Config.accessTokenUrl +=
         'token';
@@ -244,6 +244,14 @@ describe('Integration Test', () => {
 
     it('pre_oauthv2_token & post_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'pre_oauthv2_token_basic',
+        'pre_oauthv2_token'
+      );
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'post_oauthv2_token_basic',
+        'post_oauthv2_token'
+      );
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
 
@@ -259,6 +267,28 @@ describe('Integration Test', () => {
         should.equal(output.results.access_token, 'a_token');
         should.equal(output.results.something_custom, 'alright!!!');
         should.equal(output.results.name, 'Jane Doe');
+      });
+    });
+
+    it('pre_oauthv2_token, payload only in params', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'pre_oauthv2_token_payload_only_in_params',
+        'pre_oauthv2_token'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.getAccessToken'
+      );
+      input.bundle.inputData = {
+        redirect_uri: 'https://example.com',
+        code: 'one_time_code',
+      };
+      return app(input).then((output) => {
+        should.equal(output.results.access_token, 'a_token');
       });
     });
 
@@ -361,10 +391,10 @@ describe('Integration Test', () => {
       });
     });
 
-    it('pre_oauthv2_refresh, request.data should be an object on retry', () => {
+    it('pre_oauthv2_refresh, does not retry', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
-        'pre_oauthv2_refresh_request_data_retry',
+        'pre_oauthv2_refresh_does_not_retry',
         'pre_oauthv2_refresh'
       );
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
@@ -382,15 +412,12 @@ describe('Integration Test', () => {
         const params = output.results.args;
 
         should.deepEqual(data, {
-          bar: ['world'],
-          foo: ['hello'],
-        });
-        should.deepEqual(params, {
           client_id: [process.env.CLIENT_ID],
           client_secret: [process.env.CLIENT_SECRET],
           grant_type: ['refresh_token'],
           refresh_token: ['my_refresh_token'],
         });
+        should.deepEqual(params, {});
       });
     });
 
@@ -425,13 +452,11 @@ describe('Integration Test', () => {
     it('post_oauthv2_token, returns nothing', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
-        'post_oauthv2_token:',
-        'dont_care:'
-      );
-      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
         'post_oauthv2_token_returns_nothing',
         'post_oauthv2_token'
       );
+      appDefWithAuth.legacy.authentication.oauth2Config.accessTokenUrl +=
+        'token';
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);
       const app = createApp(appDefWithAuth);
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes OAuth2 scripting discrepancies:

- If `pre_oauthv2_token` or `pre_oauthv2_refresh` is defined, we should NOT retry to fetch or refresh the access token.
- We should not retry either if the error is not thrown by `response.throwForStatus()`. That is, retry only when it's a `ResponseError`.
- The OAuth payload for `pre_oauthv2_token` should be in `bundle.request.params`. Previously, we were setting `bundle.request.data` on the first attempt. And only if it fails, we retried it with `bundle.request.params`.