### PR TITLE
fix(core): handle nullish values in auth data

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "@zapier/secret-scrubber": "^1.0.2",
+    "@zapier/secret-scrubber": "^1.0.3",
     "bluebird": "3.7.2",
     "content-disposition": "0.5.3",
     "dotenv": "9.0.2",

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -11,7 +11,11 @@ const {
   SAFE_LOG_KEYS,
 } = require('../constants');
 const { unheader } = require('./http');
-const { scrub, findSensitiveValues } = require('@zapier/secret-scrubber');
+const {
+  scrub,
+  findSensitiveValues,
+  recurseExtract,
+} = require('@zapier/secret-scrubber');
 // not really a public function, but it came from here originally
 const { isUrlWithSecrets } = require('@zapier/secret-scrubber/lib/convenience');
 
@@ -101,12 +105,15 @@ const toStdout = (event, msg, data) => {
 
 const buildSensitiveValues = (event, data) => {
   const bundle = event.bundle || {};
-  const authData = Object.values(bundle.authData || {});
+  const authData = bundle.authData || {};
   // for the most part, we should censor all the values from authData
   // the exception is safe urls, which should be filtered out - we want those to be logged
-  const sensitiveAuthData = authData.filter(
-    (item) => !isUrl(item) || isUrlWithSecrets(item)
-  );
+  const sensitiveAuthData = recurseExtract(authData, (key, value) => {
+    if (isUrl(value) && !isUrlWithSecrets(value)) {
+      return false;
+    }
+    return true;
+  });
   return [
     ...sensitiveAuthData,
     ...findSensitiveValues(process.env),

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -384,4 +384,39 @@ describe('logger', () => {
       });
     });
   });
+
+  it('should handle null and nested values', () => {
+    const bundle = {
+      authData: {
+        password: 'hunter2',
+        token_tbd: null,
+        missing_secret: undefined,
+        nested: {
+          password: 'hunter2',
+          token_tbd: null,
+          missing_secret: undefined,
+        },
+      },
+    };
+    const logger = createlogger({ bundle }, options);
+
+    const data = bundle.authData;
+
+    return logger(`200 GET https://example.com/test`, data).then((response) => {
+      response.status.should.eql(200);
+      response.content.json.should.eql({
+        token: options.token,
+        message: '200 GET https://example.com/test',
+        data: {
+          log_type: 'console',
+          password: ':censored:31:0dbc81268a:',
+          // Only safe_url (no basic auth or query params) should be left
+          // uncensored
+          safe_url: 'https://example.com',
+          basic_auth_url: ':censored:27:bad5875ee0:',
+          param_url: ':censored:27:9d59e27abe:',
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
fixes [PDE-2771](https://zapierorg.atlassian.net/browse/PDE-2771)

Secret scrubber only takes a `(string | number)[]`, so we have to filter out nullish values before they go in. Secret scrubber's `recruseExtract` does this, but only if we use it!

Tests won't pass until [zapier/team-developer-platform/secret-scrubber-js!3](https://gitlab.com/zapier/team-developer-platform/secret-scrubber-js/-/merge_requests/3) is merged.