### PR TITLE
[SUPPORTESC-179] docs(cli): Add information about header format in bundle.rawRequest

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3059,8 +3059,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>bundle.rawRequest</code> is only available in the <code>perform</code> for web hooks, <code>getAccessToken</code> for oauth authentication methods, and <code>performResume</code> in a callback action.</p>
-</blockquote><p><code>bundle.rawRequest</code> holds raw information about the HTTP request that triggered the <code>perform</code> method or that represents the users browser request that triggered the <code>getAccessToken</code> call:</p>
+<p><code>bundle.rawRequest</code> is only available in the <code>perform</code> for webhooks, <code>getAccessToken</code> for OAuth authentication methods, and <code>performResume</code> in a callback action.</p>
+</blockquote><p><code>bundle.rawRequest</code> holds raw information about the HTTP request that triggered the <code>perform</code> method or that represents the user&apos;s browser request that triggered the <code>getAccessToken</code> call:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code>{
@@ -3072,6 +3072,15 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   content: &apos;{&quot;hello&quot;: &quot;world&quot;}&apos;
 }
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In <code>bundle.rawRequest</code>, headers other than <code>Content-Length</code> and <code>Content-Type</code> will be prefixed with <code>Http-</code>, and all headers will be named in Camel-Case. For example, the header <code>X-Time-GMT</code> would become <code>Http-X-Time-Gmt</code>.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -3121,7 +3130,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p><code>bundle.outputData</code> is only available in the <code>performResume</code> in a callback action.</p>
-</blockquote><p><code>bundle.outputData</code> will return a whatever data you originally returned in the <code>perform</code> allowing you to mix that with <code>bundle.rawRequest</code> or <code>bundle.cleanedRequest</code>.</p>
+</blockquote><p><code>bundle.outputData</code> will return a whatever data you originally returned in the <code>perform</code>, allowing you to mix that with <code>bundle.rawRequest</code> or <code>bundle.cleanedRequest</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -864,9 +864,9 @@ const perform = async (z, bundle) => {
 
 ### `bundle.rawRequest`
 
-> `bundle.rawRequest` is only available in the `perform` for web hooks, `getAccessToken` for oauth authentication methods, and `performResume` in a callback action.
+> `bundle.rawRequest` is only available in the `perform` for webhooks, `getAccessToken` for OAuth authentication methods, and `performResume` in a callback action.
 
-`bundle.rawRequest` holds raw information about the HTTP request that triggered the `perform` method or that represents the users browser request that triggered the `getAccessToken` call:
+`bundle.rawRequest` holds raw information about the HTTP request that triggered the `perform` method or that represents the user's browser request that triggered the `getAccessToken` call:
 
 ```
 {
@@ -879,7 +879,7 @@ const perform = async (z, bundle) => {
 }
 ```
 
-
+In `bundle.rawRequest`, headers other than `Content-Length` and `Content-Type` will be prefixed with `Http-`, and all headers will be named in Camel-Case. For example, the header `X-Time-GMT` would become `Http-X-Time-Gmt`.
 
 ### `bundle.cleanedRequest`
 
@@ -907,7 +907,7 @@ const perform = async (z, bundle) => {
 
 > `bundle.outputData` is only available in the `performResume` in a callback action.
 
-`bundle.outputData` will return a whatever data you originally returned in the `perform` allowing you to mix that with `bundle.rawRequest` or `bundle.cleanedRequest`.
+`bundle.outputData` will return a whatever data you originally returned in the `perform`, allowing you to mix that with `bundle.rawRequest` or `bundle.cleanedRequest`.
 
 
 ### `bundle.targetUrl`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1774,9 +1774,9 @@ const perform = async (z, bundle) => {
 
 ### `bundle.rawRequest`
 
-> `bundle.rawRequest` is only available in the `perform` for web hooks, `getAccessToken` for oauth authentication methods, and `performResume` in a callback action.
+> `bundle.rawRequest` is only available in the `perform` for webhooks, `getAccessToken` for OAuth authentication methods, and `performResume` in a callback action.
 
-`bundle.rawRequest` holds raw information about the HTTP request that triggered the `perform` method or that represents the users browser request that triggered the `getAccessToken` call:
+`bundle.rawRequest` holds raw information about the HTTP request that triggered the `perform` method or that represents the user's browser request that triggered the `getAccessToken` call:
 
 ```
 {
@@ -1789,7 +1789,7 @@ const perform = async (z, bundle) => {
 }
 ```
 
-
+In `bundle.rawRequest`, headers other than `Content-Length` and `Content-Type` will be prefixed with `Http-`, and all headers will be named in Camel-Case. For example, the header `X-Time-GMT` would become `Http-X-Time-Gmt`.
 
 ### `bundle.cleanedRequest`
 
@@ -1817,7 +1817,7 @@ const perform = async (z, bundle) => {
 
 > `bundle.outputData` is only available in the `performResume` in a callback action.
 
-`bundle.outputData` will return a whatever data you originally returned in the `perform` allowing you to mix that with `bundle.rawRequest` or `bundle.cleanedRequest`.
+`bundle.outputData` will return a whatever data you originally returned in the `perform`, allowing you to mix that with `bundle.rawRequest` or `bundle.cleanedRequest`.
 
 
 ### `bundle.targetUrl`

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3059,8 +3059,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p><code>bundle.rawRequest</code> is only available in the <code>perform</code> for web hooks, <code>getAccessToken</code> for oauth authentication methods, and <code>performResume</code> in a callback action.</p>
-</blockquote><p><code>bundle.rawRequest</code> holds raw information about the HTTP request that triggered the <code>perform</code> method or that represents the users browser request that triggered the <code>getAccessToken</code> call:</p>
+<p><code>bundle.rawRequest</code> is only available in the <code>perform</code> for webhooks, <code>getAccessToken</code> for OAuth authentication methods, and <code>performResume</code> in a callback action.</p>
+</blockquote><p><code>bundle.rawRequest</code> holds raw information about the HTTP request that triggered the <code>perform</code> method or that represents the user&apos;s browser request that triggered the <code>getAccessToken</code> call:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code>{
@@ -3072,6 +3072,15 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
   content: &apos;{&quot;hello&quot;: &quot;world&quot;}&apos;
 }
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>In <code>bundle.rawRequest</code>, headers other than <code>Content-Length</code> and <code>Content-Type</code> will be prefixed with <code>Http-</code>, and all headers will be named in Camel-Case. For example, the header <code>X-Time-GMT</code> would become <code>Http-X-Time-Gmt</code>.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">
@@ -3121,7 +3130,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p><code>bundle.outputData</code> is only available in the <code>performResume</code> in a callback action.</p>
-</blockquote><p><code>bundle.outputData</code> will return a whatever data you originally returned in the <code>perform</code> allowing you to mix that with <code>bundle.rawRequest</code> or <code>bundle.cleanedRequest</code>.</p>
+</blockquote><p><code>bundle.outputData</code> will return a whatever data you originally returned in the <code>perform</code>, allowing you to mix that with <code>bundle.rawRequest</code> or <code>bundle.cleanedRequest</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -215,20 +215,16 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    getRequestToken: { require: 'some/path/to/file.js' },
+  { getRequestToken: { require: 'some/path/to/file.js' },
     authorizeUrl: { require: 'some/path/to/file2.js' },
-    getAccessToken: { require: 'some/path/to/file3.js' }
-  }
+    getAccessToken: { require: 'some/path/to/file3.js' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    getRequestToken: { require: 'some/path/to/file.js' },
-    authorizeUrl: { require: 'some/path/to/file2.js' }
-  }
+  { getRequestToken: { require: 'some/path/to/file.js' },
+    authorizeUrl: { require: 'some/path/to/file2.js' } }
   ```
   _Missing required key._
 
@@ -257,20 +253,16 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    authorizeUrl: { require: 'some/path/to/file.js' },
-    getAccessToken: { require: 'some/path/to/file2.js' }
-  }
+  { authorizeUrl: { require: 'some/path/to/file.js' },
+    getAccessToken: { require: 'some/path/to/file2.js' } }
   ```
 * ```
-  {
-    authorizeUrl: { require: 'some/path/to/file.js' },
+  { authorizeUrl: { require: 'some/path/to/file.js' },
     getAccessToken: { require: 'some/path/to/file2.js' },
     refreshAccessToken: { require: 'some/path/to/file3.js' },
     codeParam: 'unique_code',
     scope: 'read/write',
-    autoRefresh: true
-  }
+    autoRefresh: true }
   ```
 
 #### Anti-Examples
@@ -432,13 +424,11 @@ Key | Required | Type | Description
 * `{ hidden: true }`
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  {
-    label: 'New Thing',
+  { label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true
-  }
+    important: true }
   ```
 
 #### Anti-Examples
@@ -476,26 +466,22 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    type: 'hook',
+  { type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
     performUnsubscribe: { require: 'some/path/to/file4.js' },
-    sample: { id: 42, name: 'Hooli' }
-  }
+    sample: { id: 42, name: 'Hooli' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    type: 'hook',
+  { type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
-    performUnsubscribe: { require: 'some/path/to/file4.js' }
-  }
+    performUnsubscribe: { require: 'some/path/to/file4.js' } }
   ```
   _Missing required key: sample. Note - This is only invalid if `display` is not explicitly set to true and if it does not belong to a resource that has a sample._
 
@@ -582,24 +568,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipes',
+  { key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation: {
-      perform: '$func$0$f$',
-      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-    }
-  }
+    operation:
+     { perform: '$func$0$f$',
+       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get User', description: 'Retrieve a user.' },
-    operation: { description: 'Define how this search method will work.' }
-  }
+  { display: { label: 'Get User', description: 'Retrieve a user.' },
+    operation: { description: 'Define how this search method will work.' } }
   ```
   _Missing required keys: key and noun_
 
@@ -623,33 +604,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    recipes: {
-      key: 'recipes',
-      noun: 'Recipes',
-      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-      operation: {
-        perform: '$func$0$f$',
-        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-      }
-    }
-  }
+  { recipes:
+     { key: 'recipes',
+       noun: 'Recipes',
+       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+       operation:
+        { perform: '$func$0$f$',
+          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    readRecipes: {
-      key: 'recipes',
-      noun: 'Recipes',
-      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-      operation: {
-        perform: '$func$0$f$',
-        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
-      }
-    }
-  }
+  { readRecipes:
+     { key: 'recipes',
+       noun: 'Recipes',
+       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+       operation:
+        { perform: '$func$0$f$',
+          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
   ```
   _Key must match the key of the associated BulkReadSchema_
 
@@ -676,49 +649,39 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
-  }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
   ```
   _Invalid value for key on operation: shouldLock_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing required key on operation: sample. Note - this is valid if the resource has defined a sample._
 
@@ -742,48 +705,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    createRecipe: {
-      key: 'createRecipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { createRecipe:
+     { key: 'createRecipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
 * ```
-  {
-    Create_Recipe_01: {
-      key: 'Create_Recipe_01',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { Create_Recipe_01:
+     { key: 'Create_Recipe_01',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    '01_Create_Recipe': {
-      key: '01_Create_Recipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { '01_Create_Recipe':
+     { key: '01_Create_Recipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
   _Key must start with a letter_
 * ```
-  {
-    Create_Recipe: {
-      key: 'createRecipe',
-      noun: 'Recipe',
-      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-      operation: { perform: '$func$2$f$', sample: { id: 1 } }
-    }
-  }
+  { Create_Recipe:
+     { key: 'createRecipe',
+       noun: 'Recipe',
+       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
   ```
   _Key must match the key field in CreateSchema_
 
@@ -1262,29 +1213,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Create Tag',
-      description: 'Create a new Tag in your account.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1309,25 +1250,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1352,29 +1287,19 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: {
-      type: 'hook',
-      perform: '$func$0$f$',
-      sample: { id: 385, name: 'proactive enable ROI' }
-    }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
   ```
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' }
-  }
+  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1399,38 +1324,24 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: {
-      perform: { url: 'https://fake-crm.getsandbox.com/users' },
-      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
-    }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation:
+     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
+       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
   ```
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.',
-      hidden: true
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display:
+     { label: 'New User',
+       description: 'Trigger when a new User is created in your account.',
+       hidden: true },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    display: {
-      label: 'New User',
-      description: 'Trigger when a new User is created in your account.'
-    },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
-  }
+  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1455,31 +1366,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1511,61 +1412,43 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    },
-    list: {
-      display: {
-        label: 'New Tag',
-        description: 'Trigger when a new Tag is created in your account.'
-      },
-      operation: {
-        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-        sample: { id: 385, name: 'proactive enable ROI' }
-      }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
+    list:
+     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
+       operation:
+        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+          sample: { id: 385, name: 'proactive enable ROI' } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'tag',
+  { key: 'tag',
     noun: 'Tag',
-    get: {
-      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-    }
-  }
+    get:
+     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1589,50 +1472,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    tag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: {
-          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' }
-        }
-      }
-    }
-  }
+  { tag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation:
+           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+             sample: { id: 385, name: 'proactive enable ROI' } } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    getTag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: {
-          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' }
-        }
-      }
-    }
-  }
+  { getTag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation:
+           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+             sample: { id: 385, name: 'proactive enable ROI' } } } } }
   ```
   _Key does not match key for associated /ResourceSchema_
 * ```
