### PR TITLE
PDE-2199: fix(legacy-scripting-runner): inputData should take precedence over authData when auth fields are not saved yet

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.7.13
 
-- :bug: `inputData` should take precedence over `authData` for `authorizeUrl` ([#359](https://github.com/zapier/zapier-platform/pull/359))
+- :bug: `inputData` should take precedence over `authData` when auth fields are not saved yet ([#359](https://github.com/zapier/zapier-platform/pull/359))
 
 ## 3.7.12
 

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.13
+
+- :bug: `inputData` should take precedence over `authData` for `authorizeUrl` ([#359](https://github.com/zapier/zapier-platform/pull/359))
+
 ## 3.7.12
 
 - :bug: Add `bundle.trigger_data` to `pre_subscribe` and `post_subscribe` ([#342](https://github.com/zapier/zapier-platform/pull/342))

--- a/packages/legacy-scripting-runner/bundle.js
+++ b/packages/legacy-scripting-runner/bundle.js
@@ -98,6 +98,14 @@ const addInputData = (event, bundle, convertedBundle) => {
     }
   } else if (event.name === 'hydrate.method') {
     Object.assign(convertedBundle, bundle.inputData.bundle);
+  } else if (event.name.startsWith('auth.oauth2.token')) {
+    // Overwrite convertedBundle.auth_fields with bundle.inputData
+    convertedBundle.auth_fields = Object.keys(
+      convertedBundle.auth_fields
+    ).reduce((result, k) => {
+      result[k] = bundle.inputData[k] || convertedBundle.auth_fields[k];
+      return result;
+    }, {});
   }
 };
 

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -815,7 +815,10 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth1GetAccessToken = (bundle) => {
-    const url = _.get(app, 'legacy.authentication.oauth1Config.accessTokenUrl');
+    let url = _.get(app, 'legacy.authentication.oauth1Config.accessTokenUrl');
+    if (url) {
+      url = replaceCurliesInRequest({ url }, bundle, bundle.inputData).url;
+    }
 
     const templateContext = { ...bundle.authData, ...bundle.inputData };
     const consumerKey = renderTemplate(process.env.CLIENT_ID, templateContext);
@@ -860,7 +863,10 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
   };
 
   const runOAuth2GetAccessToken = async (bundle) => {
-    const url = _.get(app, 'legacy.authentication.oauth2Config.accessTokenUrl');
+    let url = _.get(app, 'legacy.authentication.oauth2Config.accessTokenUrl');
+    if (url) {
+      url = replaceCurliesInRequest({ url }, bundle, bundle.inputData).url;
+    }
 
     const request = bundle.request;
     request.method = 'POST';

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -248,7 +248,7 @@ const serializeValueForCurlies = (value) => {
   return value;
 };
 
-const createCurliesBank = (bundle) => {
+const createCurliesBank = (bundle, extra) => {
   const bank = {
     // This is for new curlies syntax, such as '{{bundle.inputData.var}}' and
     // '{{bundle.authData.var}}'
@@ -259,6 +259,7 @@ const createCurliesBank = (bundle) => {
     ...bundle.inputData,
     ...bundle.subscribeData,
     ...bundle.authData,
+    ...extra,
   };
   const flattenedBank = flattenPaths(bank, {
     perseve: {
@@ -271,8 +272,8 @@ const createCurliesBank = (bundle) => {
   }, {});
 };
 
-const replaceCurliesInRequest = (request, bundle) => {
-  const bank = createCurliesBank(bundle);
+const replaceCurliesInRequest = (request, bundle, extra) => {
+  const bank = createCurliesBank(bundle, extra);
   return recurseReplaceBank(request, bank);
 };
 
@@ -803,7 +804,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       return '';
     }
 
-    url = replaceCurliesInRequest({ url }, bundle).url;
+    url = replaceCurliesInRequest({ url }, bundle, bundle.inputData).url;
     const urlObj = new URL(url);
 
     if (!urlObj.searchParams.has('oauth_token')) {
@@ -838,7 +839,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       return '';
     }
 
-    url = replaceCurliesInRequest({ url }, bundle).url;
+    url = replaceCurliesInRequest({ url }, bundle, bundle.inputData).url;
     const urlObj = new URL(url);
 
     if (!urlObj.searchParams.has('client_id')) {

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.12",
+  "version": "3.7.13",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -192,6 +192,41 @@ describe('Integration Test', () => {
       });
     });
 
+    it('oauth2 authorizeUrl, curly replacement', () => {
+      const appDefWithAuth = withAuth(appDefinition, oauth2Config);
+      appDefWithAuth.legacy.authentication.oauth2Config.authorizeUrl =
+        '{{base_url}}/authorize';
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'authentication.oauth2Config.authorizeUrl'
+      );
+
+      // inputData should take precedence over authData for authorizeUrl, but
+      // it's the other way around for other calls. This is because on CLI
+      // authData always holds the *saved* auth fields, and when generating
+      // authorizeUrl, auth fields are not saved yet.
+      input.bundle.authData = {
+        base_url: 'https://from.auth.data',
+      };
+      input.bundle.inputData = {
+        base_url: 'https://from.input.data',
+        redirect_uri: 'https://example.com',
+        state: 'qwerty',
+      };
+      return app(input).then((output) => {
+        should.equal(
+          output.results,
+          'https://from.input.data/authorize?' +
+            'client_id=1234&' +
+            'redirect_uri=https%3A%2F%2Fexample.com&' +
+            'response_type=code&state=qwerty'
+        );
+      });
+    });
+
     it('pre_oauthv2_token', () => {
       const appDefWithAuth = withAuth(appDefinition, oauth2Config);
       appDefWithAuth.legacy.scriptingSource = appDefWithAuth.legacy.scriptingSource.replace(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In the CLI world, `bundle.authData` always holds the auth fields that are already saved to the Zapier database. When rendering `authorizeUrl`, auth fields aren't saved yet, which means `bundle.authData` either is empty or holds auth fields with default values.

These occasions:

- rendering `authorizeUrl`
- rendering access token URL when performing `getAccessToken`
- generating `bundle.auth_fields` for `pre_oauthv2_token` and `post_oauthv2_token`

... all happen before the auth fields are saved. So we need to make sure values in `bundle.inputData` take precedence over `bundle.authData`. For example, for an `authorizeUrl` with a value of `https://{{domain}}/example`, we should replace `{{domain}}` with `bundle.inputData.domain` instead of `bundle.authData.domain`.

