### PR TITLE
PDE-2636 fix(tests): failing smoke tests on package size

### DIFF
--- a/packages/cli/src/utils/npm.js
+++ b/packages/cli/src/utils/npm.js
@@ -11,9 +11,7 @@ const getPackageLatestVersion = async (name) => {
 
 const getPackageSize = async (name, version) => {
   const baseUrl = `${BASE_URL}/${name}`;
-  const res = await fetch(`${baseUrl}/-/${name}-${version}.tgz`, {
-    method: 'HEAD',
-  });
+  const res = await fetch(`${baseUrl}/-/${name}-${version}.tgz`);
   return res.headers.get('content-length');
 };
 

--- a/packages/core/smoke-test/smoke-test.js
+++ b/packages/core/smoke-test/smoke-test.js
@@ -217,12 +217,7 @@ describe('smoke tests - setup will take some time', () => {
     const packageInfo = await res.json();
     const latestVersion = packageInfo['dist-tags'].latest;
 
-    res = await fetch(
-      `${baseUrl}/-/zapier-platform-core-${latestVersion}.tgz`,
-      {
-        method: 'HEAD',
-      }
-    );
+    res = await fetch(`${baseUrl}/-/zapier-platform-core-${latestVersion}.tgz`);
     const baselineSize = res.headers.get('content-length');
     const newSize = fs.statSync(context.corePackage.path).size;
     newSize.should.be.within(baselineSize * 0.7, baselineSize * 1.3);

--- a/packages/schema/smoke-test/smoke-test.js
+++ b/packages/schema/smoke-test/smoke-test.js
@@ -86,10 +86,7 @@ describe('smoke tests - setup will take some time', () => {
     const latestVersion = packageInfo['dist-tags'].latest;
 
     res = await fetch(
-      `${baseUrl}/-/zapier-platform-schema-${latestVersion}.tgz`,
-      {
-        method: 'HEAD',
-      }
+      `${baseUrl}/-/zapier-platform-schema-${latestVersion}.tgz`
     );
     const baselineSize = res.headers.get('content-length');
     const newSize = fs.statSync(context.package.path).size;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
NPM registry seems to no longer provide a `content-length` header for `HEAD` requests. This broke some of our smoke tests where we send a `HEAD` request to NPM registry to get the package size.

Here's an example failed build on Travis: https://app.travis-ci.com/github/zapier/zapier-platform/builds/235320597

This PR fixes the issue by replacing the `HEAD` request with a `GET` request.