-  {
-    tag: {
-      key: 'tag',
-      noun: 'Tag',
-      get: {
-        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-        operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
-      }
-    }
-  }
+  { tag:
+     { key: 'tag',
+       noun: 'Tag',
+       get:
+        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+          operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } } }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1680,47 +1549,38 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'searchOrCreateWidgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: 'searchOrCreateWidgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: 'searchWidgets',
-    create: 'createWidget'
-  }
+    create: 'createWidget' }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: '01_Search_or_Create_Widgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: '01_Search_or_Create_Widgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: 'searchWidgets',
-    create: 'createWidget'
-  }
+    create: 'createWidget' }
   ```
   _Invalid value for key: key (must start with a letter)_
 * ```
-  {
-    key: 'searchOrCreateWidgets',
-    display: {
-      label: 'Search or Create Widgets',
-      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-      important: true,
-      hidden: false
-    },
+  { key: 'searchOrCreateWidgets',
+    display:
+     { label: 'Search or Create Widgets',
+       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+       important: true,
+       hidden: false },
     search: { require: 'path/to/some/file.js' },
-    create: { require: 'path/to/some/file.js' }
-  }
+    create: { require: 'path/to/some/file.js' } }
   ```
   _Invalid values for keys: search and create (must be a string that matches the key of a registered search or create)_
 
@@ -1744,37 +1604,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    searchOrCreateWidgets: {
-      key: 'searchOrCreateWidgets',
-      display: {
-        label: 'Search or Create Widgets',
-        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-        important: true,
-        hidden: false
-      },
-      search: 'searchWidgets',
-      create: 'createWidget'
-    }
-  }
+  { searchOrCreateWidgets:
+     { key: 'searchOrCreateWidgets',
+       display:
+        { label: 'Search or Create Widgets',
+          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+          important: true,
+          hidden: false },
+       search: 'searchWidgets',
+       create: 'createWidget' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    searchOrCreateWidgets: {
-      key: 'socWidgets',
-      display: {
-        label: 'Search or Create Widgets',
-        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-        important: true,
-        hidden: false
-      },
-      search: 'searchWidgets',
-      create: 'createWidget'
-    }
-  }
+  { searchOrCreateWidgets:
+     { key: 'socWidgets',
+       display:
+        { label: 'Search or Create Widgets',
+          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+          important: true,
+          hidden: false },
+       search: 'searchWidgets',
+       create: 'createWidget' } }
   ```
   _Key must match the key of the associated /SearchOrCreateSchema_
 
