### PR TITLE
PDE-2079: fix(legacy-scripting-runner): add bundle.trigger_data to pre_subscribe

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.12 (unreleased)
+
+- :bug: Add `bundle.trigger_data` to `pre_subscribe` and `post_subscribe` ([#342](https://github.com/zapier/zapier-platform/pull/342))
+
 ## 3.7.11
 
 - :bug: Yet-to-save auth fields should be in `bundle.auth_fields` ([#331](https://github.com/zapier/zapier-platform/pull/331))

--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -118,11 +118,13 @@ const addHookData = (event, bundle, convertedBundle) => {
     convertedBundle.target_url = bundle.targetUrl;
     convertedBundle.subscription_url = bundle.targetUrl;
     convertedBundle.event = bundle._legacyEvent;
+    convertedBundle.trigger_data = bundle.inputData;
   } else if (event.name.startsWith('trigger.hook.unsubscribe')) {
     convertedBundle.target_url = bundle.targetUrl;
     convertedBundle.subscription_url = bundle.targetUrl;
     convertedBundle.subscribe_data = bundle.subscribeData;
     convertedBundle.event = bundle._legacyEvent;
+    convertedBundle.trigger_data = bundle.inputData;
   }
 };
 

--- a/packages/legacy-scripting-runner/test/bundle.js
+++ b/packages/legacy-scripting-runner/test/bundle.js
@@ -280,6 +280,9 @@ describe('bundleConverter', () => {
       trigger_fields: {
         user: 'Zapier',
       },
+      trigger_data: {
+        user: 'Zapier',
+      },
       trigger_fields_raw: {
         user: 'Zapier',
       },
@@ -334,6 +337,9 @@ describe('bundleConverter', () => {
       url_raw: 'https://zapier.com',
       raw_url: 'https://zapier.com',
       trigger_fields: {
+        user: 'Zapier',
+      },
+      trigger_data: {
         user: 'Zapier',
       },
       trigger_fields_raw: {
@@ -395,6 +401,9 @@ describe('bundleConverter', () => {
       url_raw: 'https://zapier.com',
       raw_url: 'https://zapier.com',
       trigger_fields: {
+        user: 'Zapier',
+      },
+      trigger_data: {
         user: 'Zapier',
       },
       trigger_fields_raw: {

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -411,6 +411,7 @@ const legacyScriptingSource = `
         data.bundleTargetUrl = bundle.target_url;
         data.bundleEvent = bundle.event;
         data.bundleZap = bundle.zap;
+        data.bundleTriggerData = bundle.trigger_data;
 
         // Old alias for bundle.target_url
         data.bundleSubscriptionUrl = bundle.subscription_url;
@@ -423,6 +424,7 @@ const legacyScriptingSource = `
         // This will go to bundle.subscribe_data in pre_unsubscribe
         var data = z.JSON.parse(bundle.response.content);
         data.hiddenMessage = 'post_subscribe was here!';
+        data.bundleTriggerData2 = bundle.trigger_data;
         return data;
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1711,6 +1711,7 @@ describe('Integration Test', () => {
       input.bundle.inputData = { foo: 'bar' };
       input.bundle.targetUrl = 'https://foo.bar';
       input.bundle.meta = { zap: { id: 9511 } };
+
       return app(input).then((output) => {
         should.equal(output.results.json.event, 'contact.created');
         should.equal(
@@ -1720,6 +1721,12 @@ describe('Integration Test', () => {
         should.equal(output.results.headers['X-Api-Key'], 'hey hey');
         should.equal(output.results.hiddenMessage, 'post_subscribe was here!');
 
+        should.deepEqual(output.results.json.bundleTriggerData, {
+          foo: 'bar',
+        });
+        should.deepEqual(output.results.bundleTriggerData2, {
+          foo: 'bar',
+        });
         should.deepEqual(output.results.json.bundleAuthFields, {
           api_key: 'hey hey',
         });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In `pre_subscribe` and `post_subscribe`, `bundle.trigger_data` should contain the same values as `bundle.trigger_fields` does. `bundle.trigger_data` is considered deprecated but there are app still using it.