### PR TITLE
[SUPPORTESC-124] docs(cli): Add note that auth is required for integrations looking to go public

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1141,6 +1141,8 @@ zapier convert 1234 --version 1.0.1 my-app
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Most applications require some sort of authentication - and Zapier provides a handful of methods for helping your users authenticate with your application. Zapier will provide some of the core behaviors, but you&apos;ll likely need to handle the rest.</p><blockquote>
 <p>Hint: You can access the data tied to your authentication via the <code>bundle.authData</code> property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.</p>
+</blockquote><blockquote>
+<p>Note: Authentication is required for integrations intending to go public on Zapier.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -307,6 +307,8 @@ Most applications require some sort of authentication - and Zapier provides a ha
 
 > Hint: You can access the data tied to your authentication via the `bundle.authData` property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.
 
+> Note: Authentication is required for integrations intending to go public on Zapier.
+
 ### Basic
 
 Useful if your app requires two pieces of information to authentication: `username` and `password` which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -445,6 +445,8 @@ Most applications require some sort of authentication - and Zapier provides a ha
 
 > Hint: You can access the data tied to your authentication via the `bundle.authData` property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.
 
+> Note: Authentication is required for integrations intending to go public on Zapier.
+
 ### Basic
 
 Useful if your app requires two pieces of information to authentication: `username` and `password` which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1141,6 +1141,8 @@ zapier convert 1234 --version 1.0.1 my-app
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Most applications require some sort of authentication - and Zapier provides a handful of methods for helping your users authenticate with your application. Zapier will provide some of the core behaviors, but you&apos;ll likely need to handle the rest.</p><blockquote>
 <p>Hint: You can access the data tied to your authentication via the <code>bundle.authData</code> property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.</p>
+</blockquote><blockquote>
+<p>Note: Authentication is required for integrations intending to go public on Zapier.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">


### PR DESCRIPTION
This was noted internally, but didn't seem to be highlighted externally. As auth can be omitted in CLI development, this seemed like a good place to note it.