### PR TITLE
fix(core): inputData for hydration function should be of type T as well (PDE-2198)

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -117,7 +117,7 @@ export interface RawHttpResponse extends BaseHttpResponse {
 
 type DehydrateFunc = <T>(
   func: (z: ZObject, bundle: Bundle<T>) => any,
-  inputData: object
+  inputData: T
 ) => string;
 
 export interface ZObject {


### PR DESCRIPTION
this might be a breaking change, depending on what objects developers have passed to `dehydrate` methods - wrong calls (with extra fields in `inputData`) will be marked so one can consider it a fix rather than a breaking change.

if extra `inputFields` fields should be tolerated a union with generic index type (i.e. `T & { [extra: string]: any }`) will describe the `inputData` more loosely.