### PR TITLE
[Hackathon] Run actions locally

### DIFF
--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -15,6 +15,12 @@ const METHODS = {
   inputFields: 'inputFields',
   outputFields: 'outputFields',
 };
+const ACTIONTYPES = {
+  triggers: 'triggers',
+  creates: 'creates',
+  searches: 'searches',
+  authentication: 'authentication',
+};
 // const { listVersions } = require('../../utils/api');
 
 class RunCommand extends BaseCommand {
@@ -130,7 +136,7 @@ RunCommand.flags = buildFlags({
 RunCommand.args = [
   {
     name: 'actionType',
-    options: ['triggers', 'creates', 'searches', 'authentication'],
+    options: Object.keys(ACTIONTYPES),
     description: 'The type of action.',
     required: true,
   },

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -14,7 +14,6 @@ const METHODS = {
   perform: 'perform',
   inputFields: 'inputFields',
   outputFields: 'outputFields',
-  test: 'test',
 };
 // const { listVersions } = require('../../utils/api');
 
@@ -24,9 +23,7 @@ class RunCommand extends BaseCommand {
       actionType, // EX: creates
       actionKey = '', // set an empty default here in case developer is testing `authentication` actionType
     } = this.args;
-    const method =
-      this.flags.method ||
-      (actionType === 'authentication' ? METHODS.test : METHODS.perform);
+    const method = this.flags.method || METHODS.perform;
 
     if (method !== 'inputFields' && this.flags.requiredFieldsOnly)
       throw new Error(
@@ -87,20 +84,20 @@ class RunCommand extends BaseCommand {
         }
       } else {
         // This is for running the Auth test if we implement that.
-        result = await appTester(App[actionType][method], bundle);
+        result = await appTester(App[actionType].test, bundle);
       }
       this.stopSpinner();
     } catch (e) {
       console.log(e); // TODO handle errors
     }
     if (writeFile) {
-      fs.writeFile(
-        `run_${actionType}_${actionKey}_${method}_output.json`,
-        JSON.stringify(result, null, 2),
-        function (err) {
-          if (err) throw err;
-        }
-      );
+      const fileName =
+        actionType === 'authentication'
+          ? `run_${actionType}_test_output.json`
+          : `run_${actionType}_${actionKey}_${method}_output.json`;
+      fs.writeFile(fileName, JSON.stringify(result, null, 2), function (err) {
+        if (err) throw err;
+      });
     }
 
     this.logJSON(result);
@@ -138,7 +135,7 @@ RunCommand.args = [
   {
     name: 'actionType',
     options: ['triggers', 'creates', 'searches', 'authentication'],
-    description: 'The type of action.', //  TODO: Test `authentication` to see if that works
+    description: 'The type of action.',
     required: true,
   },
   {

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -3,6 +3,7 @@ const { flags } = require('@oclif/command');
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
 const { callAPI } = require('../../utils/api');
+const { localAppCommand } = require('../../utils/local');
 
 // const { listVersions } = require('../../utils/api');
 
@@ -41,6 +42,9 @@ class RunCommand extends BaseCommand {
     // currently this returns a 404 as the bundle API isn't ready yet
 
     // run the action using the provided bundle
+    // not super sure how to do this. maybe using the app tester? or maybe a local command? Just throwing out suggestions
+    // we can grab the definition - not sure if that's helpful at some point!
+    // const definition = await localAppCommand({ command: 'definition' })
   }
 }
 RunCommand.flags = buildFlags({

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -74,17 +74,13 @@ class RunCommand extends BaseCommand {
     const appTester = zapier.createAppTester(App);
     let result;
     try {
-      if (actionKey) {
-        result = await appTester(
-          App[actionType][actionKey].operation[method],
-          bundle
-        );
-        if (requiredFieldsOnly && method === 'inputFields') {
-          result = result.filter((field) => field.required === true);
-        }
-      } else {
-        // This is for running the Auth test if we implement that.
-        result = await appTester(App[actionType].test, bundle);
+      const appTesterMethod =
+        actionType === 'authentication'
+          ? App[actionType].test
+          : App[actionType][actionKey].operation[method];
+      result = await appTester(appTesterMethod, bundle);
+      if (requiredFieldsOnly && method === 'inputFields') {
+        result = result.filter((field) => field.required === true);
       }
       this.stopSpinner();
     } catch (e) {

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -22,7 +22,10 @@ const authTypeFields = (type) => {
   // there are more auth options, I just picked a few
   const authOptions = {
     basic: { username: process.env.USERNAME, password: process.env.PASSWORD },
-    custom: { api_key: process.env.API_KEY },
+    custom: {
+      api_key: process.env.API_KEY || undefined,
+      apiKey: process.env.APIKEY || undefined,
+    },
     oauth1: { access_token: process.env.ACCESS_TOKEN },
     oauth2: { access_token: process.env.ACCESS_TOKEN },
   };
@@ -113,6 +116,7 @@ class RunCommand extends BaseCommand {
     // const definition = await localAppCommand({ command: 'definition' })
 
     const appTester = zapier.createAppTester(App);
+    zapier.tools.env.inject();
     let result;
     try {
       // we may need to add another condition for input/output fields as I'm not exactly sure how the App Tester will run those.

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -17,19 +17,22 @@ const METHODS = {
 // const { listVersions } = require('../../utils/api');
 
 const authTypeFields = (type) => {
-  // inject the environment variables
-  zapier.tools.env.inject();
-  // there are more auth options, I just picked a few
-  const authOptions = {
-    basic: { username: process.env.USERNAME, password: process.env.PASSWORD },
-    custom: {
-      api_key: process.env.API_KEY || undefined,
-      apiKey: process.env.APIKEY || undefined,
-    },
-    oauth1: { access_token: process.env.ACCESS_TOKEN },
-    oauth2: { access_token: process.env.ACCESS_TOKEN },
-  };
-  return authOptions[type] || {};
+  // another way for to find AuthOptions is by searching for the following phrases in keys:
+  const phrases = [
+    /.*api.*key.*/i,
+    /.*access.*token.*/i,
+    /.*token.*/i,
+    /.*user.*name.*/i,
+    /.*password.*/i,
+  ];
+  const authOptions = {};
+  phrases.forEach((phrase) => {
+    Object.keys(process.env).forEach((key) => {
+      if (key.match(phrase)) authOptions[key] = process.env[key];
+    });
+  });
+
+  return authOptions;
 };
 
 const parseAuth = (type, authInput) => {

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -76,6 +76,7 @@ class RunCommand extends BaseCommand {
     if (!Object.keys(METHODS).includes(method))
       throw new Error(`method flag must be one of ${Object.keys(METHODS)}`);
 
+    zapier.tools.env.inject(); // this must come before importing the App
     // get the index file for the app (maybe this can be soemthing other than index.js?)
     const localAppPath = path.join(process.cwd(), 'index.js');
     const App = require(localAppPath);
@@ -116,7 +117,6 @@ class RunCommand extends BaseCommand {
     // const definition = await localAppCommand({ command: 'definition' })
 
     const appTester = zapier.createAppTester(App);
-    zapier.tools.env.inject();
     let result;
     try {
       // we may need to add another condition for input/output fields as I'm not exactly sure how the App Tester will run those.

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -1,0 +1,42 @@
+const BaseCommand = require('../ZapierBaseCommand');
+const { buildFlags } = require('../buildFlags');
+
+const { listVersions } = require('../../utils/api');
+
+class RunCommand extends BaseCommand {
+  async perform() {
+    // let title = this.args.title;
+    // if (!title) {
+    //   title = await this.prompt('What is the title of your integration?');
+    // }
+
+    this.startSpinner('Running action');
+    const { versions } = await listVersions();
+    this.stopSpinner();
+
+    this.logTable({
+      rows: versions,
+      headers: [
+        ['Version', 'version'],
+        ['Platform', 'platform_version'],
+        ['Users', 'user_count'],
+        ['Deployment', 'deployment'],
+        ['Deprecation Date', 'deprecation_date'],
+        ['Timestamp', 'date'],
+      ],
+      emptyMessage:
+        'No versions to show. Try adding one with the `zapier push` command',
+    });
+
+    if (versions.map((v) => v.user_count).filter((c) => c === null).length) {
+      this.warn(
+        'Some user counts are still being calculated - run this command again in ~10 seconds (or longer if your integration has lots of users).'
+      );
+    }
+  }
+}
+
+RunCommand.flags = buildFlags({ opts: { format: true } });
+RunCommand.description = `List the versions of your integration available for use in the Zapier editor.`;
+
+module.exports = RunCommand;

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -13,7 +13,6 @@ class RunCommand extends BaseCommand {
     const {
       actionType, // EX: creates
       action,
-      operation, // EX: perform, inputFields, outputFields
     } = this.args;
     const auth = this.flags.auth || {};
     const input = this.flags.input || {};
@@ -81,6 +80,10 @@ RunCommand.flags = buildFlags({
       description:
         'The input fields and values to use, in the form `input={}`. For example: `input={"account: "356234", status": "PENDING"}`',
     }),
+    operation: flags.string({
+      description:
+        'The function you would like to test, in the form `operation=perform` (default). Alternate options: `inputFields`, `outputFields`',
+    }),
   },
 });
 
@@ -94,11 +97,6 @@ RunCommand.args = [
   {
     name: 'action',
     description: 'The action key to run.',
-    required: true,
-  },
-  {
-    name: 'operation',
-    description: 'The part of the operation to run. (Ex: `perform`)',
     required: true,
   },
 ];

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -6,6 +6,7 @@ const { callAPI } = require('../../utils/api');
 const { localAppCommand } = require('../../utils/local');
 const zapier = require('zapier-platform-core');
 const os = require('os');
+const fs = require('fs');
 
 const { parseAuth, parseInput } = require('../../utils/run');
 

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -116,7 +116,7 @@ RunCommand.flags = buildFlags({
     method: flags.string({
       options: Object.keys(METHODS),
       description:
-        'The function you would like to test, in the form `method perform` (default).',
+        'The function you would like to test, in the form `method perform` (default). Omit if testing `authentication` - the method will be set to `test` in that case.',
     }),
     requiredFieldsOnly: flags.boolean({
       description:

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -10,7 +10,11 @@ const zapier = require('zapier-platform-core');
 
 class RunCommand extends BaseCommand {
   async perform() {
-    const { action } = this.args;
+    const {
+      actionType, // EX: creates
+      action,
+      operation, // EX: perform, inputFields, outputFields
+    } = this.args;
     const auth = this.flags.auth || {};
     const input = this.flags.input || {};
 
@@ -55,7 +59,10 @@ class RunCommand extends BaseCommand {
 
     let result;
     try {
-      result = await appTester(App.creates.customer.operation.perform, bundle);
+      result = await appTester(
+        App[actionType][action].operation[operation],
+        bundle
+      );
     } catch (e) {
       console.log(e); // TODO handle errors
     }
@@ -79,8 +86,19 @@ RunCommand.flags = buildFlags({
 
 RunCommand.args = [
   {
+    name: 'actionType',
+    description:
+      'The type of action (Only `creates` is currently supported). TODO: Add `triggers`, `searches`, `authentication`',
+    required: true,
+  },
+  {
     name: 'action',
     description: 'The action key to run.',
+    required: true,
+  },
+  {
+    name: 'operation',
+    description: 'The part of the operation to run. (Ex: `perform`)',
     required: true,
   },
 ];

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -78,7 +78,7 @@ class RunCommand extends BaseCommand {
     }
 
     console.log(result);
-    return result;
+    this.logJSON(result);
   }
 }
 RunCommand.flags = buildFlags({

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -46,7 +46,7 @@ const parseInput = (type, actionKey, input) => {
   // read the input from a json file if provided
   const inputDataPath = path.join(process.cwd(), 'run-input.json');
   if (fs.existsSync(inputDataPath)) {
-    testInputData = require(inputDataPath);
+    const testInputData = require(inputDataPath);
     if (type in testInputData && actionKey in testInputData[type]) {
       inputParams = testInputData[type][actionKey];
     }
@@ -115,12 +115,14 @@ class RunCommand extends BaseCommand {
     const appTester = zapier.createAppTester(App);
     let result;
     try {
+      // we may need to add another condition for input/output fields as I'm not exactly sure how the App Tester will run those.
       if (action) {
         result = await appTester(
           App[actionType][action].operation[method],
           bundle
         );
       } else {
+        // This is for runnig the Auth test if we implement that.
         result = await appTester(App[actionType][method], bundle);
       }
     } catch (e) {

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -15,16 +15,17 @@ class RunCommand extends BaseCommand {
 
     // TODO add some error handling for the input
 
-    const valuesToSet = JSON.parse(auth);
-    console.log(valuesToSet.api_key);
-
     const payload = {
+      platformVersion: '11.1.0',
+      type: 'create',
+      method: 'perform',
+      auth: JSON.parse(auth),
       params: JSON.parse(input),
     }; // do we need to pass in the auth? or we could just add it to the bundle afterwards
 
     // call the bundle API to construct the bundles
-    const app = await this.getWritableApp();
-    const url = `/apps/${app.id}/test-bundle/`; // TODO set this to the url for the bundle API once that is implemented
+    // const app = await this.getWritableApp();
+    const url = '/bundle'; // TODO set this to the url for the bundle API once that is implemented
     let response;
     try {
       response = await callAPI(
@@ -39,6 +40,7 @@ class RunCommand extends BaseCommand {
     } catch (e) {
       console.log(e); // TODO handle errors
     }
+    console.log(response);
     // currently this returns a 404 as the bundle API isn't ready yet
 
     // run the action using the provided bundle

--- a/packages/cli/src/oclif/commands/run.js
+++ b/packages/cli/src/oclif/commands/run.js
@@ -8,6 +8,12 @@ const zapier = require('zapier-platform-core');
 const os = require('os');
 const fs = require('fs');
 
+const METHODS = {
+  perform: 'perform',
+  inputFields: 'inputFields',
+  outputFields: 'outputFields',
+  test: 'test',
+};
 // const { listVersions } = require('../../utils/api');
 
 const authTypeFields = (type) => {
@@ -62,12 +68,10 @@ class RunCommand extends BaseCommand {
     } = this.args;
     const method =
       this.flags.method ||
-      (actionType === 'authentication' ? 'test' : 'perform');
+      (actionType === 'authentication' ? METHODS.test : METHODS.perform);
 
-    if (!['perform', 'inputFields', 'outputFields', 'test'].includes(method))
-      throw new Error(
-        `method flag must be one of ['perform', 'inputFields', 'outputFields', 'test']`
-      );
+    if (!Object.keys(METHODS).includes(method))
+      throw new Error(`method flag must be one of ${Object.keys(METHODS)}`);
 
     // get the index file for the app (maybe this can be soemthing other than index.js?)
     const localAppPath = path.join(process.cwd(), 'index.js');
@@ -137,8 +141,9 @@ RunCommand.flags = buildFlags({
         'The input fields and values to use, in the form `input={}`. For example: `input={"account: "356234", status": "PENDING"}`',
     }),
     method: flags.string({
+      options: Object.keys(METHODS),
       description:
-        'The function you would like to test, in the form `method=perform` (default). Alternate options: `inputFields`, `outputFields`',
+        'The function you would like to test, in the form `method=perform` (default).',
     }),
   },
 });

--- a/packages/cli/src/utils/run.js
+++ b/packages/cli/src/utils/run.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+const authTypeFields = (type) => {
+  // another way for to find AuthOptions is by searching for the following phrases in keys:
+  const phrases = [
+    /.*api.*key.*/i,
+    /.*access.*token.*/i,
+    /.*token.*/i,
+    /.*user.*name.*/i,
+    /.*password.*/i,
+  ];
+  const authOptions = {};
+  phrases.forEach((phrase) => {
+    Object.keys(process.env).forEach((key) => {
+      if (key.match(phrase)) authOptions[key] = process.env[key];
+    });
+  });
+
+  return authOptions;
+};
+
+const parseAuth = (type, authInput) => {
+  // try to grab some sensible auth looking defaults - should really use the auth that is specified by the user
+  let auth = authTypeFields(type);
+
+  // override any of the environment variables with the ones provided via the command line
+  if (authInput) {
+    auth = { ...auth, ...JSON.parse(authInput) };
+  }
+  return auth;
+};
+
+const parseInput = (type, actionKey, input) => {
+  let inputParams = {};
+
+  // read the input from a json file if provided
+  const inputDataPath = path.join(process.cwd(), 'run-input.json');
+  if (fs.existsSync(inputDataPath)) {
+    const testInputData = require(inputDataPath);
+    if (type in testInputData && actionKey in testInputData[type]) {
+      inputParams = testInputData[type][actionKey];
+    }
+  }
+
+  // or provide JSON via the commandline, overriding any values from the run input file
+  if (input) {
+    inputParams = { ...inputParams, ...JSON.parse(input) };
+  }
+
+  return inputParams;
+};
+
+module.exports = {
+  authTypeFields,
+  parseAuth,
+  parseInput,
+};

--- a/packages/cli/src/utils/run.js
+++ b/packages/cli/src/utils/run.js
@@ -1,8 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const authTypeFields = (type) => {
-  // another way for to find AuthOptions is by searching for the following phrases in keys:
+const authFieldsFromProcessEnv = () => {
   const phrases = [
     /.*api.*key.*/i,
     /.*access.*token.*/i,
@@ -10,19 +9,19 @@ const authTypeFields = (type) => {
     /.*user.*name.*/i,
     /.*password.*/i,
   ];
-  const authOptions = {};
+  const authFields = {};
   phrases.forEach((phrase) => {
     Object.keys(process.env).forEach((key) => {
-      if (key.match(phrase)) authOptions[key] = process.env[key];
+      if (key.match(phrase)) authFields[key] = process.env[key];
     });
   });
 
-  return authOptions;
+  return authFields;
 };
 
 const parseAuth = (type, authInput) => {
   // try to grab some sensible auth looking defaults - should really use the auth that is specified by the user
-  let auth = authTypeFields(type);
+  let auth = authFieldsFromProcessEnv();
 
   // override any of the environment variables with the ones provided via the command line
   if (authInput) {
@@ -52,7 +51,7 @@ const parseInput = (type, actionKey, input) => {
 };
 
 module.exports = {
-  authTypeFields,
+  authFieldsFromProcessEnv,
   parseAuth,
   parseInput,
 };


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Run examples with command line auth and input 
`zapier run creates customer --auth '{"api_key":"test"}' --input '{"account": "356234"}'`

You can omit command line params if you have local files setup instead:

put the auth details in your `.env` file eg `API_KEY=test`

put the input data in a file called `run-input.json` eg.
```
{
  "creates": {
    "customer": {
      "account": "356234",
      "email": "zap.zaplar@zapier.com",
      "custom_field_1": "testing!"
    }
  }
}
```
 
and then run like this `zapier run creates customer`

You can also run other methods eg `zapier run creates customer --method inputFields --auth '{"api_key":"test"}' --input '{"account": "356234"}'`

If you set environment variables with `zapier env:set` you must also define the variables locally in your .env file