### PR TITLE
PDE-2205: build(core): typescript target es2019 for node 12

### DIFF
--- a/example-apps/typescript/tsconfig.json
+++ b/example-apps/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": ["esnext"],

--- a/packages/cli/src/generators/templates/typescript/tsconfig.json
+++ b/packages/cli/src/generators/templates/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "lib": ["esnext"],


### PR DESCRIPTION
as per https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping

node 12 is es2019 compatible