### PR TITLE
PDE-2002: feat(schema): Add ability to specify "code" param to OAuth2 schema

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -215,20 +215,16 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    getRequestToken: { require: 'some/path/to/file.js' },
+  { getRequestToken: { require: 'some/path/to/file.js' },
     authorizeUrl: { require: 'some/path/to/file2.js' },
-    getAccessToken: { require: 'some/path/to/file3.js' }
-  }
+    getAccessToken: { require: 'some/path/to/file3.js' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    getRequestToken: { require: 'some/path/to/file.js' },
-    authorizeUrl: { require: 'some/path/to/file2.js' }
-  }
+  { getRequestToken: { require: 'some/path/to/file.js' },
+    authorizeUrl: { require: 'some/path/to/file2.js' } }
   ```
   _Missing required key._
 
@@ -250,25 +246,23 @@ Key | Required | Type | Description
 `authorizeUrl` | **yes** | oneOf([/RedirectRequestSchema](#redirectrequestschema), [/FunctionSchema](#functionschema)) | Define where Zapier will redirect the user to authorize our app. Note: we append the redirect URL and state parameters to return value of this function.
 `getAccessToken` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Define how Zapier fetches an access token from the API
 `refreshAccessToken` | no | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Define how Zapier will refresh the access token from the API
+`codeParam` | no | `string` | Define a non-standard code param Zapier should scrape instead.
 `scope` | no | `string` | What scope should Zapier request?
 `autoRefresh` | no | `boolean` | Should Zapier invoke `refreshAccessToken` when we receive an error for a 401 response?
 
 #### Examples
 
 * ```
-  {
-    authorizeUrl: { require: 'some/path/to/file.js' },
-    getAccessToken: { require: 'some/path/to/file2.js' }
-  }
+  { authorizeUrl: { require: 'some/path/to/file.js' },
+    getAccessToken: { require: 'some/path/to/file2.js' } }
   ```
 * ```
-  {
-    authorizeUrl: { require: 'some/path/to/file.js' },
+  { authorizeUrl: { require: 'some/path/to/file.js' },
     getAccessToken: { require: 'some/path/to/file2.js' },
     refreshAccessToken: { require: 'some/path/to/file3.js' },
+    codeParam: 'unique_code',
     scope: 'read/write',
-    autoRefresh: true
-  }
+    autoRefresh: true }
   ```
 
 #### Anti-Examples
@@ -430,13 +424,11 @@ Key | Required | Type | Description
 * `{ hidden: true }`
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  {
-    label: 'New Thing',
+  { label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true
-  }
+    important: true }
   ```
 
 #### Anti-Examples
@@ -473,26 +465,22 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    type: 'hook',
+  { type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
     performUnsubscribe: { require: 'some/path/to/file4.js' },
-    sample: { id: 42, name: 'Hooli' }
-  }
+    sample: { id: 42, name: 'Hooli' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    type: 'hook',
+  { type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
-    performUnsubscribe: { require: 'some/path/to/file4.js' }
-  }
+    performUnsubscribe: { require: 'some/path/to/file4.js' } }
   ```
   _Missing required key: sample. Note - This is only invalid if `display` is not explicitly set to true and if it does not belong to a resource that has a sample._
 
@@ -579,24 +567,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipes',
+  { key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation: {
-      perform: '$func$0$f$',
-      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-    }
-  }
+    operation:
+     { perform: '$func$0$f$',
+       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get User', description: 'Retrieve a user.' },
-    operation: { description: 'Define how this search method will work.' }
-  }
+  { display: { label: 'Get User', description: 'Retrieve a user.' },
+    operation: { description: 'Define how this search method will work.' } }
   ```
   _Missing required keys: key and noun_
 
