### PR TITLE
PDE-2859 fix(legacy-scripting-runner): fix empty auth params in `request.params`

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.3
+
+- :bug: Fix empty auth params when merging `request.url` and `reqeust.params` ([#441](https://github.com/zapier/zapier-platform/pull/441))
+
 ## 3.8.2
 
 - :bug: Merge `request.url` to `request.params` before making a request ([#435](https://github.com/zapier/zapier-platform/pull/435))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -353,6 +353,9 @@ const normalizeQueryParams = (req) => {
 
   // Copy params collected from req.url to req.params
   req.params = _.mergeWith(params, req.params, (dst, src) => {
+    if (dst === undefined) {
+      return src;
+    }
     if (Array.isArray(dst)) {
       if (Array.isArray(src)) {
         return dst.concat(src);

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This is new bug caused by #435.

## Scenario to reproduce the issue

- Executing a polling trigger with _no_ script
- Polling URL (`legacy.triggers.{key}.operation.url`) has an inline querystring, such as `https://example.com?foo=bar`
- Auth mapping (`legacy.authentication.mapping`) is `{"api_key": "{{api_key}}"}`
- Auth placement (`legacy.authentication.placement`) is `querystring`
- `bundle.authData` is `{"api_key": "secret"}`

## Expected request

```json
{
  "url": "https://example.com",
  "method": "GET",
  "params": {
    "foo": "bar",
    "api_key": "secret"
  }
}
```

## Current request

```json
{
  "url": "https://example.com",
  "method": "GET",
  "params": {
    "foo": "bar",
    "api_key": ["", "secret"]
  }
}
```