### PR TITLE
chore(cli, schema, core, legacy-scripting-runner): Update License files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
 Copyright (c) Zapier, Inc.
 
-This repository is part of Zapier Platform, of which license terms can be found at
-https://zapier.com/platform/tos.
+This repository is part of Zapier Platform.  By downloading, installing, accessing, or using any part of the Zapier Platform, including this repository, you agree to the Zapier Platform Agreement, which can be found at: https://zapier.com/platform/tos.  If you do not agree to the Zapier Platform Agreement, you may not download, install, access, or use any part of the Zapier Platform, including this repository.

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,4 +1,3 @@
 Copyright (c) Zapier, Inc.
 
-This repository is part of Zapier Platform, of which license terms can be found at
-https://zapier.com/platform/tos.
+This repository is part of Zapier Platform.  By downloading, installing, accessing, or using any part of the Zapier Platform, including this repository, you agree to the Zapier Platform Agreement, which can be found at: https://zapier.com/platform/tos.  If you do not agree to the Zapier Platform Agreement, you may not download, install, access, or use any part of the Zapier Platform, including this repository.

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,4 +1,3 @@
 Copyright (c) Zapier, Inc.
 
-This repository is part of Zapier Platform, of which license terms can be found at
-https://zapier.com/platform/tos.
+This repository is part of Zapier Platform.  By downloading, installing, accessing, or using any part of the Zapier Platform, including this repository, you agree to the Zapier Platform Agreement, which can be found at: https://zapier.com/platform/tos.  If you do not agree to the Zapier Platform Agreement, you may not download, install, access, or use any part of the Zapier Platform, including this repository.

--- a/packages/legacy-scripting-runner/LICENSE
+++ b/packages/legacy-scripting-runner/LICENSE
@@ -1,4 +1,3 @@
 Copyright (c) Zapier, Inc.
 
-This repository is part of Zapier Platform, of which license terms can be found at
-https://zapier.com/platform/tos.
+This repository is part of Zapier Platform.  By downloading, installing, accessing, or using any part of the Zapier Platform, including this repository, you agree to the Zapier Platform Agreement, which can be found at: https://zapier.com/platform/tos.  If you do not agree to the Zapier Platform Agreement, you may not download, install, access, or use any part of the Zapier Platform, including this repository.

--- a/packages/schema/LICENSE
+++ b/packages/schema/LICENSE
@@ -1,4 +1,3 @@
 Copyright (c) Zapier, Inc.
 
-This repository is part of Zapier Platform, of which license terms can be found at
-https://zapier.com/platform/tos.
+This repository is part of Zapier Platform.  By downloading, installing, accessing, or using any part of the Zapier Platform, including this repository, you agree to the Zapier Platform Agreement, which can be found at: https://zapier.com/platform/tos.  If you do not agree to the Zapier Platform Agreement, you may not download, install, access, or use any part of the Zapier Platform, including this repository.


### PR DESCRIPTION
Simple text update to increase clarity.

Duplicated into multiple files, but since it changes so infrequently, doesn't seem worthwhile to automate it (like we do with `docs`).

[PDE-2817](https://zapierorg.atlassian.net/browse/PDE-2817)