@@ -1801,36 +1653,26 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } }
-  }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
-    display: {
-      label: 'Find a Recipe',
-      description: 'Search for recipe by cuisine style.',
-      hidden: true
-    },
-    operation: { perform: '$func$2$f$' }
-  }
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+    operation: { perform: '$func$2$f$' } }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  {
-    key: 'recipe',
+  { key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' }
-  }
+    operation: { perform: '$func$2$f$' } }
   ```
   _Missing required key in operation: sample. Note - this is valid if the associated resource has defined a sample._
 
@@ -1854,35 +1696,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    recipe: {
-      key: 'recipe',
-      noun: 'Recipe',
-      display: {
-        label: 'Find a Recipe',
-        description: 'Search for recipe by cuisine style.',
-        hidden: true
-      },
-      operation: { perform: '$func$2$f$' }
-    }
-  }
+  { recipe:
+     { key: 'recipe',
+       noun: 'Recipe',
+       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+       operation: { perform: '$func$2$f$' } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    searchRecipe: {
-      key: 'recipe',
-      noun: 'Recipe',
-      display: {
-        label: 'Find a Recipe',
-        description: 'Search for recipe by cuisine style.',
-        hidden: true
-      },
-      operation: { perform: '$func$2$f$' }
-    }
-  }
+  { searchRecipe:
+     { key: 'recipe',
+       noun: 'Recipe',
+       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
+       operation: { perform: '$func$2$f$' } } }
   ```
   _Key must match the key of the associated /SearchSchema_
 