@@ -620,33 +603,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    recipes: {
-      key: 'recipes',
-      noun: 'Recipes',
-      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-      operation: {
-        perform: '$func$0$f$',
-        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-      }
-    }
-  }
+  { recipes:
+     { key: 'recipes',
+       noun: 'Recipes',
+       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+       operation:
+        { perform: '$func$0$f$',
+          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    readRecipes: {
-      key: 'recipes',
-      noun: 'Recipes',
-      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-      operation: {
-        perform: '$func$0$f$',
-        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-      }
-    }
-  }
+  { readRecipes:
+     { key: 'recipes',
+       noun: 'Recipes',
+       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+       operation:
+        { perform: '$func$0$f$',
+          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
   ```
   _Key must match the key of the associated BulkReadSchema_
 
@@ -673,49 +648,39 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
-  }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
   ```
   _Invalid value for key on operation: shouldLock_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing required key on operation: sample. Note - this is valid if the resource has defined a sample._
 
@@ -739,48 +704,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    createRecipe: {
-      key: 'createRecipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { createRecipe:
+     { key: 'createRecipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
 * ```
-  {
-    Create_Recipe_01: {
-      key: 'Create_Recipe_01',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { Create_Recipe_01:
+     { key: 'Create_Recipe_01',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    '01_Create_Recipe': {
-      key: '01_Create_Recipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { '01_Create_Recipe':
+     { key: '01_Create_Recipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
   _Key must start with a letter_
 * ```
-  {
-    Create_Recipe: {
-      key: 'createRecipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { Create_Recipe:
+     { key: 'createRecipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
   _Key must match the key field in CreateSchema_
 
@@ -1258,29 +1211,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Create Tag',
-      description: 'Create a new Tag in your account.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1305,25 +1248,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1348,29 +1285,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: {
-      type: 'hook',
-      perform: '$func$0$f$',
-      sample: { id: 385, name: 'proactive enable ROI' }
-    }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1395,38 +1322,24 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: {
-      perform: { url: 'https://fake-crm.getsandbox.com/users' },
-      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
-    }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation:
+     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
+       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.',
-      hidden: true
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display:
+     { label: 'New User',
+       description: 'Trigger when a new User is created in your account.',
+       hidden: true },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1451,31 +1364,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1507,61 +1410,43 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1585,50 +1470,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    tag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: {
-          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' }
-        }
-      }
-    }
-  }
+  { tag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation:
+           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+             sample: { id: 385, name: 'proactive enable ROI' } } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    getTag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: {
-          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' }
-        }
-      }
-    }
-  }
+  { getTag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation:
+           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+             sample: { id: 385, name: 'proactive enable ROI' } } } } }
   ```
   _Key does not match key for associated /ResourceSchema_
 * ```
-  {
-    tag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-      }
-    }
-  }
+  { tag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1676,47 +1547,38 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'searchOrCreateWidgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: 'searchOrCreateWidgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: 'searchWidgets',
-    create: 'createWidget'
-  }
+    create: 'createWidget' }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: '01_Search_or_Create_Widgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: '01_Search_or_Create_Widgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: 'searchWidgets',
-    create: 'createWidget'
-  }
+    create: 'createWidget' }
   ```
   _Invalid value for key: key (must start with a letter)_
 * ```
-  {
-    key: 'searchOrCreateWidgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: 'searchOrCreateWidgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: { require: 'path/to/some/file.js' },
-    create: { require: 'path/to/some/file.js' }
-  }
+    create: { require: 'path/to/some/file.js' } }
   ```
   _Invalid values for keys: search and create (must be a string that matches the key of a registered search or create)_
 
@@ -1740,37 +1602,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    searchOrCreateWidgets: {
-      key: 'searchOrCreateWidgets',
-      display: {
-        label: 'Search or Create Widgets',
-        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-        important: true,
-        hidden: false
-      },
-      search: 'searchWidgets',
-      create: 'createWidget'
-    }
-  }
+  { searchOrCreateWidgets:
+     { key: 'searchOrCreateWidgets',
+       display:
+        { label: 'Search or Create Widgets',
+          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+          important: true,
+          hidden: false },
+       search: 'searchWidgets',
+       create: 'createWidget' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    searchOrCreateWidgets: {
-      key: 'socWidgets',
-      display: {
-        label: 'Search or Create Widgets',
-        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-        important: true,
-        hidden: false
-      },
-      search: 'searchWidgets',
-      create: 'createWidget'
-    }
-  }
+  { searchOrCreateWidgets:
+     { key: 'socWidgets',
+       display:
+        { label: 'Search or Create Widgets',
+          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+          important: true,
+          hidden: false },
+       search: 'searchWidgets',
+       create: 'createWidget' } }
   ```
   _Key must match the key of the associated /SearchOrCreateSchema_
 
