### PR TITLE
PDE-2751 fix(legacy-scripting-runner): Empty `request.data` should send an empty request body instead of an empty object

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.8.1 (unreleased)
 
 - :bug: Add support for `z.reqeust({ json: true, body: {...} })` ([#418](https://github.com/zapier/zapier-platform/pull/418))
+- :bug: Empty `request.data` should send an empty request body instead of an empty object ([#423](https://github.com/zapier/zapier-platform/pull/423))
 
 ## 3.8.0
 

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -203,7 +203,7 @@ const parseFinalResult = async (result, event) => {
       } catch (e) {
         result.body = result.data;
       }
-    } else {
+    } else if (result.data === null || result.data === '') {
       result.body = '';
     }
     return result;

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -196,13 +196,15 @@ const parseFinalResult = async (result, event) => {
       return addFilesToRequestBodyFromPreResult(result, event);
     }
 
-    if (result.data !== undefined) {
+    if (result.data) {
       // Old request was .data (string), new is .body (object), which matters for _pre
       try {
-        result.body = JSON.parse(result.data || '{}');
+        result.body = JSON.parse(result.data);
       } catch (e) {
         result.body = result.data;
       }
+    } else {
+      result.body = '';
     }
     return result;
   }

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -642,6 +642,12 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_write_request_data_empty_string: function(bundle) {
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/echo';
+        bundle.request.data = '';
+        return bundle.request;
+      },
+
       movie_write_default_headers: function(bundle) {
         bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -294,7 +294,7 @@ const legacyScriptingSource = `
 
       movie_pre_poll_GET_with_body: function(bundle) {
         // Use postman-echo because httpbin doesn't echo a GET request's body
-        bundle.request.url = 'https://postman-echo.com/get';
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/echo';
         bundle.request.method = 'GET';
         bundle.request.data = JSON.stringify({
           name: 'Luke Skywalker'
@@ -313,7 +313,7 @@ const legacyScriptingSource = `
       },
 
       movie_pre_poll_env_var: function(bundle) {
-        bundle.request.url = 'https://{{process.env.SECRET_HTTPBIN_URL}}/get';
+        bundle.request.url = '{{process.env.SECRET_HTTPBIN_URL}}/get';
         return bundle.request;
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2258,6 +2258,27 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_write, request.data is an empty string', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_pre_write_request_data_empty_string',
+          'movie_pre_write'
+        );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        const echoed = output.results;
+        should.equal(echoed.textBody, '');
+      });
+    });
+
     it('KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.url += 's';

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1075,7 +1075,7 @@ describe('Integration Test', () => {
       );
       return _app(input).then((output) => {
         const echoed = output.results[0];
-        should.equal(echoed.args.name, 'Luke Skywalker');
+        should.equal(echoed.textBody, '{"name":"Luke Skywalker"}');
       });
     });
 
@@ -1128,7 +1128,7 @@ describe('Integration Test', () => {
     });
 
     it('KEY_pre_poll, env in url', () => {
-      process.env.SECRET_HTTPBIN_URL = HTTPBIN_URL.slice(8); // remove the protocol
+      process.env.SECRET_HTTPBIN_URL = HTTPBIN_URL;
 
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
@@ -1148,12 +1148,14 @@ describe('Integration Test', () => {
         'triggers.movie.operation.perform'
       );
 
-      delete process.env.MY_SECRET;
-
-      return _app(input).then((output) => {
-        const result = output.results[0];
-        should.equal(result.url, 'https://httpbin.zapier-tooling.com/get');
-      });
+      return _app(input)
+        .then((output) => {
+          const result = output.results[0];
+          should.equal(result.url, `${HTTPBIN_URL}/get`);
+        })
+        .finally(() => {
+          delete process.env.SECRET_HTTPBIN_URL;
+        });
     });
 
     it('KEY_pre_poll, double headers', () => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Legacy scripting code to reproduce the issue

```js
var Zap = {
  KEY_pre_write: function(bundle) {
    bundle.request.url = 'https://auth-json-server.zapier-staging.com/echo';
    bundle.request.data = '';
    // or bundle.request.data = null;
    return bundle.request;
  }
};
```

## Expected behavior

The request body should be an empty string.

## Current behavior

The request body is JSON-encoded empty object, i.e., `{}`.