### PR TITLE
SUPPORTESC-148 fix(core): stashFile no longer throws 'source.on' error when a request that uses await is passed in

### DIFF
--- a/packages/core/src/tools/create-file-stasher.js
+++ b/packages/core/src/tools/create-file-stasher.js
@@ -106,7 +106,7 @@ const createFileStasher = (input) => {
     return rpc('get_presigned_upload_post_data', fileContentType).then(
       (result) => {
         const parseFinalResponse = (stream) => {
-          var newBufferStringStream = stream;
+          let newBufferStringStream = stream;
 
           // if stream is string, don't update headers, just return as is
           if (_.isString(stream)) {

--- a/packages/core/src/tools/create-file-stasher.js
+++ b/packages/core/src/tools/create-file-stasher.js
@@ -105,70 +105,69 @@ const createFileStasher = (input) => {
 
     return rpc('get_presigned_upload_post_data', fileContentType).then(
       (result) => {
-        if (isPromise(bufferStringStream)) {
-          return bufferStringStream.then((maybeResponse) => {
-            const isStreamed = _.get(maybeResponse, 'request.raw', false);
+        const parseFinalResponse = (stream) => {
+          var newBufferStringStream = stream;
 
-            const parseFinalResponse = (response) => {
-              let newBufferStringStream = response;
-              if (_.isString(response)) {
-                newBufferStringStream = response;
-              } else if (response) {
-                if (Buffer.isBuffer(response)) {
-                  newBufferStringStream = response;
-                } else if (Buffer.isBuffer(response.dataBuffer)) {
-                  newBufferStringStream = response.dataBuffer;
-                } else if (
-                  response.body &&
-                  typeof response.body.pipe === 'function'
-                ) {
-                  newBufferStringStream = response.body;
-                } else {
-                  newBufferStringStream = response.content;
-                }
-
-                if (response.headers) {
-                  knownLength =
-                    knownLength || response.getHeader('content-length');
-                  const cd = response.getHeader('content-disposition');
-                  if (cd) {
-                    filename =
-                      filename ||
-                      contentDisposition.parse(cd).parameters.filename;
-                  }
-                }
-              } else {
-                throw new Error(
-                  'Cannot stash a Promise wrapped file of unknown type.'
-                );
-              }
-
-              return uploader(
-                result,
-                newBufferStringStream,
-                knownLength,
-                filename,
-                fileContentType
-              );
-            };
-
-            if (isStreamed) {
-              return maybeResponse.buffer().then((buffer) => {
-                maybeResponse.dataBuffer = buffer;
-                return parseFinalResponse(maybeResponse);
-              });
-            } else {
-              return parseFinalResponse(maybeResponse);
+          // if stream is string, don't update headers, just return as is
+          if (_.isString(stream)) {
+            newBufferStringStream = stream;
+          } else if (stream) {
+            if (Buffer.isBuffer(stream)) {
+              newBufferStringStream = stream;
+            } else if (Buffer.isBuffer(stream.dataBuffer)) {
+              newBufferStringStream = stream.dataBuffer;
+            } else if (stream.body && typeof stream.body.pipe === 'function') {
+              newBufferStringStream = stream.body;
+            } else if (stream.content) {
+              newBufferStringStream = stream.content;
             }
-          });
-        } else {
+
+            // if stream has headers update knownLength and filename to reflect the header values
+            if (stream.headers) {
+              knownLength = knownLength || stream.getHeader('content-length');
+              const cd = stream.getHeader('content-disposition');
+              if (cd) {
+                filename =
+                  filename || contentDisposition.parse(cd).parameters.filename;
+              }
+            }
+            // if stream is not defined, error
+          } else {
+            throw new Error('Cannot stash a file of unknown type.');
+          }
+
+          // send final response to uploader
           return uploader(
             result,
-            bufferStringStream,
+            newBufferStringStream,
             knownLength,
             filename,
             fileContentType
           );
+        };
+
+        const formResponse = (response) => {
+          // determine if string is streamed based on if raw:true
+          const isStreamed = _.get(response, 'request.raw', false);
+
+          // if it's streamed, buffer first
+          if (isStreamed) {
+            return response.buffer().then((buffer) => {
+              response.dataBuffer = buffer;
+              return parseFinalResponse(response);
+            });
+          } else {
+            return parseFinalResponse(response);
+          }
+        };
+
+        // if stream is a promise, wait until resolved
+        if (isPromise(bufferStringStream)) {
+          return bufferStringStream.then((maybeResponse) => {
+            return formResponse(maybeResponse);
+          });
+        } else {
+          return formResponse(bufferStringStream);
         }
       }
     );

--- a/packages/core/test/tools/file-stasher.js
+++ b/packages/core/test/tools/file-stasher.js
@@ -13,7 +13,7 @@ const createAppRequestClient = require('../../src/tools/create-app-request-clien
 const createInput = require('../../src/tools/create-input');
 const { HTTPBIN_URL } = require('../constants');
 
-describe('file upload', () => {
+describe('file upload from promise', () => {
   const testLogger = () => Promise.resolve({});
   const input = createInput({}, {}, testLogger);
 
@@ -283,5 +283,58 @@ describe('file upload', () => {
         done();
       })
       .catch(done);
+  });
+});
+
+describe('file upload using async/await', () => {
+  const testLogger = () => Promise.resolve({});
+  const input = createInput({}, {}, testLogger);
+
+  const rpc = mocky.makeRpc();
+  const stashFile = createFileStasher({
+    _zapier: {
+      rpc,
+      event: {
+        method: 'hydrators.test',
+      },
+    },
+  });
+
+  it('should upload a raw response', async () => {
+    mocky.mockRpcCall(mocky.fakeSignedPostData);
+    mocky.mockUpload();
+
+    const request = createAppRequestClient(input);
+    const file = await request(`${HTTPBIN_URL}/stream-bytes/1024`, {
+      raw: true,
+    });
+
+    const url = await stashFile(file);
+    should(url).eql(
+      `${mocky.fakeSignedPostData.url}${mocky.fakeSignedPostData.fields.key}`
+    );
+  });
+
+  it('should get filename from content-disposition', async () => {
+    mocky.mockRpcCall(mocky.fakeSignedPostData);
+
+    // Expect to have this part in the request body sent to S3
+    mocky.mockUpload(
+      /name="Content-Disposition"\r\n\r\nattachment; filename="an example\.json"/
+    );
+
+    const request = createAppRequestClient(input);
+    const file = await request({
+      url: `${HTTPBIN_URL}/response-headers`,
+      params: {
+        'Content-Disposition': 'inline; filename="an example.json"',
+      },
+      raw: true,
+    });
+
+    const url = await stashFile(file);
+    should(url).eql(
+      `${mocky.fakeSignedPostData.url}${mocky.fakeSignedPostData.fields.key}`
+    );
   });
 });


### PR DESCRIPTION
This Pull Request fixes [this issue](https://github.com/zapier/zapier-platform/issues/169)

Previously, when await was used on a request that was passed to z.stashFile like so:

```
const x = await z.request(...);
return z.stashFile(x);
```

formData would throw the `source.on is not a function`. This PR fixes that issue. 

Jira: https://zapierorg.atlassian.net/browse/SUPPORTESC-148 
