### PR TITLE
feat(core): allow running adhoc functions in tests

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -351,6 +351,7 @@ a code {
 </li>
 <li><a href="#testing">Testing</a><ul>
 <li><a href="#writing-unit-tests">Writing Unit Tests</a></li>
+<li><a href="#using-the-z-object-in-tests">Using the <code>z</code> Object in Tests</a></li>
 <li><a href="#mocking-requests">Mocking Requests</a></li>
 <li><a href="#running-unit-tests">Running Unit Tests</a></li>
 <li><a href="#testing--environment-variables">Testing &amp; Environment Variables</a></li>
@@ -558,6 +559,7 @@ a code {
 </li>
 <li><a href="#testing">Testing</a><ul>
 <li><a href="#writing-unit-tests">Writing Unit Tests</a></li>
+<li><a href="#using-the-z-object-in-tests">Using the <code>z</code> Object in Tests</a></li>
 <li><a href="#mocking-requests">Mocking Requests</a></li>
 <li><a href="#running-unit-tests">Running Unit Tests</a></li>
 <li><a href="#testing--environment-variables">Testing &amp; Environment Variables</a></li>
@@ -4374,6 +4376,71 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
     <span class="hljs-keyword">const</span> firstRecipe = results[<span class="hljs-number">0</span>];
     expect(firstRecipe.id).toBe(<span class="hljs-number">1</span>);
     expect(firstRecipe.name).toBe(<span class="hljs-string">&apos;Baked Falafel&apos;</span>);
+  });
+});
+
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="using-the-z-object-in-tests">Using the <code>z</code> Object in Tests</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Introduced in <a href="mailto:`core@11.1.0">`core@11.1.0</a><code>,</code>appTester` can now run arbitrary functions:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">/* globals describe, expect, test */</span>
+
+<span class="hljs-keyword">const</span> zapier = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;zapier-platform-core&apos;</span>);
+
+<span class="hljs-keyword">const</span> App = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;../index&apos;</span>);
+<span class="hljs-keyword">const</span> appTester = zapier.createAppTester(App);
+
+describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
+  test(<span class="hljs-string">&apos;load recipes&apos;</span>, <span class="hljs-keyword">async</span> () =&gt; {
+    <span class="hljs-keyword">const</span> adHodResult = <span class="hljs-keyword">await</span> appTester(
+      <span class="hljs-comment">// your in-line function takes the same [z, bundle] arguments as normal</span>
+      <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+        <span class="hljs-comment">// requests are made using your integration&apos;s actual middleware</span>
+        <span class="hljs-comment">// make sure to pass the normal `bundle` arg to `appTester` if your requests need auth</span>
+        <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(
+          <span class="hljs-string">&apos;https://example.com/some/setup/method&apos;</span>,
+          {
+            <span class="hljs-attr">params</span>: {
+              <span class="hljs-attr">numItems</span>: bundle.inputData.someValue,
+            },
+          }
+        );
+
+        <span class="hljs-keyword">return</span> {
+          <span class="hljs-comment">// you can use all the functions on the `z` object</span>
+          <span class="hljs-attr">someHash</span>: z.hash(<span class="hljs-string">&apos;md5&apos;</span>, <span class="hljs-string">&apos;mySecret&apos;</span>),
+          <span class="hljs-attr">data</span>: response.data,
+        };
+      },
+      {
+        <span class="hljs-comment">// you must provide auth data for authenticated requests</span>
+        <span class="hljs-comment">// (just like running a normal trigger)</span>
+        <span class="hljs-attr">authData</span>: { <span class="hljs-attr">token</span>: <span class="hljs-string">&apos;some-api-key&apos;</span> },
+        <span class="hljs-comment">// put arbitrary function params in `inputData`</span>
+        <span class="hljs-attr">inputData</span>: {
+          <span class="hljs-attr">someValue</span>: <span class="hljs-number">3</span>,
+        },
+      }
+    );
+
+    expect(adHodResult.someHash).toEqual(<span class="hljs-string">&apos;a5beb6624e092adf7be31176c3079e64&apos;</span>);
+    expect(adHodResult.data).toEqual({ <span class="hljs-attr">whatever</span>: <span class="hljs-literal">true</span> });
+
+    <span class="hljs-comment">// ... rest of test</span>
   });
 });
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1484,6 +1484,14 @@ Since v10, we recommend using the [Jest](https://jestjs.io/) testing framework. 
 [insert-file:./snippets/jest-test.js]
 ```
 
+### Using the `z` Object in Tests
+
+Introduced in `core@11.1.0`, `appTester` can now run arbitrary functions:
+
+```js
+[insert-file:./snippets/jest-adhoc-func.js]
+```
+
 ### Mocking Requests
 
 While testing, it's useful to test your code without actually hitting any external services. [Nock](https://github.com/node-nock/nock) is a node.js utility that intercepts requests before they ever leave your computer. You can specify a response code, body, headers, and more. It works out of the box with `z.request` by setting up your `nock` before calling `appTester`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2666,7 +2666,7 @@ describe('triggers', () => {
 
 ### Using the `z` Object in Tests
 
-Introduced in `core@11.1.0`, `appTester` can now run arbitrary functions:
+Introduced in `core@11.1.0`, `appTester` can now run arbitrary functions that are not in your app definition:
 
 ```js
 /* globals describe, expect, test */

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -117,6 +117,7 @@ This doc describes the latest CLI version (**11.0.1**), as of this writing. If y
     + [v10 Breaking Change: Auth Refresh](#v10-breaking-change-auth-refresh)
 - [Testing](#testing)
   * [Writing Unit Tests](#writing-unit-tests)
+  * [Using the `z` Object in Tests](#using-the-z-object-in-tests)
   * [Mocking Requests](#mocking-requests)
   * [Running Unit Tests](#running-unit-tests)
   * [Testing & Environment Variables](#testing--environment-variables)
@@ -2658,6 +2659,60 @@ describe('triggers', () => {
     const firstRecipe = results[0];
     expect(firstRecipe.id).toBe(1);
     expect(firstRecipe.name).toBe('Baked Falafel');
+  });
+});
+
+```
+
+### Using the `z` Object in Tests
+
+Introduced in `core@11.1.0`, `appTester` can now run arbitrary functions:
+
+```js
+/* globals describe, expect, test */
+
+const zapier = require('zapier-platform-core');
+
+const App = require('../index');
+const appTester = zapier.createAppTester(App);
+
+describe('triggers', () => {
+  test('load recipes', async () => {
+    const adHodResult = await appTester(
+      // your in-line function takes the same [z, bundle] arguments as normal
+      async (z, bundle) => {
+        // requests are made using your integration's actual middleware
+        // make sure to pass the normal `bundle` arg to `appTester` if your requests need auth
+        const response = await z.request(
+          'https://example.com/some/setup/method',
+          {
+            params: {
+              numItems: bundle.inputData.someValue,
+            },
+          }
+        );
+
+        return {
+          // you can use all the functions on the `z` object
+          someHash: z.hash('md5', 'mySecret'),
+          data: response.data,
+        };
+      },
+      {
+        // you must provide auth data for authenticated requests
+        // (just like running a normal trigger)
+        authData: { token: 'some-api-key' },
+        // put arbitrary function params in `inputData`
+        inputData: {
+          someValue: 3,
+        },
+      }
+    );
+
+    expect(adHodResult.someHash).toEqual('a5beb6624e092adf7be31176c3079e64');
+    expect(adHodResult.data).toEqual({ whatever: true });
+
+    // ... rest of test
   });
 });
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -351,6 +351,7 @@ a code {
 </li>
 <li><a href="#testing">Testing</a><ul>
 <li><a href="#writing-unit-tests">Writing Unit Tests</a></li>
+<li><a href="#using-the-z-object-in-tests">Using the <code>z</code> Object in Tests</a></li>
 <li><a href="#mocking-requests">Mocking Requests</a></li>
 <li><a href="#running-unit-tests">Running Unit Tests</a></li>
 <li><a href="#testing--environment-variables">Testing &amp; Environment Variables</a></li>
@@ -558,6 +559,7 @@ a code {
 </li>
 <li><a href="#testing">Testing</a><ul>
 <li><a href="#writing-unit-tests">Writing Unit Tests</a></li>
+<li><a href="#using-the-z-object-in-tests">Using the <code>z</code> Object in Tests</a></li>
 <li><a href="#mocking-requests">Mocking Requests</a></li>
 <li><a href="#running-unit-tests">Running Unit Tests</a></li>
 <li><a href="#testing--environment-variables">Testing &amp; Environment Variables</a></li>
@@ -4374,6 +4376,71 @@ describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
     <span class="hljs-keyword">const</span> firstRecipe = results[<span class="hljs-number">0</span>];
     expect(firstRecipe.id).toBe(<span class="hljs-number">1</span>);
     expect(firstRecipe.name).toBe(<span class="hljs-string">&apos;Baked Falafel&apos;</span>);
+  });
+});
+
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="using-the-z-object-in-tests">Using the <code>z</code> Object in Tests</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Introduced in <a href="mailto:`core@11.1.0">`core@11.1.0</a><code>,</code>appTester` can now run arbitrary functions:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">/* globals describe, expect, test */</span>
+
+<span class="hljs-keyword">const</span> zapier = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;zapier-platform-core&apos;</span>);
+
+<span class="hljs-keyword">const</span> App = <span class="hljs-built_in">require</span>(<span class="hljs-string">&apos;../index&apos;</span>);
+<span class="hljs-keyword">const</span> appTester = zapier.createAppTester(App);
+
+describe(<span class="hljs-string">&apos;triggers&apos;</span>, () =&gt; {
+  test(<span class="hljs-string">&apos;load recipes&apos;</span>, <span class="hljs-keyword">async</span> () =&gt; {
+    <span class="hljs-keyword">const</span> adHodResult = <span class="hljs-keyword">await</span> appTester(
+      <span class="hljs-comment">// your in-line function takes the same [z, bundle] arguments as normal</span>
+      <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+        <span class="hljs-comment">// requests are made using your integration&apos;s actual middleware</span>
+        <span class="hljs-comment">// make sure to pass the normal `bundle` arg to `appTester` if your requests need auth</span>
+        <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request(
+          <span class="hljs-string">&apos;https://example.com/some/setup/method&apos;</span>,
+          {
+            <span class="hljs-attr">params</span>: {
+              <span class="hljs-attr">numItems</span>: bundle.inputData.someValue,
+            },
+          }
+        );
+
+        <span class="hljs-keyword">return</span> {
+          <span class="hljs-comment">// you can use all the functions on the `z` object</span>
+          <span class="hljs-attr">someHash</span>: z.hash(<span class="hljs-string">&apos;md5&apos;</span>, <span class="hljs-string">&apos;mySecret&apos;</span>),
+          <span class="hljs-attr">data</span>: response.data,
+        };
+      },
+      {
+        <span class="hljs-comment">// you must provide auth data for authenticated requests</span>
+        <span class="hljs-comment">// (just like running a normal trigger)</span>
+        <span class="hljs-attr">authData</span>: { <span class="hljs-attr">token</span>: <span class="hljs-string">&apos;some-api-key&apos;</span> },
+        <span class="hljs-comment">// put arbitrary function params in `inputData`</span>
+        <span class="hljs-attr">inputData</span>: {
+          <span class="hljs-attr">someValue</span>: <span class="hljs-number">3</span>,
+        },
+      }
+    );
+
+    expect(adHodResult.someHash).toEqual(<span class="hljs-string">&apos;a5beb6624e092adf7be31176c3079e64&apos;</span>);
+    expect(adHodResult.data).toEqual({ <span class="hljs-attr">whatever</span>: <span class="hljs-literal">true</span> });
+
+    <span class="hljs-comment">// ... rest of test</span>
   });
 });
 

--- a/packages/cli/snippets/jest-adhoc-func.js
+++ b/packages/cli/snippets/jest-adhoc-func.js
@@ -1,0 +1,46 @@
+/* globals describe, expect, test */
+
+const zapier = require('zapier-platform-core');
+
+const App = require('../index');
+const appTester = zapier.createAppTester(App);
+
+describe('triggers', () => {
+  test('load recipes', async () => {
+    const adHodResult = await appTester(
+      // your in-line function takes the same [z, bundle] arguments as normal
+      async (z, bundle) => {
+        // requests are made using your integration's actual middleware
+        // make sure to pass the normal `bundle` arg to `appTester` if your requests need auth
+        const response = await z.request(
+          'https://example.com/some/setup/method',
+          {
+            params: {
+              numItems: bundle.inputData.someValue,
+            },
+          }
+        );
+
+        return {
+          // you can use all the functions on the `z` object
+          someHash: z.hash('md5', 'mySecret'),
+          data: response.data,
+        };
+      },
+      {
+        // you must provide auth data for authenticated requests
+        // (just like running a normal trigger)
+        authData: { token: 'some-api-key' },
+        // put arbitrary function params in `inputData`
+        inputData: {
+          someValue: 3,
+        },
+      }
+    );
+
+    expect(adHodResult.someHash).toEqual('a5beb6624e092adf7be31176c3079e64');
+    expect(adHodResult.data).toEqual({ whatever: true });
+
+    // ... rest of test
+  });
+});

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -16,7 +16,10 @@ export const createAppTester: (
   options?: { customStoreKey?: string }
 ) => <T, B extends Bundle>(
   func: (z: ZObject, bundle: B) => T | Promise<T>,
-  bundle?: Partial<B> // partial so we don't have to make a full bundle in tests
+  bundle?: Partial<B>, // partial so we don't have to make a full bundle in tests
+  opts?: {
+    adHoc?: boolean;
+  }
 ) => Promise<T>; // appTester always returns a promise
 
 // internal only
@@ -123,12 +126,13 @@ type DehydrateFunc = <T>(
 export interface ZObject {
   request: {
     // most specific overloads go first
-    (url: string, options: HttpRequestOptions & { raw: true }): Promise<
-      RawHttpResponse
-    >;
-    (options: HttpRequestOptions & { raw: true; url: string }): Promise<
-      RawHttpResponse
-    >;
+    (
+      url: string,
+      options: HttpRequestOptions & { raw: true }
+    ): Promise<RawHttpResponse>;
+    (
+      options: HttpRequestOptions & { raw: true; url: string }
+    ): Promise<RawHttpResponse>;
 
     (url: string, options?: HttpRequestOptions): Promise<HttpResponse>;
     (options: HttpRequestOptions & { url: string }): Promise<HttpResponse>;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -16,10 +16,7 @@ export const createAppTester: (
   options?: { customStoreKey?: string }
 ) => <T, B extends Bundle>(
   func: (z: ZObject, bundle: B) => T | Promise<T>,
-  bundle?: Partial<B>, // partial so we don't have to make a full bundle in tests
-  opts?: {
-    adHoc?: boolean;
-  }
+  bundle?: Partial<B> // partial so we don't have to make a full bundle in tests
 ) => Promise<T>; // appTester always returns a promise
 
 // internal only

--- a/packages/core/src/tools/resolve-method-path.js
+++ b/packages/core/src/tools/resolve-method-path.js
@@ -13,7 +13,7 @@ const isRequestMethod = (needle) =>
     resolveMethodPath(app, app.resources.contact.get.operation.perform)
 
 */
-const resolveMethodPath = (app, needle) => {
+const resolveMethodPath = (app, needle, explodeIfMissing = true) => {
   // temporary warning for all those with old code
   if (typeof needle === 'string') {
     console.log(
@@ -39,7 +39,7 @@ const resolveMethodPath = (app, needle) => {
   const path =
     dataTools.memoizedFindMapDeep(app, needle) ||
     dataTools.memoizedFindMapDeep(app, needle, _.isEqual);
-  if (!path) {
+  if (!path && explodeIfMissing) {
     throw new Error(
       'We could not find your function/array/object anywhere on your App definition.'
     );

--- a/packages/core/src/tools/resolve-method-path.js
+++ b/packages/core/src/tools/resolve-method-path.js
@@ -1,44 +1,31 @@
 'use strict';
 
-const _ = require('lodash');
-const dataTools = require('./data');
+const { isEqual } = require('lodash');
+const { memoizedFindMapDeep } = require('./data');
 
 const isRequestMethod = (needle) =>
   typeof needle === 'object' && typeof needle.url === 'string';
 
-/*
-  Verifies a object in an app tree, returning the path to it if found (or throwing an error if not found):
-
-    // a findable function/array/method
-    resolveMethodPath(app, app.resources.contact.get.operation.perform)
-
+/**
+  Verifies a object exists in an app tree, returning the path to it if found (optionally throwing an error if not found)
 */
 const resolveMethodPath = (app, needle, explodeIfMissing = true) => {
-  // temporary warning for all those with old code
-  if (typeof needle === 'string') {
-    console.log(
-      'In version 0.9.10 we removed string path resolution. Read more here https://github.com/zapier/zapier-platform-core/blob/master/CHANGELOG.md#0910'
-    );
-  }
-
   if (
     !(
       typeof needle === 'function' ||
-      _.isArray(needle) ||
+      Array.isArray(needle) ||
       isRequestMethod(needle)
     )
   ) {
     throw new Error(
-      'You must pass in a function/array/object. We got ' +
-        typeof needle +
-        ' instead.'
+      `You must pass in a function/array/object. We got ${typeof needle} instead.`
     );
   }
 
   // incurs roughly ~10ms penalty for _.isEqual fallback on a === miss on an averagish app
   const path =
-    dataTools.memoizedFindMapDeep(app, needle) ||
-    dataTools.memoizedFindMapDeep(app, needle, _.isEqual);
+    memoizedFindMapDeep(app, needle) ||
+    memoizedFindMapDeep(app, needle, isEqual);
   if (!path && explodeIfMissing) {
     throw new Error(
       'We could not find your function/array/object anywhere on your App definition.'

--- a/packages/core/test/test-tools.js
+++ b/packages/core/test/test-tools.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('should');
+const should = require('should');
 
 const createAppTester = require('../src/tools/create-app-tester');
 const appDefinition = require('./userapp');
@@ -8,12 +8,48 @@ const appDefinition = require('./userapp');
 describe('test-tools', () => {
   const appTester = createAppTester(appDefinition);
 
-  it('should run explicit path', (done) => {
-    appTester(appDefinition.resources.list.list.operation.perform)
-      .then((results) => {
-        results.should.eql([{ id: 1234 }, { id: 5678 }]);
-        done();
-      })
-      .catch(done);
+  it('should run an explicit path', async () => {
+    const results = await appTester(
+      appDefinition.resources.list.list.operation.perform
+    );
+    results.should.eql([{ id: 1234 }, { id: 5678 }]);
+  });
+
+  it('should fail to run a string path', () => {
+    const results = () =>
+      appTester('appDefinition.resources.list.list.operation.perform');
+    results.should.throw(/You must pass in a function\/array\/object/);
+  });
+
+  it('should run simple ad-hoc functions', async () => {
+    const results = await appTester(() => [1, 2, 3]);
+    results.should.eql([1, 2, 3]);
+  });
+
+  it('should pass real z and bundle to ad-hoc functions', async () => {
+    const results = await appTester(
+      (z, bundle) => ({
+        authData: bundle.authData,
+        functionsWork: z.hash('md5', 'david'),
+        zRequestExists: Boolean(z.request),
+      }),
+      { authData: { secret: 'password' } }
+    );
+
+    results.should.eql({
+      authData: { secret: 'password' },
+      functionsWork: '172522ec1028ab781d9dfd17eaca4427',
+      zRequestExists: true,
+    });
+  });
+
+  it('should error for an ad-hoc non-function', () => {
+    const results = () => appTester([1, 2, 3]);
+    results.should.throw(/Unable to find the following/);
+  });
+
+  it('should delete the temporary handler after use', async () => {
+    await appTester(() => [1, 2, 3]);
+    should(appDefinition._testRequest).eql(undefined);
   });
 });

--- a/packages/core/test/tools/resolve-method-path.js
+++ b/packages/core/test/tools/resolve-method-path.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('should');
+const should = require('should');
 
 const _ = require('lodash');
 
@@ -83,7 +83,7 @@ describe('resolve-method-path', () => {
     ).should.eql('authentication.oauth2Config.authorizeUrl');
   });
 
-  it('should resolve deep paths fastly', () => {
+  it('should resolve deep paths quickly', () => {
     // is >1000ms if not memoizedFindMapDeep, ~300ms after
     const authApp = schemaTools.prepareApp(oauthAppDef);
     for (let i = 1000; i >= 0; i--) {
@@ -92,5 +92,22 @@ describe('resolve-method-path', () => {
         oauthAppDef.authentication.oauth2Config.authorizeUrl
       );
     }
+  });
+
+  it('should throw if it fails to find', () => {
+    const shouldThrow = () => resolveMethodPath(app, () => null);
+    shouldThrow.should.throw(/We could not find/);
+  });
+
+  it('should be able to skip throwing if it fails to find', () => {
+    should(resolveMethodPath(app, () => null, false)).eql(undefined);
+  });
+
+  it('should always error if it gets a wrong type', () => {
+    const shouldThrow = () => resolveMethodPath(app, undefined);
+    shouldThrow.should.throw(/You must pass in a function\/array\/object/);
+
+    const shouldThrow2 = () => resolveMethodPath(app, 'ok', false);
+    shouldThrow2.should.throw(/You must pass in a function\/array\/object/);
   });
 });


### PR DESCRIPTION
Addresses https://github.com/zapier/zapier-platform/issues/16.

see also: [PDE-2539](https://zapierorg.atlassian.net/browse/PDE-2539)

## Todo

- [x] verify that TS works nicely
- [x] write unit tests

## Testing

1. With this PR cloned locally, run `yarn link` in the `core` directory
2. elsewhere, run `zapier init ad-hoc-test -t custom-auth`
3. run `cd ad-hoc-test && yarn && yarn link zapier-platform-core`

Now, `appTester` can be fed ad-hoc functions. Try the following test:

```js
/* globals describe, it, expect */

const zapier = require("zapier-platform-core");

const App = require("../index");
const appTester = zapier.createAppTester(App);

describe("custom auth", () => {
  it("passes authentication and returns json", async () => {
    const bundle = {
      authData: {
        apiKey: "secret",
      },
    };

    const response = await appTester(
      (z, bundle) =>
        z.request({ url: "https://auth-json-server.zapier-staging.com/me" }),
      bundle    
    );
    expect(response.data).toHaveProperty("username");
  });
});
```

It's a simple test, but it proves a point: a test function can use `z.request` and take advantage of middleware. 