### PR TITLE
fix(schema): skip checking keys on fields without key properties

### DIFF
--- a/packages/schema/lib/functional-constraints/uniqueInputFieldKeys.js
+++ b/packages/schema/lib/functional-constraints/uniqueInputFieldKeys.js
@@ -15,6 +15,11 @@ const uniqueInputFieldKeys = (definition) => {
       const existingKeys = {}; // map of key to where it already lives
 
       inputFields.forEach((inputField, index) => {
+        // could be a string or a non-field object (`source` or `require` function obj)
+        if (!inputField.key) {
+          return;
+        }
+
         if (existingKeys[inputField.key]) {
           errors.push(
             new jsonschema.ValidationError(

--- a/packages/schema/test/functional-constraints/uniqueInputFieldKeys.js
+++ b/packages/schema/test/functional-constraints/uniqueInputFieldKeys.js
@@ -117,4 +117,35 @@ describe('uniqueInputFieldKeys', () => {
       )
       .should.be.true();
   });
+
+  it('should handle non-inputField objects', () => {
+    const definition = {
+      version: '1.0.0',
+      platformVersion: '1.0.0',
+      creates: {
+        foo: {
+          key: 'foo',
+          noun: 'Foo',
+          display: {
+            label: 'Create Foo',
+            description: 'Creates a...',
+          },
+          operation: {
+            perform: '$func$2$f$',
+            sample: { id: 1 },
+            inputFields: [
+              // each of these is valid, but none declares a .key property
+              '$func$2$f$', // dynamic fields
+              '$func$2$f$',
+              { source: 'return []' },
+              { require: './some/js/file.js' },
+            ],
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(0);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/zapier/zapier-platform/issues/375 (and [PDE-2410](https://zapierorg.atlassian.net/browse/PDE-2410))