@@ -1909,35 +1737,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-  }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
   ```
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
-    display: {
-      label: 'New Recipe',
-      description: 'Triggers when a new recipe is added.',
-      hidden: true
-    },
-    operation: { type: 'polling', perform: '$func$0$f$' }
-  }
+    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
+    operation: { type: 'polling', perform: '$func$0$f$' } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    key: 'new_recipe',
+  { key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' }
-  }
+    operation: { perform: '$func$0$f$' } }
   ```
   _Missing required key from operation: sample. Note - this is valid if the Recipe resource has defined a sample._
 
@@ -1961,27 +1779,21 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  {
-    newRecipe: {
-      key: 'newRecipe',
-      noun: 'Recipe',
-      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-    }
-  }
+  { newRecipe:
+     { key: 'newRecipe',
+       noun: 'Recipe',
+       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
   ```
 
 #### Anti-Examples
 
 * ```
-  {
-    newRecipe: {
-      key: 'new_recipe',
-      noun: 'Recipe',
-      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
-    }
-  }
+  { newRecipe:
+     { key: 'new_recipe',
+       noun: 'Recipe',
+       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
   ```
   _Key must match the key on the associated /TriggerSchema_
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -215,16 +215,20 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { getRequestToken: { require: 'some/path/to/file.js' },
+  {
+    getRequestToken: { require: 'some/path/to/file.js' },
     authorizeUrl: { require: 'some/path/to/file2.js' },
-    getAccessToken: { require: 'some/path/to/file3.js' } }
+    getAccessToken: { require: 'some/path/to/file3.js' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { getRequestToken: { require: 'some/path/to/file.js' },
-    authorizeUrl: { require: 'some/path/to/file2.js' } }
+  {
+    getRequestToken: { require: 'some/path/to/file.js' },
+    authorizeUrl: { require: 'some/path/to/file2.js' }
+  }
   ```
   _Missing required key._
 
@@ -253,16 +257,20 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { authorizeUrl: { require: 'some/path/to/file.js' },
-    getAccessToken: { require: 'some/path/to/file2.js' } }
+  {
+    authorizeUrl: { require: 'some/path/to/file.js' },
+    getAccessToken: { require: 'some/path/to/file2.js' }
+  }
   ```
 * ```
-  { authorizeUrl: { require: 'some/path/to/file.js' },
+  {
+    authorizeUrl: { require: 'some/path/to/file.js' },
     getAccessToken: { require: 'some/path/to/file2.js' },
     refreshAccessToken: { require: 'some/path/to/file3.js' },
     codeParam: 'unique_code',
     scope: 'read/write',
-    autoRefresh: true }
+    autoRefresh: true
+  }
   ```
 
 #### Anti-Examples
@@ -424,11 +432,13 @@ Key | Required | Type | Description
 * `{ hidden: true }`
 * `{ label: 'New Thing', description: 'Gets a new thing for you.' }`
 * ```
-  { label: 'New Thing',
+  {
+    label: 'New Thing',
     description: 'Gets a new thing for you.',
     directions: 'This is how you use the thing.',
     hidden: false,
-    important: true }
+    important: true
+  }
   ```
 
 #### Anti-Examples
@@ -466,22 +476,26 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { type: 'hook',
+  {
+    type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
     performUnsubscribe: { require: 'some/path/to/file4.js' },
-    sample: { id: 42, name: 'Hooli' } }
+    sample: { id: 42, name: 'Hooli' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { type: 'hook',
+  {
+    type: 'hook',
     perform: { require: 'some/path/to/file.js' },
     performList: { require: 'some/path/to/file2.js' },
     performSubscribe: { require: 'some/path/to/file3.js' },
-    performUnsubscribe: { require: 'some/path/to/file4.js' } }
+    performUnsubscribe: { require: 'some/path/to/file4.js' }
+  }
   ```
   _Missing required key: sample. Note - This is only invalid if `display` is not explicitly set to true and if it does not belong to a resource that has a sample._
 
@@ -568,19 +582,24 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'recipes',
+  {
+    key: 'recipes',
     noun: 'Recipes',
     display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-    operation:
-     { perform: '$func$0$f$',
-       sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } }
+    operation: {
+      perform: '$func$0$f$',
+      sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get User', description: 'Retrieve a user.' },
-    operation: { description: 'Define how this search method will work.' } }
+  {
+    display: { label: 'Get User', description: 'Retrieve a user.' },
+    operation: { description: 'Define how this search method will work.' }
+  }
   ```
   _Missing required keys: key and noun_
 
@@ -604,25 +623,33 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { recipes:
-     { key: 'recipes',
-       noun: 'Recipes',
-       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-       operation:
-        { perform: '$func$0$f$',
-          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
+  {
+    recipes: {
+      key: 'recipes',
+      noun: 'Recipes',
+      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+      operation: {
+        perform: '$func$0$f$',
+        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { readRecipes:
-     { key: 'recipes',
-       noun: 'Recipes',
-       display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
-       operation:
-        { perform: '$func$0$f$',
-          sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' } } } }
+  {
+    readRecipes: {
+      key: 'recipes',
+      noun: 'Recipes',
+      display: { label: 'Recipes', description: 'A Read that lets Zapier fetch all recipes.' },
+      operation: {
+        perform: '$func$0$f$',
+        sample: { id: 1, firstName: 'Walter', lastName: 'Sobchak', occupation: 'Bowler' }
+      }
+    }
+  }
   ```
   _Key must match the key of the associated BulkReadSchema_
 
@@ -649,39 +676,49 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 }, shouldLock: true }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$', shouldLock: 'yes' } }
+    operation: { perform: '$func$2$f$', shouldLock: 'yes' }
+  }
   ```
   _Invalid value for key on operation: shouldLock_
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing required key on operation: sample. Note - this is valid if the resource has defined a sample._
 
@@ -705,36 +742,48 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { createRecipe:
-     { key: 'createRecipe',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    createRecipe: {
+      key: 'createRecipe',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
 * ```
-  { Create_Recipe_01:
-     { key: 'Create_Recipe_01',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    Create_Recipe_01: {
+      key: 'Create_Recipe_01',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { '01_Create_Recipe':
-     { key: '01_Create_Recipe',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    '01_Create_Recipe': {
+      key: '01_Create_Recipe',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
   _Key must start with a letter_
 * ```
-  { Create_Recipe:
-     { key: 'createRecipe',
-       noun: 'Recipe',
-       display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
-       operation: { perform: '$func$2$f$', sample: { id: 1 } } } }
+  {
+    Create_Recipe: {
+      key: 'createRecipe',
+      noun: 'Recipe',
+      display: { label: 'Create Recipe', description: 'Creates a new recipe.' },
+      operation: { perform: '$func$2$f$', sample: { id: 1 } }
+    }
+  }
   ```
   _Key must match the key field in CreateSchema_
 
@@ -1213,19 +1262,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Create Tag',
+      description: 'Create a new Tag in your account.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: { label: 'Create Tag', description: 'Create a new Tag in your account.' },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1250,19 +1309,25 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' }, sample: { id: 385, name: 'proactive enable ROI' } }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { perform: { url: '$func$0$f$' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { perform: { url: '$func$0$f$' } }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1287,19 +1352,29 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$', sample: { id: 385, name: 'proactive enable ROI' } } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: {
+      type: 'hook',
+      perform: '$func$0$f$',
+      sample: { id: 385, name: 'proactive enable ROI' }
+    }
+  }
   ```
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-    operation: { type: 'hook', perform: '$func$0$f$' } }
+  {
+    display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+    operation: { type: 'hook', perform: '$func$0$f$' }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1324,24 +1399,38 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation:
-     { perform: { url: 'https://fake-crm.getsandbox.com/users' },
-       sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: {
+      perform: { url: 'https://fake-crm.getsandbox.com/users' },
+      sample: { id: 49, name: 'Veronica Kuhn', email: 'veronica.kuhn@company.com' }
+    }
+  }
   ```
 * ```
-  { display:
-     { label: 'New User',
-       description: 'Trigger when a new User is created in your account.',
-       hidden: true },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.',
+      hidden: true
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { display: { label: 'New User', description: 'Trigger when a new User is created in your account.' },
-    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } } }
+  {
+    display: {
+      label: 'New User',
+      description: 'Trigger when a new User is created in your account.'
+    },
+    operation: { perform: { url: 'https://fake-crm.getsandbox.com/users' } }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1366,21 +1455,31 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+  {
+    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+  {
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1412,43 +1511,61 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
     sample: { id: 385, name: 'proactive enable ROI' },
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } },
-    list:
-     { display: { label: 'New Tag', description: 'Trigger when a new Tag is created in your account.' },
-       operation:
-        { perform: { url: 'https://fake-crm.getsandbox.com/tags' },
-          sample: { id: 385, name: 'proactive enable ROI' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.', hidden: true },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    },
+    list: {
+      display: {
+        label: 'New Tag',
+        description: 'Trigger when a new Tag is created in your account.'
+      },
+      operation: {
+        perform: { url: 'https://fake-crm.getsandbox.com/tags' },
+        sample: { id: 385, name: 'proactive enable ROI' }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'tag',
+  {
+    key: 'tag',
     noun: 'Tag',
-    get:
-     { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-       operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } }
+    get: {
+      display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+      operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+    }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1472,36 +1589,50 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { tag:
-     { key: 'tag',
-       noun: 'Tag',
-       get:
-        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-          operation:
-           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-             sample: { id: 385, name: 'proactive enable ROI' } } } } }
+  {
+    tag: {
+      key: 'tag',
+      noun: 'Tag',
+      get: {
+        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+        operation: {
+          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' }
+        }
+      }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { getTag:
-     { key: 'tag',
-       noun: 'Tag',
-       get:
-        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-          operation:
-           { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
-             sample: { id: 385, name: 'proactive enable ROI' } } } } }
+  {
+    getTag: {
+      key: 'tag',
+      noun: 'Tag',
+      get: {
+        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+        operation: {
+          perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' },
+          sample: { id: 385, name: 'proactive enable ROI' }
+        }
+      }
+    }
+  }
   ```
   _Key does not match key for associated /ResourceSchema_
 * ```
-  { tag:
-     { key: 'tag',
-       noun: 'Tag',
-       get:
-        { display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
-          operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } } } } }
+  {
+    tag: {
+      key: 'tag',
+      noun: 'Tag',
+      get: {
+        display: { label: 'Get Tag by ID', description: 'Grab a specific Tag by ID.' },
+        operation: { perform: { url: 'https://fake-crm.getsandbox.com/tags/{{inputData.id}}' } }
+      }
+    }
+  }
   ```
   _Missing key from operation: sample. Note – this is valid if the resource has defined a sample._
 
@@ -1549,38 +1680,47 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'searchOrCreateWidgets',
-    display:
-     { label: 'Search or Create Widgets',
-       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-       important: true,
-       hidden: false },
+  {
+    key: 'searchOrCreateWidgets',
+    display: {
+      label: 'Search or Create Widgets',
+      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+      important: true,
+      hidden: false
+    },
     search: 'searchWidgets',
-    create: 'createWidget' }
+    create: 'createWidget'
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: '01_Search_or_Create_Widgets',
-    display:
-     { label: 'Search or Create Widgets',
-       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-       important: true,
-       hidden: false },
+  {
+    key: '01_Search_or_Create_Widgets',
+    display: {
+      label: 'Search or Create Widgets',
+      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+      important: true,
+      hidden: false
+    },
     search: 'searchWidgets',
-    create: 'createWidget' }
+    create: 'createWidget'
+  }
   ```
   _Invalid value for key: key (must start with a letter)_
 * ```
-  { key: 'searchOrCreateWidgets',
-    display:
-     { label: 'Search or Create Widgets',
-       description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-       important: true,
-       hidden: false },
+  {
+    key: 'searchOrCreateWidgets',
+    display: {
+      label: 'Search or Create Widgets',
+      description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+      important: true,
+      hidden: false
+    },
     search: { require: 'path/to/some/file.js' },
-    create: { require: 'path/to/some/file.js' } }
+    create: { require: 'path/to/some/file.js' }
+  }
   ```
   _Invalid values for keys: search and create (must be a string that matches the key of a registered search or create)_
 
@@ -1604,29 +1744,37 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { searchOrCreateWidgets:
-     { key: 'searchOrCreateWidgets',
-       display:
-        { label: 'Search or Create Widgets',
-          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-          important: true,
-          hidden: false },
-       search: 'searchWidgets',
-       create: 'createWidget' } }
+  {
+    searchOrCreateWidgets: {
+      key: 'searchOrCreateWidgets',
+      display: {
+        label: 'Search or Create Widgets',
+        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+        important: true,
+        hidden: false
+      },
+      search: 'searchWidgets',
+      create: 'createWidget'
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { searchOrCreateWidgets:
-     { key: 'socWidgets',
-       display:
-        { label: 'Search or Create Widgets',
-          description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
-          important: true,
-          hidden: false },
-       search: 'searchWidgets',
-       create: 'createWidget' } }
+  {
+    searchOrCreateWidgets: {
+      key: 'socWidgets',
+      display: {
+        label: 'Search or Create Widgets',
+        description: 'Searches for a widget matching the provided query, or creates one if it does not exist.',
+        important: true,
+        hidden: false
+      },
+      search: 'searchWidgets',
+      create: 'createWidget'
+    }
+  }
   ```
   _Key must match the key of the associated /SearchOrCreateSchema_
 
@@ -1653,26 +1801,36 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$', sample: { id: 1 } } }
+    operation: { perform: '$func$2$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
-    display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-    operation: { perform: '$func$2$f$' } }
+    display: {
+      label: 'Find a Recipe',
+      description: 'Search for recipe by cuisine style.',
+      hidden: true
+    },
+    operation: { perform: '$func$2$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * `'abc'` - _Must be an object_
 * ```
-  { key: 'recipe',
+  {
+    key: 'recipe',
     noun: 'Recipe',
     display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.' },
-    operation: { perform: '$func$2$f$' } }
+    operation: { perform: '$func$2$f$' }
+  }
   ```
   _Missing required key in operation: sample. Note - this is valid if the associated resource has defined a sample._
 
@@ -1696,21 +1854,35 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { recipe:
-     { key: 'recipe',
-       noun: 'Recipe',
-       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-       operation: { perform: '$func$2$f$' } } }
+  {
+    recipe: {
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Find a Recipe',
+        description: 'Search for recipe by cuisine style.',
+        hidden: true
+      },
+      operation: { perform: '$func$2$f$' }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { searchRecipe:
-     { key: 'recipe',
-       noun: 'Recipe',
-       display: { label: 'Find a Recipe', description: 'Search for recipe by cuisine style.', hidden: true },
-       operation: { perform: '$func$2$f$' } } }
+  {
+    searchRecipe: {
+      key: 'recipe',
+      noun: 'Recipe',
+      display: {
+        label: 'Find a Recipe',
+        description: 'Search for recipe by cuisine style.',
+        hidden: true
+      },
+      operation: { perform: '$func$2$f$' }
+    }
+  }
   ```
   _Key must match the key of the associated /SearchSchema_
 
@@ -1737,25 +1909,35 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } }
+    operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+  }
   ```
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
-    display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.', hidden: true },
-    operation: { type: 'polling', perform: '$func$0$f$' } }
+    display: {
+      label: 'New Recipe',
+      description: 'Triggers when a new recipe is added.',
+      hidden: true
+    },
+    operation: { type: 'polling', perform: '$func$0$f$' }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { key: 'new_recipe',
+  {
+    key: 'new_recipe',
     noun: 'Recipe',
     display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-    operation: { perform: '$func$0$f$' } }
+    operation: { perform: '$func$0$f$' }
+  }
   ```
   _Missing required key from operation: sample. Note - this is valid if the Recipe resource has defined a sample._
 
@@ -1779,21 +1961,27 @@ Key | Required | Type | Description
 #### Examples
 
 * ```
-  { newRecipe:
-     { key: 'newRecipe',
-       noun: 'Recipe',
-       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
+  {
+    newRecipe: {
+      key: 'newRecipe',
+      noun: 'Recipe',
+      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+    }
+  }
   ```
 
 #### Anti-Examples
 
 * ```
-  { newRecipe:
-     { key: 'new_recipe',
-       noun: 'Recipe',
-       display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
-       operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } } } }
+  {
+    newRecipe: {
+      key: 'new_recipe',
+      noun: 'Recipe',
+      display: { label: 'New Recipe', description: 'Triggers when a new recipe is added.' },
+      operation: { type: 'polling', perform: '$func$0$f$', sample: { id: 1 } }
+    }
+  }
   ```
   _Key must match the key on the associated /TriggerSchema_
 


### PR DESCRIPTION
Adds a note about how headers are (re)formatted in the bundle, so that devs no longer need to guess/test.
Relevant to #290 - we may improve this in the future, in which case this addition would need to be removed.