### PR TITLE
BREAKING CHANGE(core) run apps using node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "12"
+  - "14"
 cache:
   - npm: true
   - yarn: true
@@ -19,34 +19,34 @@ jobs:
     - stage: "Test"
       name: "lint"
       script: "yarn lint"
-      node_js: "12"
-    - name: "cli - unit tests - Node 10"
-      script: "yarn workspace zapier-platform-cli test"
-      node_js: "10"
-    - name: "cli - smoke tests - Node 10"
-      script: "yarn workspace zapier-platform-cli smoke-test"
-      node_js: "10"
+      node_js: "14"
     - name: "cli - unit tests - Node 12"
       script: "yarn workspace zapier-platform-cli test"
       node_js: "12"
     - name: "cli - smoke tests - Node 12"
       script: "yarn workspace zapier-platform-cli smoke-test"
       node_js: "12"
-    - name: "core - unit tests - Node 12"
+    - name: "cli - unit tests - Node 14"
+      script: "yarn workspace zapier-platform-cli test"
+      node_js: "14"
+    - name: "cli - smoke tests - Node 14"
+      script: "yarn workspace zapier-platform-cli smoke-test"
+      node_js: "14"
+    - name: "core - unit tests - Node 14"
       script: "yarn workspace zapier-platform-core test"
-      node_js: "12"
-    - name: "core - smoke tests - Node 12"
+      node_js: "14"
+    - name: "core - smoke tests - Node 14"
       script: "yarn workspace zapier-platform-core smoke-test"
-      node_js: "12"
-    - name: "schema - unit tests - Node 12"
+      node_js: "14"
+    - name: "schema - unit tests - Node 14"
       script: "yarn workspace zapier-platform-schema test"
-      node_js: "12"
-    - name: "schema - smoke tests - Node 12"
+      node_js: "14"
+    - name: "schema - smoke tests - Node 14"
       script: "yarn workspace zapier-platform-schema smoke-test"
-      node_js: "12"
-    - name: "legacy-scripting-runner - integration tests - Node 12"
+      node_js: "14"
+    - name: "legacy-scripting-runner - integration tests - Node 14"
       script: "yarn workspace zapier-platform-legacy-scripting-runner test"
-      node_js: "12"
+      node_js: "14"
     - stage: "Deploy"
       script: skip
       deploy:
@@ -54,7 +54,7 @@ jobs:
         script: ./scripts/publish.sh
         on:
           tags: true,
-          node: "12"
+          node: "14"
         skip_cleanup: true
 notifications:
   email: false

--- a/boilerplate/scripts/build.sh
+++ b/boilerplate/scripts/build.sh
@@ -113,8 +113,8 @@ update_deps "$BOILERPLATE_DIR/package.json" $CORE_VERSION $LEGACY_VERSION
 pushd $BOILERPLATE_DIR > /dev/null
 
 # Build the zip!
-# the node-X segment in the next line should match all supported node versions
-zip -R $TARGET_FILE '*.js' '*.json' '*/linux-x64-node-12/*.node' '*/linux-x64-node-14/*.node'
+# the node-X segment in the next line should match all node versions where a boilerplate built with this script might run on
+zip -R $TARGET_FILE '*.js' '*.json' '*/linux-x64-node-10/*.node' '*/linux-x64-node-12/*.node' '*/linux-x64-node-14/*.node'
 
 # Remove generated files
 rm -f zapierwrapper.js definition.json core-*.tgz legacy-*.tgz

--- a/boilerplate/scripts/build.sh
+++ b/boilerplate/scripts/build.sh
@@ -113,8 +113,8 @@ update_deps "$BOILERPLATE_DIR/package.json" $CORE_VERSION $LEGACY_VERSION
 pushd $BOILERPLATE_DIR > /dev/null
 
 # Build the zip!
