### PR TITLE
PDE-2012: fix(legacy-scripting-runner): yet-to-save auth fields should be in bundle.auth_fields

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -868,9 +868,9 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     );
     authFieldKeys.push('_zapier_account_id');
 
-    // In CLI, it's bundle.inputData instead of bundle.authData has yet-to-save
-    // (auth hasn't been saved) auth fields. In WB, bundle.auth_fields always
-    // has yet-to-save auth fields.
+    // In CLI, it's bundle.inputData instead of bundle.authData that has
+    // yet-to-save (auth hasn't been saved) auth fields. In WB,
+    // bundle.auth_fields always has yet-to-save auth fields.
     bundle.authData = {
       ..._.pick(bundle.inputData, authFieldKeys),
       ...bundle.authData,

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -863,6 +863,19 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       templateContext
     );
 
+    const authFieldKeys = (_.get(app, 'authentication.fields') || []).map(
+      (f) => f.key
+    );
+    authFieldKeys.push('_zapier_account_id');
+
+    // In CLI, it's bundle.inputData instead of bundle.authData has yet-to-save
+    // (auth hasn't been saved) auth fields. In WB, bundle.auth_fields always
+    // has yet-to-save auth fields.
+    bundle.authData = {
+      ..._.pick(bundle.inputData, authFieldKeys),
+      ...bundle.authData,
+    };
+
     const params = request.params;
     params.code = bundle.inputData.code;
     params.client_id = clientId;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -61,6 +61,12 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      pre_oauthv2_token_yet_to_save_auth_fields: function(bundle) {
+        bundle.request.url = '${HTTPBIN_URL}/post';
+        bundle.request.data = bundle.auth_fields;
+        return bundle.request;
+      },
+
       pre_oauthv2_refresh_auth_json_server: function(bundle) {
         bundle.request.url += 'token';
         return bundle.request;

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -292,6 +292,32 @@ describe('Integration Test', () => {
       });
     });
 
+    it('pre_oauthv2_token, yet to save auth_fields', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'pre_oauthv2_token_yet_to_save_auth_fields',
+        'pre_oauthv2_token'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.getAccessToken'
+      );
+      input.bundle.inputData = {
+        redirect_uri: 'https://example.com',
+        code: 'one_time_code',
+        something_custom: 'hey',
+      };
+      return app(input).then((output) => {
+        const echoed = output.results;
+        should.deepEqual(echoed.form, {
+          something_custom: ['hey'],
+        });
+      });
+    });
+
     it('pre_oauthv2_refresh', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In `pre_oauthv2_token`, `bundle.auth_fields` should contain yet-to-save auth fields. `bundle.auth_fields` was empty because:

- yet-to-save auth fields are in `bundle.inputData` in the CLI world
- we were copying only from `bundle.authData`, not from `bundle.inputData`, to `bundle.auth_fields`