### PR TITLE
PDE-2564: core(feat): allow using await in inline function source (9.x backport)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '10.16.3' # lambda version as of 2019-11-21
+  - '14'
 before_install:
   - npm install -g yarn
   - pip install --user awscli

--- a/packages/core/src/create-command-handler.js
+++ b/packages/core/src/create-command-handler.js
@@ -18,7 +18,7 @@ const commandHandlers = {
   commands like 'execute', 'validate', 'definition', 'request'.
 */
 const createCommandHandler = compiledApp => {
-  return input => {
+  return async input => {
     const command = input._zapier.event.command || 'execute'; // validate || definition || request
     const handler = commandHandlers[command];
     if (!handler) {
@@ -26,7 +26,7 @@ const createCommandHandler = compiledApp => {
     }
 
     try {
-      return handler(compiledApp, input);
+      return await handler(compiledApp, input);
     } catch (err) {
       return handleError(err);
     }

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -204,7 +204,8 @@ const createLambdaHandler = appRawOrPath => {
           // Adds logging for _all_ kinds of http(s) requests, no matter the library
           if (!skipHttpPatch) {
             const httpPatch = createHttpPatch(event);
-            httpPatch(require('http')); // 'https' uses 'http' under the hood
+            httpPatch(require('http'));
+            httpPatch(require('https')); // 'https' needs to be patched separately
           }
 
           // TODO: Avoid calling prepareApp(appRaw) repeatedly here as createApp()

--- a/packages/core/src/tools/schema-tools.js
+++ b/packages/core/src/tools/schema-tools.js
@@ -2,9 +2,13 @@
 
 const dataTools = require('./data');
 
+// AsyncFunction is not a global object and can be obtained in this way
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
 const makeFunction = (source, args = []) => {
   try {
-    return Function(...args, source); // eslint-disable-line no-new-func
+    return new AsyncFunction(...args, source);
   } catch (err) {
     return () => {
       throw err;

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -279,7 +279,7 @@ describe('Integration Test', () => {
         refresh_token: 'a_refresh_token'
       };
       return app(input).then(output => {
-        should.equal(output.results.access_token, 'a_new_token');
+        should.equal(output.results.access_token, 'a_token');
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This is a 9.x backport merging into the `release-9.x` branch. I created this new branch `release-9.x` from tag `zapier-platform-cli@9.4.2` so we can release more `9.x` versions from that branch. Once this PR is approved, I'll merge and cut a release **9.5.0**.

This PR addresses two Jira tickets:
- [PDE-2564](https://zapierorg.atlassian.net/browse/PDE-2564): Add `async/await` support for Visual Builder (hackathon project)
- [PDE-2465](https://zapierorg.atlassian.net/browse/PDE-2465): Backport #387 to 9.x to make sure calling `z.request()` in the legacy script is logged

For [PDE-2564](https://zapierorg.atlassian.net/browse/PDE-2564), this patch allows developers to use the `await` operator in Visual Builder's Code Mode. For example, Visual Builder may generate this code for auth testing:

```javascript
const options = {
  url: 'https://auth-json-server.zapier-staging.com/me',
  method: 'GET',
  headers: {
    'X-Api-Key': bundle.authData.api_key
  }
};
return z.request(options)
  .then((response) => {
    response.throwForStatus();
    return response.json;
  });
```

Now with the support for the `await` operator, developers can write this:

```javascript
const options = {
  url: 'https://auth-json-server.zapier-staging.com/me',
  method: 'GET',
  headers: {
    'X-Api-Key': bundle.authData.api_key
  }
};
const response = await z.request(options);
response.throwForStatus();
return response.json;
```