### PR TITLE
[PDE-2554] fix(cli): Remove string literal from boolean reference in session-auth example

### DIFF
--- a/packages/cli/src/utils/auth-files-codegen.js
+++ b/packages/cli/src/utils/auth-files-codegen.js
@@ -404,13 +404,13 @@ const sessionAuthFile = () => {
           obj(
             objProperty('key', strLiteral('username')),
             objProperty('label', strLiteral('Username')),
-            objProperty('required', strLiteral('true'))
+            objProperty('required', 'true')
           ),
           obj(
             objProperty('key', strLiteral('password')),
             objProperty('label', strLiteral('Password')),
             objProperty('required', 'true'),
-            comment('this lets the user enter maksed data'),
+            comment('this lets the user enter masked data'),
             objProperty('type', strLiteral('password'))
           ),
         ],


### PR DESCRIPTION
https://github.com/zapier/zapier/issues/50045

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
