### PR TITLE
feat(core): TN-169 Updates the app tester to support hook with canPaginate for performList

### DIFF
--- a/packages/core/src/tools/create-app-tester.js
+++ b/packages/core/src/tools/create-app-tester.js
@@ -3,32 +3,9 @@
 const createLambdaHandler = require('./create-lambda-handler');
 const resolveMethodPath = require('./resolve-method-path');
 const ZapierPromise = require('./promise');
-const { get, isFunction } = require('lodash');
+const { isFunction } = require('lodash');
 const { genId } = require('./data');
-
-// this is (annoyingly) mirrored in cli/api_base, so that test functions only
-// have a storeKey when canPaginate is true. otherwise, a test would work but a
-// poll on site would fail. this is only used in test handlers
-
-// there are 2 places you can put a method that can interact with cursors:
-// triggers.contact.operation.perform, if it's a poll trigger
-// resources.contact.list.operation.perform if it's a resource
-// schema doesn't currently allow cursor use on hook trigger `performList`, so we don't need to account for it
-const shouldPaginate = (appRaw, method) => {
-  const methodParts = method.split('.');
-
-  if (
-    method.endsWith('perform') &&
-    ((methodParts[0] === 'resources' && methodParts[2] === 'list') ||
-      methodParts[0] === 'triggers' ||
-      methodParts[0] === 'bulkReads')
-  ) {
-    methodParts.pop();
-    return get(appRaw, [...methodParts, 'canPaginate']);
-  }
-
-  return false;
-};
+const { shouldPaginate } = require('./should-paginate');
 
 // Convert a app handler to promise for convenience.
 const promisifyHandler = (handler) => {

--- a/packages/core/src/tools/should-paginate.js
+++ b/packages/core/src/tools/should-paginate.js
@@ -16,7 +16,11 @@ const shouldPaginate = (appRaw, method) => {
   const operation = get(appRaw, methodParts);
 
   if (methodParts[0] === 'triggers') {
-    if (operation.type === 'poll' && methodName === 'perform') {
+    // Polling operations may not specify type
+    if (
+      ['polling', undefined].includes(operation.type) &&
+      methodName === 'perform'
+    ) {
       return !!operation.canPaginate;
     }
 

--- a/packages/core/src/tools/should-paginate.js
+++ b/packages/core/src/tools/should-paginate.js
@@ -4,10 +4,12 @@ const { get } = require('lodash');
 // have a storeKey when canPaginate is true. otherwise, a test would work but a
 // poll on site would fail. this is only used in test handlers
 
-// there are 2 places you can put a method that can interact with cursors:
+// there are 4 places you can put a method that can interact with cursors:
 // triggers.contact.operation.perform, if it's a poll trigger
+// triggers.contact.operation.performList, if it's a hook trigger
 // resources.contact.list.operation.perform if it's a resource
-// schema doesn't currently allow cursor use on hook trigger `performList`, so we don't need to account for it
+// resources.contact.hook.operation.performList if it's a resource
+
 const shouldPaginate = (appRaw, method) => {
   const methodParts = method.split('.');
   const methodName = methodParts.pop();

--- a/packages/core/src/tools/should-paginate.js
+++ b/packages/core/src/tools/should-paginate.js
@@ -1,0 +1,41 @@
+const { get } = require('lodash');
+
+// this is (annoyingly) mirrored in cli/api_base, so that test functions only
+// have a storeKey when canPaginate is true. otherwise, a test would work but a
+// poll on site would fail. this is only used in test handlers
+
+// there are 2 places you can put a method that can interact with cursors:
+// triggers.contact.operation.perform, if it's a poll trigger
+// resources.contact.list.operation.perform if it's a resource
+// schema doesn't currently allow cursor use on hook trigger `performList`, so we don't need to account for it
+const shouldPaginate = (appRaw, method) => {
+  const methodParts = method.split('.');
+  const methodName = methodParts.pop();
+  const operation = get(appRaw, methodParts);
+
+  if (methodParts[0] === 'triggers') {
+    if (operation.type === 'poll' && methodName === 'perform') {
+      return !!operation.canPaginate;
+    }
+
+    if (operation.type === 'hook' && methodName === 'performList') {
+      return !!operation.canPaginate;
+    }
+  }
+
+  if (methodParts[0] === 'resources') {
+    if (methodParts[2] === 'list' && methodName === 'perform') {
+      return !!operation.canPaginate;
+    }
+
+    if (methodParts[2] === 'hook' && methodName === 'performList') {
+      return !!operation.canPaginate;
+    }
+  }
+
+  return false;
+};
+
+module.exports = {
+  shouldPaginate,
+};

--- a/packages/core/test/test-should-paginate.js
+++ b/packages/core/test/test-should-paginate.js
@@ -11,7 +11,7 @@ describe('shouldPaginate', () => {
         triggers: {
           trigger: {
             operation: {
-              type: 'poll',
+              type: 'polling',
               perform: '$func$2$f$',
               canPaginate: true,
             },
@@ -28,7 +28,38 @@ describe('shouldPaginate', () => {
         triggers: {
           trigger: {
             operation: {
-              type: 'poll',
+              type: 'polling',
+              perform: '$func$2$f$',
+            },
+          },
+        },
+      },
+      'triggers.trigger.operation.perform'
+    ).should.eql(false);
+  });
+
+  it('should paginate a trigger without type with canPaginate', () => {
+    shouldPaginate(
+      {
+        triggers: {
+          trigger: {
+            operation: {
+              perform: '$func$2$f$',
+              canPaginate: true,
+            },
+          },
+        },
+      },
+      'triggers.trigger.operation.perform'
+    ).should.eql(true);
+  });
+
+  it('should not paginate a trigger without type without canPaginate', () => {
+    shouldPaginate(
+      {
+        triggers: {
+          trigger: {
+            operation: {
               perform: '$func$2$f$',
             },
           },

--- a/packages/core/test/test-should-paginate.js
+++ b/packages/core/test/test-should-paginate.js
@@ -1,0 +1,167 @@
+'use strict';
+
+require('should');
+
+const { shouldPaginate } = require('../src/tools/should-paginate');
+
+describe('shouldPaginate', () => {
+  it('should paginate a polling trigger with canPaginate', () => {
+    shouldPaginate(
+      {
+        triggers: {
+          trigger: {
+            operation: {
+              type: 'poll',
+              perform: '$func$2$f$',
+              canPaginate: true,
+            },
+          },
+        },
+      },
+      'triggers.trigger.operation.perform'
+    ).should.eql(true);
+  });
+
+  it('should not paginate a polling trigger without canPaginate', () => {
+    shouldPaginate(
+      {
+        triggers: {
+          trigger: {
+            operation: {
+              type: 'poll',
+              perform: '$func$2$f$',
+            },
+          },
+        },
+      },
+      'triggers.trigger.operation.perform'
+    ).should.eql(false);
+  });
+
+  it('should paginate a hook trigger with canPaginate for performList only', () => {
+    const definition = {
+      triggers: {
+        trigger: {
+          operation: {
+            type: 'hook',
+            perform: '$func$2$f$',
+            performList: '$func$2$f$',
+            canPaginate: true,
+          },
+        },
+      },
+    };
+    shouldPaginate(
+      definition,
+      'triggers.trigger.operation.perform'
+    ).should.equal(false);
+    shouldPaginate(
+      definition,
+      'triggers.trigger.operation.performList'
+    ).should.equal(true);
+  });
+
+  it('should not paginate a hook trigger without canPaginate', () => {
+    const definition = {
+      triggers: {
+        trigger: {
+          operation: {
+            type: 'hook',
+            perform: '$func$2$f$',
+            performList: '$func$2$f$',
+          },
+        },
+      },
+    };
+    shouldPaginate(
+      definition,
+      'triggers.trigger.operation.perform'
+    ).should.equal(false);
+    shouldPaginate(
+      definition,
+      'triggers.trigger.operation.performList'
+    ).should.equal(false);
+  });
+
+  it('should paginate a list resource with canPaginate', () => {
+    shouldPaginate(
+      {
+        resources: {
+          resource: {
+            list: {
+              operation: {
+                perform: '$func$2$f',
+                canPaginate: true,
+              },
+            },
+          },
+        },
+      },
+      'resources.resource.list.operation.perform'
+    ).should.eql(true);
+  });
+
+  it('should not paginate a list resource without canPaginate', () => {
+    shouldPaginate(
+      {
+        resources: {
+          resource: {
+            list: {
+              operation: {
+                perform: '$func$2$f',
+              },
+            },
+          },
+        },
+      },
+      'resources.resource.list.operation.perform'
+    ).should.eql(false);
+  });
+
+  it('should paginate a hook resource with canPaginate for performList only', () => {
+    const definition = {
+      resources: {
+        resource: {
+          hook: {
+            operation: {
+              perform: '$func$2$f$',
+              performList: '$func$2$f$',
+              canPaginate: true,
+            },
+          },
+        },
+      },
+    };
+    shouldPaginate(
+      definition,
+      'resources.resource.hook.operation.perform'
+    ).should.equal(false);
+    shouldPaginate(
+      definition,
+      'resources.resource.hook.operation.performList'
+    ).should.equal(true);
+  });
+
+  it('should not paginate a hook resource without canPaginate', () => {
+    const definition = {
+      resources: {
+        resource: {
+          hook: {
+            operation: {
+              perform: '$func$2$f$',
+              performList: '$func$2$f$',
+            },
+          },
+        },
+      },
+    };
+    shouldPaginate(
+      definition,
+      'resources.resource.hook.operation.perform'
+    ).should.equal(false);
+    shouldPaginate(
+      definition,
+      'resources.resource.hook.operation.performList'
+    ).should.equal(false);
+  });
+});


### PR DESCRIPTION
In order to make a CLI hook trigger compatible with Transfer, it needs to be able to set `canPaginate` for its `performList` method.  This PR updates the app tester to validate such a schema.

I wasn't sure whether `create-app-tester` is something third party devs might import, or if it's only used internally by us, but to be safe I refactored `shouldPaginate` into its own file rather than refactor `create-app-tester.js`'s module.exports.