### PR TITLE
feat(core): Add `code` type for `inputField`s

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -920,9 +920,7 @@ Key | Required | Type | Description
 `key` | **yes** | `string` | A unique machine readable key for this value (IE: "fname").
 `label` | no | `string` | A human readable label for this value (IE: "First Name").
 `helpText` | no | `string` | A human readable description of this value (IE: "The first part of a full name."). You can use Markdown.
-`type` | no | `string` in (`'string'`, `'text'`, `'integer'`, `'number'`, `'boolean'`, `'datetime'`, `'file'`, `'password'`, `'copy'`, `'code'`) | The type of this value.
-
-Use `string` for basic text input, `text` for a large, `<textarea>` style box, and `code` for a `<textarea>` with a fixed-width font.
+`type` | no | `string` in (`'string'`, `'text'`, `'integer'`, `'number'`, `'boolean'`, `'datetime'`, `'file'`, `'password'`, `'copy'`, `'code'`) | The type of this value. Use `string` for basic text input, `text` for a large, `<textarea>` style box, and `code` for a `<textarea>` with a fixed-width font.
 `required` | no | `boolean` | If this value is required or not.
 `placeholder` | no | `string` | An example value that is not saved.
 `default` | no | `string` | A default value that is saved the first time a Zap is created.

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -164,7 +164,7 @@
           "maxLength": 1000
         },
         "type": {
-          "description": "The type of this value.\n\nUse `string` for basic text input, `text` for a large, `<textarea>` style box, and `code` for a `<textarea>` with a fixed-width font.",
+          "description": "The type of this value. Use `string` for basic text input, `text` for a large, `<textarea>` style box, and `code` for a `<textarea>` with a fixed-width font.",
           "type": "string",
           "enum": [
             "string",

--- a/packages/schema/lib/schemas/FieldSchema.js
+++ b/packages/schema/lib/schemas/FieldSchema.js
@@ -45,7 +45,7 @@ module.exports = makeSchema(
       },
       type: {
         description:
-          'The type of this value.\n\nUse `string` for basic text input, `text` for a large, `<textarea>` style box, and `code` for a `<textarea>` with a fixed-width font.',
+          'The type of this value. Use `string` for basic text input, `text` for a large, `<textarea>` style box, and `code` for a `<textarea>` with a fixed-width font.',
         type: 'string',
         // string == unicode
         // text == a long textarea string


### PR DESCRIPTION
Adds an already-recognized inputField type as a valid option

[PDE-2856](https://zapierorg.atlassian.net/browse/PDE-2856)