### PR TITLE
SUPPORTESC-214 perf(core): Speed up cleaner.js

### DIFF
--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -45,6 +45,12 @@ const recurseCleanFuncs = (obj, path) => {
 
 // Recurse a nested object replace all instances of keys->vals in the bank.
 const recurseReplaceBank = (obj, bank = {}) => {
+  const matchesCurlies = /({{.*?}})/;
+  const matchesKeyRegexMap = Object.keys(bank).reduce((acc, key) => {
+    // Escape characters (ex. {{foo}} => \\{\\{foo\\}\\} )
+    acc[key] = new RegExp(key.replace(/[-[\]/{}()\\*+?.^$|]/g, '\\$&'), 'g');
+    return acc;
+  }, {});
   const replacer = (out) => {
     if (!['string', 'number'].includes(typeof out)) {
       return out;
@@ -57,15 +63,11 @@ const recurseReplaceBank = (obj, bank = {}) => {
     let maybeChangedString = originalValueStr;
 
     Object.keys(bank).forEach((key) => {
-      // Escape characters (ex. {{foo}} => \\{\\{foo\\}\\} )
-      const escapedKey = key.replace(/[-[\]/{}()\\*+?.^$|]/g, '\\$&');
-      const matchesKey = new RegExp(escapedKey, 'g');
-
+      const matchesKey = matchesKeyRegexMap[key];
       if (!matchesKey.test(maybeChangedString)) {
         return;
       }
 
-      const matchesCurlies = /({{.*?}})/;
       const valueParts = maybeChangedString
         .split(matchesCurlies)
         .filter(Boolean);


### PR DESCRIPTION
Given an object with M keys and a bank with N keys, we call replacer M * N times. The actual replacer is pretty light-weight, except for its usage of Regex. With a bank size of ~4000 keys and a object size of ~500 keys, we can see 2,000,000 compilations of Regex. It can cause quite a slowdown!

This change will still result in N * M calls to replacer, but only N compilations of Regex.

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
