### PR TITLE
PDE-2737 fix(legacy-scripting-runner): duplicate headers with session auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,6 @@ jobs:
     - name: "smoke tests - Node 14"
       script: "yarn smoke-test"
       node_js: "14"
-    - stage: "Deploy"
-      script: skip
-      deploy:
-        provider: script
-        script: ./scripts/publish.sh
-        on:
-          tags: true,
-          node: "14"
-        skip_cleanup: true
 notifications:
   email: false
 env:

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 3.8.1 (unreleased)
+## 3.8.1
 
 - :bug: Add support for `z.reqeust({ json: true, body: {...} })` ([#418](https://github.com/zapier/zapier-platform/pull/418))
 - :bug: Empty `request.data` should send an empty request body instead of an empty object ([#423](https://github.com/zapier/zapier-platform/pull/423))
+- :bug: Fix duplicate headers with session auth ([#424](https://github.com/zapier/zapier-platform/pull/424))
 
 ## 3.8.0
 

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1158,7 +1158,7 @@ describe('Integration Test', () => {
         });
     });
 
-    it('KEY_pre_poll, double headers', () => {
+    it('KEY_pre_poll, double headers with api key auth', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
         'movie_pre_poll_double_headers',
@@ -1178,6 +1178,34 @@ describe('Integration Test', () => {
       );
       input.bundle.authData = {
         api_key: 'one',
+      };
+      return _app(input).then((output) => {
+        const echoed = output.results[0];
+        should.deepEqual(echoed.headers['X-Api-Key'], ['three']);
+      });
+    });
+
+    it('KEY_pre_poll, double headers with session auth', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_double_headers',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, sessionAuthConfig);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      input.bundle.authData = {
+        key1: 'only',
+        key2: 'one',
       };
       return _app(input).then((output) => {
         const echoed = output.results[0];

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2040,6 +2040,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('scriptingless perform, session auth', () => {
+      const appDefWithAuth = withAuth(appDefinition, sessionAuthConfig);
+      appDefWithAuth.legacy.creates.movie.operation.url = `${HTTPBIN_URL}/post`;
+      appDefWithAuth.legacy.authentication.mapping['content-type'] =
+        'hello/world';
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      input.bundle.authData = { key1: 'sec', key2: 'ret' };
+      return app(input).then((output) => {
+        const echoed = output.results;
+        // Only one content-type header should be sent
+        should.deepEqual(echoed.headers['Content-Type'], [
+          'application/json; charset=utf-8',
+        ]);
+      });
+    });
+
     it('scriptingless perform, curlies in URL', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       const legacyProps = appDefWithAuth.legacy.creates.movie.operation;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Legacy Web Builder app to reproduce the issue

Session auth in headers with the following auth mapping:

```json
{
  "x-api-key": "{{api_key}}",
  "content-type": "application/json"
}
```

Then run an action with **no scripting**.

## Expected behavior

Only one `content-type: application/json` header should be sent.

## Current behavior

Two duplicate `content-type: application/json` headers are sent.

## Related PRs

Related to the previous fixes with API Key auth:

- https://github.com/zapier/zapier-platform/pull/364
- https://github.com/zapier/zapier-platform/pull/365