### PR TITLE
PDE-2666 fix(legacy-scripting-runner): polling trigger should coerce a "null" response to an empty array

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 3.7.18 (unreleased)
+## 3.8.0 (unreleased)
 
+- :tada: Include `isBulkRead` to `bundle.meta` ([#414](https://github.com/zapier/zapier-platform/pull/414))
 - :bug: Fix `Cannot read property 'errors' of undefined` on auth refresh ([#410](https://github.com/zapier/zapier-platform/pull/410))
+- :bug: Fix `JSON results array could not be located` when a trigger response is "null" ([#415](https://github.com/zapier/zapier-platform/pull/415))
 
 ## 3.7.17
 

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -472,6 +472,8 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
             }
           }
         }
+      } else if (!result) {
+        return [];
       }
       throw new Error('JSON results array could not be located.');
     } else if (type.startsWith('object-')) {

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -623,6 +623,26 @@ describe('Integration Test', () => {
       });
     });
 
+    it('scriptingless, null response', () => {
+      if (!nock.isActive()) {
+        nock.activate();
+      }
+      // Mock the response with a string 'null'
+      nock(AUTH_JSON_SERVER_URL).get('/movies').reply(200, 'null');
+
+      const appDef = _.cloneDeep(appDefinition);
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        should.deepEqual(output.results, []);
+      });
+    });
+
     it('KEY_poll', () => {
       const input = createTestInput(
         compiledApp,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

When calling a scriptless polling trigger, if the response body is a string "null", legacy-scripting-runner should make it an empty array instead of throwing an error saying `JSON results array could not be located`.