### PR TITLE
PDE-2087: fix(legacy-scripting-runner): fix file field inconsistency

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.7.12 (unreleased)
 
 - :bug: Add `bundle.trigger_data` to `pre_subscribe` and `post_subscribe` ([#342](https://github.com/zapier/zapier-platform/pull/342))
+- :bug: Fix inconsistency with optional file fields ([#344](https://github.com/zapier/zapier-platform/pull/344))
 
 ## 3.7.11
 

--- a/packages/legacy-scripting-runner/file.js
+++ b/packages/legacy-scripting-runner/file.js
@@ -28,6 +28,18 @@ const isFileField = (fieldKey, bundle) => {
   return bundle._fileFieldKeys.indexOf(fieldKey) >= 0;
 };
 
+const isAnyFileFieldSet = (bundle) => {
+  const body = _.get(bundle, 'request.body');
+  if (body && bundle._fileFieldKeys) {
+    for (const k of bundle._fileFieldKeys) {
+      if (body[k]) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
 const isUrl = (str) => {
   try {
     const parsed = new urllib.URL(str);
@@ -168,5 +180,6 @@ module.exports = {
   markFileFieldsInBundle,
   hasFileFields,
   isFileField,
+  isAnyFileFieldSet,
   LazyFile,
 };

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -823,6 +823,20 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      file_pre_write_optional_file_field: function(bundle) {
+        if (_.isEmpty(bundle.request.files)) {
+          // Reach here when the optional file field is empty
+          bundle.request.headers['Content-Type'] = 'application/json';
+          bundle.request.url = 'https://httpbin.zapier-tooling.com/post';
+          return bundle.request;
+        } else {
+          // Reach here when the optional file field is filled
+          bundle.request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+          bundle.request.data = JSON.parse(bundle.request.data);
+          return bundle.request;
+        }
+      },
+
       /*
        * Search
        */
@@ -1133,6 +1147,7 @@ const FileUpload = {
     inputFields: [
       { key: 'filename', label: 'Filename', type: 'string' },
       { key: 'file', label: 'File', type: 'file' },
+      { key: 'yes', label: 'Yes', type: 'boolean' },
     ],
     outputFields: [{ key: 'id', label: 'ID', type: 'integer' }],
   },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -3192,6 +3192,58 @@ describe('Integration Test', () => {
       });
     });
 
+    it('file upload, KEY_pre_write, optional file field is empty', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'file_pre_write_optional_file_field',
+        'file_pre_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.file.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        filename: 'pig.png',
+      };
+      return app(input).then((output) => {
+        const echoed = output.results;
+        should.equal(echoed.headers['Content-Type'], 'application/json');
+        should.deepEqual(echoed.json, { filename: 'pig.png' });
+      });
+    });
+
+    it('file upload, KEY_pre_write, optional file field is filled', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(
+        'file_pre_write_optional_file_field',
+        'file_pre_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.file.operation.perform'
+      );
+      input.bundle.authData = { api_key: 'secret' };
+      input.bundle.inputData = {
+        filename: 'pig.png',
+        file: `${HTTPBIN_URL}/robots.txt`,
+        yes: true,
+      };
+      return app(input).then((output) => {
+        const response = output.results;
+        const file = response.file;
+        should.equal(response.filename, 'pig.png');
+        should.equal(response.yes, 'True');
+        should.equal(file.sha1, '4becbe4770c949a40cb28f9d1c2b4910fbf7e37d');
+      });
+    });
+
     describe('legacyMethodHydrator', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       const compiledApp = schemaTools.prepareApp(appDefWithAuth);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes edge cases with optional file fields.
- When the action has an optional file field and it's empty, we should encode the request body in JSON as if the file field didn't exist (as opposed to doing `multipart/form-data` encoding).
- Only when the file field is set, we encode the request body in `multipart/form-data`.

Also, fixes another bug where boolean values crash `form-data`:

```javascript
  const FormData = require('form-data');

  const form = new FormData();
  form.append('yes', true);

  form.submit('https://httpbin.zapier-tooling.com/post', function (err, res) {
    console.log(res.statusCode);
  });
  // ^^^ would crash with the following error:
  // TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer.
  // Received type boolean (true)
```

So before adding a boolean value to the form data, we should stringify the boolean like how Python does it, i.e., `true` -> `"True"` and `false` -> `"False"`.