### PR TITLE
BREAKING CHANGE (schema) add functional constraint for globally unique input fields

### DIFF
--- a/packages/schema/lib/functional-constraints/index.js
+++ b/packages/schema/lib/functional-constraints/index.js
@@ -17,6 +17,7 @@ const checks = [
   require('./requiredSamples'),
   require('./matchingKeys'),
   require('./labelWhenVisible'),
+  require('./uniqueInputFieldKeys'),
 ];
 
 const runFunctionalConstraints = (definition, mainSchema) => {

--- a/packages/schema/lib/functional-constraints/uniqueInputFieldKeys.js
+++ b/packages/schema/lib/functional-constraints/uniqueInputFieldKeys.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const _ = require('lodash');
+const jsonschema = require('jsonschema');
+
+const actionTypes = ['triggers', 'searches', 'creates'];
+
+const uniqueInputFieldKeys = (definition) => {
+  const errors = [];
+  for (const actionType of actionTypes) {
+    const group = definition[actionType] || {};
+    _.each(group, (action, key) => {
+      const inputFields = _.get(action, ['operation', 'inputFields'], []);
+
+      const existingKeys = {}; // map of key to where it already lives
+
+      inputFields.forEach((inputField, index) => {
+        if (existingKeys[inputField.key]) {
+          errors.push(
+            new jsonschema.ValidationError(
+              `inputField keys must be unique for each action. The key "${
+                inputField.key
+              }" is already in use at ${actionType}.${key}.operation.${
+                existingKeys[inputField.key]
+              }.key`,
+              inputField.key,
+              `/BasicOperationSchema`,
+              `instance.${actionType}.${key}.operation.inputFields[${index}].key`
+            )
+          );
+        } else {
+          existingKeys[inputField.key] = `inputFields[${index}]`;
+        }
+
+        (inputField.children || []).forEach((subField, subFieldIndex) => {
+          if (existingKeys[subField.key]) {
+            errors.push(
+              new jsonschema.ValidationError(
+                `inputField keys must be unique for each action, even if they're children. The key "${
+                  subField.key
+                }" is already in use at ${actionType}.${key}.operation.${
+                  existingKeys[subField.key]
+                }.key`,
+                subField.key,
+                `/BasicOperationSchema`,
+                `instance.${actionType}.${key}.operation.inputFields[${index}].children[${subFieldIndex}].key`
+              )
+            );
+          } else {
+            existingKeys[
+              subField.key
+            ] = `inputFields[${index}].children[${subFieldIndex}]`;
+          }
+        });
+      });
+    });
+  }
+
+  return errors;
+};
+
+module.exports = uniqueInputFieldKeys;


### PR DESCRIPTION
Input fields' `key` must be unique across all fields in a given trigger. Nesting fields under `children` doesn't help here. 