### PR TITLE
PDE-2352: fix(legacy-scripting-runner): auth can be an object for z.request

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.16
+
+- :bug: Allow `auth` to be an object for `z.request` ([#366](https://github.com/zapier/zapier-platform/pull/366))
+
 ## 3.7.15
 
 - :bug: Fix another edge case that can lead to duplicate API Key headers ([#365](https://github.com/zapier/zapier-platform/pull/365))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.7.15",
+  "version": "3.7.16",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -335,6 +335,21 @@ const legacyScriptingSource = `
         return [z.JSON.parse(bundle.response.content)];
       },
 
+      movie_post_poll_z_request_auth: function(bundle) {
+        var response = z.request({
+          url: '${HTTPBIN_URL}/get',
+          auth: {
+            bearer: bundle.auth_fields.api_key
+          }
+        });
+        var data = z.JSON.parse(response.content);
+        var authHeader = data.headers.Authorization;
+        return z.JSON.parse(bundle.response.content).map(function(movie) {
+          movie.authHeader = authHeader;
+          return movie;
+        });
+      },
+
       movie_poll_default_headers: function(bundle) {
         // Copy Accept and Content-Type to params so we know they're already
         // available in pre_poll

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1251,6 +1251,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_post_poll, z.request auth', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_z_request_auth',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, apiKeyAuth);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = {
+        api_key: 'secret',
+      };
+      return _app(input).then((output) => {
+        const movie = output.results[0];
+        should.deepEqual(movie.authHeader, ['Bearer secret']);
+      });
+    });
+
     it('KEY_pre_poll & KEY_post_poll', () => {
       const input = createTestInput(
         compiledApp,

--- a/packages/legacy-scripting-runner/zfactory.js
+++ b/packages/legacy-scripting-runner/zfactory.js
@@ -13,21 +13,18 @@ const convertBundleRequest = (bundleOrBundleRequest) => {
     ? bundleOrBundleRequest.request
     : bundleOrBundleRequest;
 
-  let auth = null;
-
   if (
     bundleRequest.auth &&
-    _.isArray(bundleRequest.auth) &&
+    Array.isArray(bundleRequest.auth) &&
     bundleRequest.auth.length === 2
   ) {
-    auth = {
+    bundleRequest.auth = {
       user: bundleRequest.auth[0],
       password: bundleRequest.auth[1],
     };
   }
 
   bundleRequest.qs = bundleRequest.params || {};
-  bundleRequest.auth = auth;
   bundleRequest.body = bundleRequest.data || '';
 
   delete bundleRequest.params;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Steps

In a scripting method, pass an `auth` object to `z.request`:

```javascript
var response = z.request({
  url: '...',
  auth: {
    bearer: 'my_token'
  }
});
```

## Expected Behavior

The [request](https://www.npmjs.com/package/request#http-authentication) library will send an `Authorization: Bearer my_token` header.

## Actual Behavior

The `auth` argument is [set to null](https://github.com/zapier/zapier-platform/blob/b02ee5bee1452788ada9b71193bc31c7c668f272/packages/legacy-scripting-runner/zfactory.js#L16-L30) from the `z.request` call if it's not an array.