### PR TITLE
fix(cli): handle missing versions better in env command

### DIFF
--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -37,6 +37,11 @@ class SetEnvCommand extends BaseCommand {
     }, {});
 
     const app = await this.getWritableApp();
+    if (!app.all_versions.includes(version)) {
+      this.error(
+        `Version ${version} doesn't exist on integration "${app.title}"`
+      );
+    }
 
     const url = `/apps/${app.id}/versions/${version}/multi-environment`;
 
@@ -58,7 +63,7 @@ class SetEnvCommand extends BaseCommand {
       const failedKeys = e.json.errors[0].split('update: ')[1].split(', ');
       const successfulResult = omit(payload, failedKeys);
       if (!Object.keys(successfulResult).length) {
-        this.error(e.json.errors);
+        this.error(e.json.errors[0]);
       }
 
       this.warn(successMessage(version));

--- a/packages/cli/src/oclif/commands/env/unset.js
+++ b/packages/cli/src/oclif/commands/env/unset.js
@@ -34,6 +34,11 @@ class UnsetEnvCommand extends BaseCommand {
     }, {});
 
     const app = await this.getWritableApp();
+    if (!app.all_versions.includes(version)) {
+      this.error(
+        `Version ${version} doesn't exist on integration "${app.title}"`
+      );
+    }
 
     const url = `/apps/${app.id}/versions/${version}/multi-environment`;
 


### PR DESCRIPTION
Fixes [PDE-2356](https://zapierorg.atlassian.net/browse/PDE-2356). 

1. First, explicitly check that the version exists before we try to make an API call (the server error isn't super helpful here)
2. Also, `this.error` expects a string, so if we get an list of errors back, we should only send the first one. That's the `TypeError: first argument must be a string or instance of Error` in the jira ticket.