### PR TITLE
BREAKING CHANGE(cli): tweak test command to pass on extra args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
+## 11.0.0
+
+_unreleased_
+
+### Migration Guide
+
+1. Whenever you call `zapier test` with the `timeout` or `grep` flags:
+  * Add `--` before any existing `grep` and `timeout` flags
+  * `zapier test -g 'cool' --timeout 5000` :arrow_right: `zapier test -- -g 'cool' --timeout 5000`
+
 ## 10.2.0
+
+_released `2021-02-23`_
 
 ### cli
 
@@ -17,6 +29,8 @@ None!
 * :nail_care: Add ability to specify "code" param to OAuth2 schema ([#333](https://github.com/zapier/zapier-platform/pull/333))
 
 ## 10.1.3
+
+_released `2021-02-09`_
 
 ### cli
 
@@ -41,6 +55,8 @@ None!
 
 ## 10.1.2
 
+_released `2020-10-30`_
+
 This release mostly has internal features, but also ships a lot of documentation updates and a few bumped dependencies.
 
 ### cli
@@ -63,6 +79,8 @@ None!
 
 ## 10.1.1
 
+_released `2020-09-02`_
+
 ### cli
 
 * :bug: `_zapier-build` should be optional ([#265](https://github.com/zapier/zapier-platform/pull/265))
@@ -76,6 +94,8 @@ None!
 None!
 
 ## 10.1.0
+
+_released `2020-08-30`_
 
 ### cli
 
@@ -91,6 +111,8 @@ None!
 * None!
 
 ## 10.0.1
+
+_released `2020-07-20`_
 
 ### cli
 
@@ -113,6 +135,8 @@ None!
 * :hammer: Bump Lodash from 4.17.15 to 4.17.19 ([#248](https://github.com/zapier/zapier-platform/pull/248))
 
 ## 10.0.0
+
+_released `2020-05-20`_
 
 Another major release! We have some great improvements in this version but also have breaking changes. Please review the following to see if you need to change anything to upgrade `zapier-platform-core` to v10.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ _unreleased_
 ### Migration Guide
 
 1. Whenever you call `zapier test` with the `timeout` or `grep` flags:
-  * Add `--` before any existing `grep` and `timeout` flags
-  * `zapier test -g 'cool' --timeout 5000` :arrow_right: `zapier test -- -g 'cool' --timeout 5000`
+    * Add `--` before any existing `grep` and `timeout` flags
+    * `zapier test -g 'cool' --timeout 5000` :arrow_right: `zapier test -- -g 'cool' --timeout 5000`
 
 ## 10.2.0
 

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -1010,16 +1010,15 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Test your integration via <code>npm test</code>.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is effectively the same as <code>npm test</code>, except we also validate your integration and set up the environment. We recommend using mocha as your testing framework.</p><p><strong>Flags</strong></p><ul>
-<li><code>-t, --timeout</code> | Set test-case timeout in milliseconds.  Defaults to <code>2000</code>.</li>
-<li><code>--grep</code> | Only run tests matching pattern.</li>
-<li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before <code>npm test</code>.</li>
-<li><code>--yarn</code> | Use yarn instead of npm.</li>
+<p>Test your integration via the &quot;test&quot; script in your &quot;package.json&quot;.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is a wrapper around <code>npm test</code> that also validates the structure of your integration and sets up extra environment variables.</p><p>You can pass any args/flags after a <code>--</code>; they will get forwarded onto your test script.</p><p><strong>Flags</strong></p><ul>
+<li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before tests are run. This will speed up tests if you&apos;re modifying functionality of an existing integration rather than adding new actions.</li>
+<li><code>--yarn</code> | Use <code>yarn</code> instead of <code>npm</code>. This happens automatically if there&apos;s a <code>yarn.lock</code> file, but you can manually force <code>yarn</code> if you run tests from a sub-directory.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier test</code></li>
-<li><code>zapier test -t 30000 --grep api --skip-validate</code></li>
+<li><code>zapier test --skip-validate</code></li>
+<li><code>zapier test -- --f --testNamePattern &quot;auth pass&quot;</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -1017,8 +1017,8 @@ a code {
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier test</code></li>
-<li><code>zapier test --skip-validate</code></li>
-<li><code>zapier test -- --f --testNamePattern &quot;auth pass&quot;</code></li>
+<li><code>zapier test --skip-validate -- -t 30000 --grep api</code></li>
+<li><code>zapier test -- -fo --testNamePattern &quot;auth pass&quot;</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -530,8 +530,8 @@ You can pass any args/flags after a `--`; they will get forwarded onto your test
 
 **Examples**
 * `zapier test`
-* `zapier test --skip-validate`
-* `zapier test -- --f --testNamePattern "auth pass"`
+* `zapier test --skip-validate -- -t 30000 --grep api`
+* `zapier test -- -fo --testNamePattern "auth pass"`
 
 
 ## upload

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -515,22 +515,23 @@ Admins will immediately lose write access to the integration. Subscribers won't 
 
 ## test
 
-> Test your integration via `npm test`.
+> Test your integration via the "test" script in your "package.json".
 
 **Usage**: `zapier test`
 
-This command is effectively the same as `npm test`, except we also validate your integration and set up the environment. We recommend using mocha as your testing framework.
+This command is a wrapper around `npm test` that also validates the structure of your integration and sets up extra environment variables.
+
+You can pass any args/flags after a `--`; they will get forwarded onto your test script.
 
 **Flags**
-* `-t, --timeout` | Set test-case timeout in milliseconds.  Defaults to `2000`.
-* `--grep` | Only run tests matching pattern.
-* `--skip-validate` | Forgo running `zapier validate` before `npm test`.
-* `--yarn` | Use yarn instead of npm.
+* `--skip-validate` | Forgo running `zapier validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.
+* `--yarn` | Use `yarn` instead of `npm`. This happens automatically if there's a `yarn.lock` file, but you can manually force `yarn` if you run tests from a sub-directory.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**
 * `zapier test`
-* `zapier test -t 30000 --grep api --skip-validate`
+* `zapier test --skip-validate`
+* `zapier test -- --f --testNamePattern "auth pass"`
 
 
 ## upload

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -1010,16 +1010,15 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Test your integration via <code>npm test</code>.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is effectively the same as <code>npm test</code>, except we also validate your integration and set up the environment. We recommend using mocha as your testing framework.</p><p><strong>Flags</strong></p><ul>
-<li><code>-t, --timeout</code> | Set test-case timeout in milliseconds.  Defaults to <code>2000</code>.</li>
-<li><code>--grep</code> | Only run tests matching pattern.</li>
-<li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before <code>npm test</code>.</li>
-<li><code>--yarn</code> | Use yarn instead of npm.</li>
+<p>Test your integration via the &quot;test&quot; script in your &quot;package.json&quot;.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is a wrapper around <code>npm test</code> that also validates the structure of your integration and sets up extra environment variables.</p><p>You can pass any args/flags after a <code>--</code>; they will get forwarded onto your test script.</p><p><strong>Flags</strong></p><ul>
+<li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before tests are run. This will speed up tests if you&apos;re modifying functionality of an existing integration rather than adding new actions.</li>
+<li><code>--yarn</code> | Use <code>yarn</code> instead of <code>npm</code>. This happens automatically if there&apos;s a <code>yarn.lock</code> file, but you can manually force <code>yarn</code> if you run tests from a sub-directory.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier test</code></li>
-<li><code>zapier test -t 30000 --grep api --skip-validate</code></li>
+<li><code>zapier test --skip-validate</code></li>
+<li><code>zapier test -- --f --testNamePattern &quot;auth pass&quot;</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -1017,8 +1017,8 @@ a code {
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier test</code></li>
-<li><code>zapier test --skip-validate</code></li>
-<li><code>zapier test -- --f --testNamePattern &quot;auth pass&quot;</code></li>
+<li><code>zapier test --skip-validate -- -t 30000 --grep api</code></li>
+<li><code>zapier test -- -fo --testNamePattern &quot;auth pass&quot;</code></li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -530,8 +530,8 @@ You can pass any args/flags after a `--`; they will get forwarded onto your test
 
 **Examples**
 * `zapier test`
-* `zapier test --skip-validate`
-* `zapier test -- --f --testNamePattern "auth pass"`
+* `zapier test --skip-validate -- -t 30000 --grep api`
+* `zapier test -- -fo --testNamePattern "auth pass"`
 
 
 ## upload

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -515,22 +515,23 @@ Admins will immediately lose write access to the integration. Subscribers won't 
 
 ## test
 
-> Test your integration via `npm test`.
+> Test your integration via the "test" script in your "package.json".
 
 **Usage**: `zapier test`
 
-This command is effectively the same as `npm test`, except we also validate your integration and set up the environment. We recommend using mocha as your testing framework.
+This command is a wrapper around `npm test` that also validates the structure of your integration and sets up extra environment variables.
+
+You can pass any args/flags after a `--`; they will get forwarded onto your test script.
 
 **Flags**
-* `-t, --timeout` | Set test-case timeout in milliseconds.  Defaults to `2000`.
-* `--grep` | Only run tests matching pattern.
-* `--skip-validate` | Forgo running `zapier validate` before `npm test`.
-* `--yarn` | Use yarn instead of npm.
+* `--skip-validate` | Forgo running `zapier validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.
+* `--yarn` | Use `yarn` instead of `npm`. This happens automatically if there's a `yarn.lock` file, but you can manually force `yarn` if you run tests from a sub-directory.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**
 * `zapier test`
-* `zapier test -t 30000 --grep api --skip-validate`
+* `zapier test --skip-validate`
+* `zapier test -- --f --testNamePattern "auth pass"`
 
 
 ## upload

--- a/packages/cli/src/oclif/commands/test.js
+++ b/packages/cli/src/oclif/commands/test.js
@@ -87,8 +87,8 @@ TestCommand.flags = buildFlags({
 TestCommand.strict = false;
 TestCommand.examples = [
   'zapier test',
-  'zapier test --skip-validate',
-  'zapier test -- --f --testNamePattern "auth pass"',
+  'zapier test --skip-validate -- -t 30000 --grep api',
+  'zapier test -- -fo --testNamePattern "auth pass"',
 ];
 TestCommand.description = `Test your integration via the "test" script in your "package.json".
 


### PR DESCRIPTION
Sort of addresses https://github.com/zapier/zapier-platform/issues/338- 

Rather than hard-code some test-runner-specific flags, we can just let users pass data through to whatever's in their `test` script.

Notes to include in eventual changelog to help migration and describe the breaking changes:

* In the command `zapier test -g asdf`, the `-g` flag will no longer get passed onto the test runner. It needs to be `zapier test -- -g asdf` instead
* Previously, we were passing a `timeout` value of `2000` (if you hadn't been specifying `-t|--timeout` explicitly in `zapier test`) to your test runner. If you want that behavior to continue, you need to add that flag manually after a `--`. Only relevant if you use `mocha` (`jest` has a different flag name). 

[PDE-2109](https://zapierorg.atlassian.net/browse/PDE-2109)