-# the node-X segment in the next line should match the latest major version
-zip -R $TARGET_FILE '*.js' '*.json' '*/linux-x64-node-10/*.node' '*/linux-x64-node-12/*.node'
+# the node-X segment in the next line should match all supported node versions
+zip -R $TARGET_FILE '*.js' '*.json' '*/linux-x64-node-12/*.node' '*/linux-x64-node-14/*.node'
 
 # Remove generated files
 rm -f zapierwrapper.js definition.json core-*.tgz legacy-*.tgz

--- a/docs/index.html
+++ b/docs/index.html
@@ -696,7 +696,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>All Zapier CLI apps are run using Node.js <code>v12</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v12</code>. If you&apos;re using features not yet available in <code>v12</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v12</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/minimal/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v12</code>, or do <code>nvm exec v12 zapier test</code> so you can run tests without having to switch versions while developing.</p>
+      <p>All Zapier CLI apps are run using Node.js <code>v14</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v14</code>. If you&apos;re using features not yet available in <code>v14</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v14</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/minimal/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v14</code>, or do <code>nvm exec v14 zapier test</code> so you can run tests without having to switch versions while developing.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -4543,7 +4543,7 @@ zapier <span class="hljs-built_in">test</span>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-yaml"><span class="hljs-attr">language:</span> <span class="hljs-string">node_js</span>
 <span class="hljs-attr">node_js:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v12&quot;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v14&quot;</span>
 <span class="hljs-attr">before_script:</span> <span class="hljs-string">npm</span> <span class="hljs-string">install</span> <span class="hljs-string">-g</span> <span class="hljs-string">zapier-platform-cli</span>
 <span class="hljs-attr">script:</span> <span class="hljs-string">CLIENT_ID=1234</span> <span class="hljs-string">CLIENT_SECRET=abcd</span> <span class="hljs-string">zapier</span> <span class="hljs-string">test</span>
 </code></pre>
@@ -4836,7 +4836,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html">versions</a> of Node (the latest of which is <code>v12</code>. As that updates, so too will we.</p>
+      <p>We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html">versions</a> of Node (the latest of which is <code>v14</code>. As that updates, so too will we.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -5217,7 +5217,7 @@ zapier push
       <p>... then you need to update your <code>zapier-platform-core</code> dependency to a non-deprecated version that uses a newer version of Node.js. Complete the following instructions as soon as possible:</p><ol>
 <li>Edit <code>package.json</code> to depend on a later major version of <code>zapier-platform-core</code>. There&apos;s a list of all breaking changes (marked with a :exclamation:) in the <a href="https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md">changelog</a>.</li>
 <li>Increment the <code>version</code> property in <code>package.json</code></li>
-<li>Ensure you&apos;re using version <code>v12</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
+<li>Ensure you&apos;re using version <code>v14</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
 <li>Run <code>rm -rf node_modules &amp;&amp; npm i</code> to get a fresh copy of everything</li>
 <li>Run <code>zapier test</code> to ensure your tests still pass</li>
 <li>Run <code>zapier push</code></li>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -184,15 +184,15 @@ Zapier Platform CLI is designed to be used by development teams who collaborate 
 
 ### Requirements
 
-All Zapier CLI apps are run using Node.js `v12`.
+All Zapier CLI apps are run using Node.js `v14`.
 