@@ -1797,36 +1651,26 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing required key in operation: sample. Note - this is valid if the associated resource has defined a sample._
 
@@ -1850,35 +1694,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    recipe: {
-      key: 'recipe',
-      noun: 'Recipe',
-      display: {
-        label: 'Find a Recipe',
-        description: 'Search for recipe by cuisine style.',
-        hidden: true
-      },
-      operation: { perform: '$func$2$f$' }
-    }
-  }
+  { recipe:
+     { key: 'recipe',
+       noun: 'Recipe',
+       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+       operation: { perform: '$func$2$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    searchRecipe: {
-      key: 'recipe',
-      noun: 'Recipe',
-      display: {
-        label: 'Find a Recipe',
-        description: 'Search for recipe by cuisine style.',
-        hidden: true
-      },
-      operation: { perform: '$func$2$f$' }
-    }
-  }
+  { searchRecipe:
+     { key: 'recipe',
+       noun: 'Recipe',
+       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+       operation: { perform: '$func$2$f$' } } }
   ```
   _Key must match the key of the associated /SearchSchema_
 
@@ -1905,35 +1735,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-  }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
-    display: {
-      label: 'New Recipe',
-      description: 'Triggers when a new recipe is added.',
-      hidden: true
-    },
-    operation: { type: 'polling', perform: '$func$0$f$' }
-  }
+    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
+    operation: { type: 'polling', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' }
-  }
+    operation: { perform: '$func$0$f$' } }
   ```
   _Missing required key from operation: sample. Note - this is valid if the Recipe resource has defined a sample._
 
@@ -1957,27 +1777,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    newRecipe: {
-      key: 'newRecipe',
-      noun: 'Recipe',
-      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-    }
-  }
+  { newRecipe:
+     { key: 'newRecipe',
+       noun: 'Recipe',
+       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    newRecipe: {
-      key: 'new_recipe',
-      noun: 'Recipe',
-      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-    }
-  }
+  { newRecipe:
+     { key: 'new_recipe',
+       noun: 'Recipe',
+       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
   ```
   _Key must match the key on the associated /TriggerSchema_
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -530,6 +530,10 @@
             }
           ]
         },
+        "codeParam": {
+          "description": "Define a non-standard code param Zapier should scrape instead.",
+          "type": "string"
+        },
         "scope": {
           "description": "What scope should Zapier request?",
           "type": "string"

--- a/packages/schema/lib/schemas/AuthenticationOAuth2ConfigSchema.js
+++ b/packages/schema/lib/schemas/AuthenticationOAuth2ConfigSchema.js
@@ -30,6 +30,11 @@ module.exports = makeSchema(
           'Define how Zapier will refresh the access token from the API',
         oneOf: [{ $ref: RequestSchema.id }, { $ref: FunctionSchema.id }],
       },
+      codeParam: {
+        description:
+          'Define a non-standard code param Zapier should scrape instead.',
+        type: 'string',
+      },
       scope: {
         description: 'What scope should Zapier request?',
         type: 'string',
@@ -50,6 +55,7 @@ module.exports = makeSchema(
         authorizeUrl: { require: 'some/path/to/file.js' },
         getAccessToken: { require: 'some/path/to/file2.js' },
         refreshAccessToken: { require: 'some/path/to/file3.js' },
+        codeParam: 'unique_code',
         scope: 'read/write',
         autoRefresh: true,
       },


### PR DESCRIPTION
## Description   
This change allows CLI developers using OAuth2 to specify a non standard parameter for us to scrape instead of code. Some Oauth flows, such as Amazon, respond from the authorizeUrl with a parameter other than code.  
[Amazon Docs](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/developer-guide/SellingPartnerApiDeveloperGuide.md#step-3-amazon-sends-you-the-authorization-information)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Related Issue

<!-- Fixes #XXX or link to Jira / Loki / Trello -->  
https://zapierorg.atlassian.net/browse/PDE-2002

## Before / Current Behavior

<!-- If applicable, screenshots, recordings, etc. -->  
All CLI integrations could only use OAuth2 if the authentication flow responded with a `code` param.  

## After / New Behavior

<!-- If applicable, screenshots, recordings, etc. -->   
CLI developers can specify a param to scrape instead of `code`, i.e. `spapi_oauth_code`.   
