### PR TITLE
PDE-2853 fix(legacy-scripting-runner): merge `request.url` to `request.params` before making the request

### DIFF
--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -313,7 +313,8 @@ const legacyScriptingSource = `
       },
 
       movie_pre_poll_env_var: function(bundle) {
-        bundle.request.url = '{{process.env.SECRET_HTTPBIN_URL}}/get';
+        bundle.request.url = '{{process.env.SECRET_HTTPBIN_URL}}/get?a=1&a=1';
+        bundle.request.params.a = [2, 2];
         return bundle.request;
       },
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1151,7 +1151,8 @@ describe('Integration Test', () => {
       return _app(input)
         .then((output) => {
           const result = output.results[0];
-          should.equal(result.url, `${HTTPBIN_URL}/get`);
+          should.equal(result.url, `${HTTPBIN_URL}/get?a=1&a=1&a=2&a=2`);
+          should.deepEqual(result.args.a, ['1', '1', '2', '2']);
         })
         .finally(() => {
           delete process.env.SECRET_HTTPBIN_URL;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->


## Legacy scripting code to reproduce the issue

```js
var Zap = {
  KEY_pre_poll: function(bundle) {
    bundle.request.url = 'https://httpbin.zapier-tooling.com/get?title[]=null';
    bundle.request.params['title[]'] = ['dune', 'eternals'];
    return bundle.request;
  }
};
```

## Expected behavior

Should send a request with `title[]` being all three values. i.e., `?title[]=null&title[]=dune&title[]=eternals`.

## Current behavior

The parameter in `request.url` takes precedence over `request.params`. The final querystring being sent is `?title[]=null`.