-You can develop using any version of Node you'd like, but your eventual code must be compatible with `v12`. If you're using features not yet available in `v12`, you can transpile your code to a compatible format with [Babel](https://babeljs.io/) (or similar).
+You can develop using any version of Node you'd like, but your eventual code must be compatible with `v14`. If you're using features not yet available in `v14`, you can transpile your code to a compatible format with [Babel](https://babeljs.io/) (or similar).
 
-To ensure stability for our users, we strongly encourage you run tests on `v12` sometime before your code reaches users. This can be done multiple ways.
+To ensure stability for our users, we strongly encourage you run tests on `v14` sometime before your code reaches users. This can be done multiple ways.
 
 Firstly, by using a CI tool (like [Travis CI](https://travis-ci.org/) or [Circle CI](https://circleci.com/), which are free for open source projects). We provide a sample [.travis.yml](https://github.com/zapier/zapier-platform/blob/master/example-apps/minimal/.travis.yml) file in our template apps to get you started.
 
-Alternatively, you can change your local node version with tools such as [nvm](https://github.com/nvm-sh/nvm#installation-and-update). Then you can either swap to that version with `nvm use v12`, or do `nvm exec v12 zapier test` so you can run tests without having to switch versions while developing.
+Alternatively, you can change your local node version with tools such as [nvm](https://github.com/nvm-sh/nvm#installation-and-update). Then you can either swap to that version with `nvm use v14`, or do `nvm exec v14 zapier test` so you can run tests without having to switch versions while developing.
 
 
 ### Quick Setup Guide
@@ -2763,7 +2763,7 @@ This makes it pretty straightforward to integrate into your testing interface. I
 ```yaml
 language: node_js
 node_js:
-  - "v12"
+  - "v14"
 before_script: npm install -g zapier-platform-cli
 script: CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
 ```
@@ -2952,7 +2952,7 @@ There are a lot of details left out - check out the full example app for a worki
 
 ### Why doesn't Zapier support newer versions of Node.js?
 
-We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) of Node (the latest of which is `v12`. As that updates, so too will we.
+We run your code on AWS Lambda, which only supports a few [versions](https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html) of Node (the latest of which is `v14`. As that updates, so too will we.
 
 ### How do I manually set the Node.js version to run my app with?
 
@@ -3235,7 +3235,7 @@ InvalidParameterValueException An error occurred (InvalidParameterValueException
 
 1. Edit `package.json` to depend on a later major version of `zapier-platform-core`. There's a list of all breaking changes (marked with a :exclamation:) in the [changelog](https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md).
 2. Increment the `version` property in `package.json`
-3. Ensure you're using version `v12` (or greater) of node locally (`node -v`). Use [nvm](https://github.com/nvm-sh/nvm) to use a different one if need be.
+3. Ensure you're using version `v14` (or greater) of node locally (`node -v`). Use [nvm](https://github.com/nvm-sh/nvm) to use a different one if need be.
 4. Run `rm -rf node_modules && npm i` to get a fresh copy of everything
 5. Run `zapier test` to ensure your tests still pass
 6. Run `zapier push`

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -696,7 +696,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>All Zapier CLI apps are run using Node.js <code>v12</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v12</code>. If you&apos;re using features not yet available in <code>v12</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v12</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/minimal/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v12</code>, or do <code>nvm exec v12 zapier test</code> so you can run tests without having to switch versions while developing.</p>
+      <p>All Zapier CLI apps are run using Node.js <code>v14</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v14</code>. If you&apos;re using features not yet available in <code>v14</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v14</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/master/example-apps/minimal/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v14</code>, or do <code>nvm exec v14 zapier test</code> so you can run tests without having to switch versions while developing.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -4543,7 +4543,7 @@ zapier <span class="hljs-built_in">test</span>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-yaml"><span class="hljs-attr">language:</span> <span class="hljs-string">node_js</span>
 <span class="hljs-attr">node_js:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v12&quot;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v14&quot;</span>
 <span class="hljs-attr">before_script:</span> <span class="hljs-string">npm</span> <span class="hljs-string">install</span> <span class="hljs-string">-g</span> <span class="hljs-string">zapier-platform-cli</span>
 <span class="hljs-attr">script:</span> <span class="hljs-string">CLIENT_ID=1234</span> <span class="hljs-string">CLIENT_SECRET=abcd</span> <span class="hljs-string">zapier</span> <span class="hljs-string">test</span>
 </code></pre>
@@ -4836,7 +4836,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html">versions</a> of Node (the latest of which is <code>v12</code>. As that updates, so too will we.</p>
+      <p>We run your code on AWS Lambda, which only supports a few <a href="https://docs.aws.amazon.com/lambda/latest/dg/programming-model.html">versions</a> of Node (the latest of which is <code>v14</code>. As that updates, so too will we.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -5217,7 +5217,7 @@ zapier push
       <p>... then you need to update your <code>zapier-platform-core</code> dependency to a non-deprecated version that uses a newer version of Node.js. Complete the following instructions as soon as possible:</p><ol>
 <li>Edit <code>package.json</code> to depend on a later major version of <code>zapier-platform-core</code>. There&apos;s a list of all breaking changes (marked with a :exclamation:) in the <a href="https://github.com/zapier/zapier-platform/blob/master/CHANGELOG.md">changelog</a>.</li>
 <li>Increment the <code>version</code> property in <code>package.json</code></li>
-<li>Ensure you&apos;re using version <code>v12</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
+<li>Ensure you&apos;re using version <code>v14</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
 <li>Run <code>rm -rf node_modules &amp;&amp; npm i</code> to get a fresh copy of everything</li>
 <li>Run <code>zapier test</code> to ensure your tests still pass</li>
 <li>Run <code>zapier push</code></li>

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -26,7 +26,7 @@ const BLACKLISTED_PATHS = [
 ];
 const NODE_VERSION = versionStore[versionStore.length - 1].nodeVersion;
 const LAMBDA_VERSION = `v${NODE_VERSION}`;
-const NODE_VERSION_CLI_REQUIRES = '>=10';
+const NODE_VERSION_CLI_REQUIRES = '>=12'; // should be the oldest non-ETL version
 const AUTH_KEY = 'deployKey';
 const ANALYTICS_KEY = 'analyticsMode';
 const ANALYTICS_MODES = {

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -159,7 +159,7 @@ const forceIncludeDumbPath = (appConfig, filePath) => {
   return (
     filePath.endsWith('package.json') ||
     filePath.endsWith('definition.json') ||
-    filePath.endsWith(path.join('bin', 'linux-x64-node-10', 'deasync.node')) ||
+    filePath.endsWith(path.join('bin', 'linux-x64-node-12', 'deasync.node')) ||
     filePath.endsWith(
       // Special, for zapier-platform-legacy-scripting-runner
       path.join('bin', `linux-x64-node-${nodeMajorVersion}`, 'deasync.node')

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -159,6 +159,8 @@ const forceIncludeDumbPath = (appConfig, filePath) => {
   return (
     filePath.endsWith('package.json') ||
     filePath.endsWith('definition.json') ||
+    // include old async deasync versions so this runs seamlessly across node versions
+    filePath.endsWith(path.join('bin', 'linux-x64-node-10', 'deasync.node')) ||
     filePath.endsWith(path.join('bin', 'linux-x64-node-12', 'deasync.node')) ||
     filePath.endsWith(
       // Special, for zapier-platform-legacy-scripting-runner

--- a/packages/cli/src/version-store.js
+++ b/packages/cli/src/version-store.js
@@ -13,4 +13,5 @@ module.exports = [
   { nodeVersion: '8.10.0', npmVersion: '>=5.6.0' }, // 8.x
   { nodeVersion: '10', npmVersion: '>=5.6.0' }, // 9.x; it's no longer a specific version
   { nodeVersion: '12', npmVersion: '>=5.6.0' }, // 10.x
+  { nodeVersion: '14', npmVersion: '>=5.6.0' }, // 11.x
 ];


### PR DESCRIPTION
I figured I'd do a dep update in a separate PR. 

Also, I _think_ we can take advantage of the travis [build matrix](https://docs.travis-ci.com/user/build-matrix/) feature to more cleanly declare our tests. On each of 12 and 14, run each of `test` and `smoke test`. I know you mentioned travis being slow;  i'm not sure this will help a lot, but it'll at least clean up that file.