### PR TITLE
feat(core): TN-168 Adds meta.isBulkRead TypeScript binding for platform 11.1.0

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -37,6 +37,7 @@ export interface Bundle<InputData = { [x: string]: any }> {
   inputData: InputData;
   inputDataRaw: { [x: string]: string };
   meta: {
+    isBulkRead: boolean;
     isFillingDynamicDropdown: boolean;
     isLoadingSample: boolean;
     isPopulatingDedupe: boolean;


### PR DESCRIPTION
See https://github.com/zapier/zapier/pull/50527 which will add `meta.isBulkRead` for platform >= 11.1.0.