### PR TITLE
PDE-2333: Fix case-insensitive duplicate headers

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.14
+
+- :bug: Fix case-insesitive duplicate auth headers when using "API Key in Header" ([#364](https://github.com/zapier/zapier-platform/pull/364))
+
 ## 3.7.13
 
 - :bug: `inputData` should take precedence over `authData` when auth fields are not saved yet ([#359](https://github.com/zapier/zapier-platform/pull/359))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -294,6 +294,27 @@ const cleanHeaders = (headers) => {
   return newHeaders;
 };
 
+// Header keys are considered case insensitive. This function removes duplicate
+// headers. A former value is replaced by latterly appearing value with the same
+// case-insensitive key.
+const dedupeHeaders = (headers) => {
+  // lowerToFirstKeys stores the mapping from lowercased keys to the key that
+  // first appears in the headers
+  const lowerToFirstKeys = {};
+
+  const newHeaders = {};
+  Object.entries(headers).forEach(([k, v], index) => {
+    const lowerKey = k.toLowerCase();
+    if (lowerToFirstKeys[lowerKey] === undefined) {
+      lowerToFirstKeys[lowerKey] = k;
+    }
+    const firstKey = lowerToFirstKeys[lowerKey] || k;
+    newHeaders[firstKey] = v;
+  });
+
+  return newHeaders;
+};
+
 const compileLegacyScriptingSource = (source, zcli, app) => {
   const { DOMParser, XMLSerializer } = require('xmldom');
 
@@ -696,6 +717,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         .replace(/%7B/g, '{')
         .replace(/%7D/g, '}');
       request.headers = cleanHeaders(request.headers);
+      request.headers = dedupeHeaders(request.headers);
       request.allowGetBody = true;
       request.serializeValueForCurlies = serializeValueForCurlies;
       request.skipThrowForStatus = true;

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.13",
+  "version": "3.7.14",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1108,6 +1108,33 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, no double headers', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_invalid_chars_in_headers',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = {
+        api_key: 'one',
+      };
+      return _app(input).then((output) => {
+        const echoed = output.results[0];
+        should.equal(echoed.headers['X-Api-Key'], 'H E Y');
+      });
+    });
+
     it('KEY_post_poll, jQuery utils', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Suppose a legacy app uses "API Key in Header" auth and has this auth mapping:

```json
{
  "X-Api-Key": "{{api_key}}"
}
```

Doing this in a `pre` method will cause two duplicate headers, `X-Api-Key` and `x-api-key`, being sent:

```javascript
function(bundle) {
  bundle.request.headers = {
    'x-api-key': bundle.auth_fields.api_key
  };
  return bundle.request;
}
```

Some web servers may not like it.