### PR TITLE
PDE-2564: core(feat): allow using `await` in inline function source (11.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,21 @@ See below for a detailed changelog (**:exclamation: denotes a breaking change**)
 
 - :hammer: Mass dependency update and linting ([#218](https://github.com/zapier/zapier-platform/pull/218), [#220](https://github.com/zapier/zapier-platform/pull/220))
 
+## 9.5.0
+
+### cli
+
+- None!
+
+### core
+
+- :tada: Allow using `await` in inline function source ([#390](https://github.com/zapier/zapier-platform/pull/390))
+- :bug: Make sure all HTTP requests logged ([#390](https://github.com/zapier/zapier-platform/pull/390))
+
+### schema
+
+- None!
+
 ## 9.4.2
 
 ### cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 11.1.0
+
+_unreleased_
+
+### core
+
+- :tada: Allow using `await` in inline function source ([#396](https://github.com/zapier/zapier-platform/pull/396))
+
 ## 11.0.1
 
 _released `2021-05-28`_
@@ -231,6 +239,8 @@ See below for a detailed changelog (**:exclamation: denotes a breaking change**)
 - :hammer: Mass dependency update and linting ([#218](https://github.com/zapier/zapier-platform/pull/218), [#220](https://github.com/zapier/zapier-platform/pull/220))
 
 ## 9.5.0
+
+_released `2021-07-02`_
 
 ### cli
 

--- a/packages/core/src/create-command-handler.js
+++ b/packages/core/src/create-command-handler.js
@@ -18,7 +18,7 @@ const commandHandlers = {
   commands like 'execute', 'validate', 'definition', 'request'.
 */
 const createCommandHandler = (compiledApp) => {
-  return (input) => {
+  return async (input) => {
     const command = input._zapier.event.command || 'execute'; // validate || definition || request
     const handler = commandHandlers[command];
     if (!handler) {
@@ -26,7 +26,7 @@ const createCommandHandler = (compiledApp) => {
     }
 
     try {
-      return handler(compiledApp, input);
+      return await handler(compiledApp, input);
     } catch (err) {
       return handleError(err);
     }

--- a/packages/core/src/tools/schema-tools.js
+++ b/packages/core/src/tools/schema-tools.js
@@ -2,9 +2,13 @@
 
 const dataTools = require('./data');
 
+// AsyncFunction is not a global object and can be obtained in this way
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
 const makeFunction = (source, args = []) => {
   try {
-    return Function(...args, source); // eslint-disable-line no-new-func
+    return new AsyncFunction(...args, source);
   } catch (err) {
     return () => {
       throw err;

--- a/packages/core/test/tools/schema-tools.js
+++ b/packages/core/test/tools/schema-tools.js
@@ -9,7 +9,7 @@ describe('schema-tools', () => {
   describe('makeFunction', () => {
     it('should make a function', () => {
       const func = schemaTools.makeFunction('return [{ id: 1234 }];');
-      func().should.deepEqual([{ id: 1234 }]);
+      return func().should.finally.deepEqual([{ id: 1234 }]);
     });
 
     it('should throw when node require is used', () => {
@@ -20,7 +20,7 @@ describe('schema-tools', () => {
       `;
 
       const func = schemaTools.makeFunction(body);
-      func.should.throw(ReferenceError, { message: 'require is not defined' });
+      return func().should.be.rejectedWith(/require is not defined/);
     });
 
     it('should gracefully handle bad code', () => {
@@ -54,7 +54,23 @@ describe('schema-tools', () => {
         beforeRequest: [{ source: 'return a - b;', args: ['a', 'b'] }],
       };
       const app = schemaTools.findSourceRequireFunctions(appRaw);
-      app.beforeRequest[0](123, 23).should.eql(100);
+      return app.beforeRequest[0](123, 23).should.finally.eql(100);
+    });
+
+    it('should replace async function source', () => {
+      const source = `
+        const one = await promiseOne;
+        const two = await promiseTwo;
+        return one + two;
+      `;
+      const appRaw = {
+        beforeRequest: [{ source, args: ['promiseOne', 'promiseTwo'] }],
+      };
+      const app = schemaTools.findSourceRequireFunctions(appRaw);
+      return app.beforeRequest[0](
+        Promise.resolve(123),
+        Promise.resolve(456)
+      ).should.finally.eql(579);
     });
   });
 });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Same as https://github.com/zapier/zapier-platform/pull/390 but on the master branch.