### PR TITLE
PDE-2704 fix(legacy-scripting-runner): add support for `z.request({ json: true })`

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.1 (unreleased)
+
+- :bug: Add support for `z.reqeust({ json: true, body: {...} })` ([#418](https://github.com/zapier/zapier-platform/pull/418))
+
 ## 3.8.0
 
 - :tada: Include `isBulkRead` to `bundle.meta` ([#414](https://github.com/zapier/zapier-platform/pull/414))

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -678,6 +678,18 @@ const legacyScriptingSource = `
         });
       },
 
+      movie_write_json_true: function(bundle) {
+        var data = z.JSON.parse(bundle.request.data);
+        data.hello = 'world';
+        var response = z.request({
+          method: 'POST',
+          url: '${HTTPBIN_URL}/post',
+          json: true,
+          body: data
+        });
+        return response.content;
+      },
+
       // To be replaced with 'movie_pre_custom_action_fields' at runtime
       movie_pre_custom_action_fields_disabled: function(bundle) {
         bundle.request.url += 's';

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2663,6 +2663,25 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_write, z.request({ json: true })', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_write_json_true',
+        'movie_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        const echoed = output.results;
+        should.equal(echoed.json.hello, 'world');
+      });
+    });
+
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.inputFieldsUrl += 's';

--- a/packages/legacy-scripting-runner/zfactory.js
+++ b/packages/legacy-scripting-runner/zfactory.js
@@ -24,8 +24,12 @@ const convertBundleRequest = (bundleOrBundleRequest) => {
     };
   }
 
-  bundleRequest.qs = bundleRequest.params || {};
-  bundleRequest.body = bundleRequest.data || '';
+  if (!bundleRequest.qs && bundleRequest.params) {
+    bundleRequest.qs = bundleRequest.params;
+  }
+  if (!bundleRequest.body && bundleRequest.data) {
+    bundleRequest.body = bundleRequest.data;
+  }
 
   delete bundleRequest.params;
   delete bundleRequest.data;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

In Web Builder scripting, developers could pass `json: true` to `z.request()`:

```js
var Zap = {
  KEY_write: function(bundle) {
       var data = z.JSON.parse(bundle.request.data);
       data.hello = 'world';
       var response = z.request({
           method: 'POST',
           url: 'https://httpbin.zapier-tooling.com/post',
           json: true,
           body: data  // <- an object
       });
       return response.content;  // <- an object
  }
};
```

The returned result should be an object containing `{"json": {"hello": "world"}}`. This PR fixes legacy-scripting-runner to recreate this behavior.