### PR TITLE
PDE-2333: Fix duplicate API Key headers part 2

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.15
+
+- :bug: Fix another edge case that can lead to duplicate API Key headers ([#365](https://github.com/zapier/zapier-platform/pull/365))
+
 ## 3.7.14
 
 - :bug: Fix case-insesitive duplicate auth headers when using "API Key in Header" ([#364](https://github.com/zapier/zapier-platform/pull/364))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -307,7 +307,7 @@ const dedupeHeaders = (headers) => {
     if (lowerToFirstKeys[lowerKey] === undefined) {
       lowerToFirstKeys[lowerKey] = k;
     }
-    const firstKey = lowerToFirstKeys[lowerKey] || k;
+    const firstKey = lowerToFirstKeys[lowerKey];
     result[firstKey] = v;
     return result;
   }, {});

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -295,22 +295,22 @@ const cleanHeaders = (headers) => {
 };
 
 // Header keys are considered case insensitive. This function removes duplicate
-// headers. A former value is replaced by latterly appearing value with the same
-// case-insensitive key.
+// headers.
+// dedupeHeaders({'x-key': 'one', 'X-KEY': 'two'}) returns {'x-key': 'two'}
 const dedupeHeaders = (headers) => {
   // lowerToFirstKeys stores the mapping from lowercased keys to the key that
   // first appears in the headers
   const lowerToFirstKeys = {};
 
-  const newHeaders = {};
-  Object.entries(headers).forEach(([k, v], index) => {
+  const newHeaders = Object.entries(headers).reduce((result, [k, v]) => {
     const lowerKey = k.toLowerCase();
     if (lowerToFirstKeys[lowerKey] === undefined) {
       lowerToFirstKeys[lowerKey] = k;
     }
     const firstKey = lowerToFirstKeys[lowerKey] || k;
-    newHeaders[firstKey] = v;
-  });
+    result[firstKey] = v;
+    return result;
+  }, {});
 
   return newHeaders;
 };

--- a/packages/legacy-scripting-runner/middleware-factory.js
+++ b/packages/legacy-scripting-runner/middleware-factory.js
@@ -98,8 +98,19 @@ const createBeforeRequest = (app) => {
 
   const apiKeyInHeader = (req, z, bundle) => {
     if (!_.isEmpty(bundle.authData)) {
-      _.each(authMapping, (v, k) => {
-        req.headers[k] = req.headers[k] || renderTemplate(v, bundle.authData);
+      const lowerHeaders = Object.entries(req.headers).reduce(
+        (result, [k, v]) => {
+          result[k.toLowerCase()] = v;
+          return result;
+        },
+        {}
+      );
+
+      Object.entries(authMapping).forEach(([k, v]) => {
+        const lowerKey = k.toLowerCase();
+        if (!lowerHeaders[lowerKey]) {
+          req.headers[k] = renderTemplate(v, bundle.authData);
+        }
       });
     }
     return req;

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.14",
+  "version": "3.7.15",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -317,6 +317,15 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_double_headers: function(bundle) {
+        bundle.request.url = '${HTTPBIN_URL}/get';
+        bundle.request.headers = {
+          'x-api-key': 'two',
+          'X-API-KEY': 'three'
+        };
+        return bundle.request;
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1108,10 +1108,10 @@ describe('Integration Test', () => {
       });
     });
 
-    it('KEY_pre_poll, no double headers', () => {
+    it('KEY_pre_poll, double headers', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
-        'movie_pre_poll_invalid_chars_in_headers',
+        'movie_pre_poll_double_headers',
         'movie_pre_poll'
       );
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
@@ -1131,7 +1131,7 @@ describe('Integration Test', () => {
       };
       return _app(input).then((output) => {
         const echoed = output.results[0];
-        should.equal(echoed.headers['X-Api-Key'], 'H E Y');
+        should.deepEqual(echoed.headers['X-Api-Key'], ['three']);
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Turns out #364 only fixes part of the issue. This PR fixes another edge case that can lead to duplicate API Key headers.