### PR TITLE
fix(legacy-scripting-runner): make sure redirect_uri is available for oauth refreshes

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.8.4
 
 - :bug: Make sure `redirect_uri` is available during `oauth2.refresh` ([#444](https://github.com/zapier/zapier-platform/pull/444))
-- :bug: Don't send auth with `z.dehydrateFile` ([#445](https://github.com/zapier/zapier-platform/pull/445))
+- :bug: Don't send auth with `z.dehydrateFile(url, {})` ([#445](https://github.com/zapier/zapier-platform/pull/445))
 
 ## 3.8.3
 

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.8.4
 
-- :bug: make sure `redirect_uri` is available during `oauth2.refresh` ([#444](https://github.com/zapier/zapier-platform/pull/444))
+- :bug: Make sure `redirect_uri` is available during `oauth2.refresh` ([#444](https://github.com/zapier/zapier-platform/pull/444))
+- :bug: Don't send auth with `z.dehydrateFile` ([#445](https://github.com/zapier/zapier-platform/pull/445))
 
 ## 3.8.3
 

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.3
+
+- :bug: make sure `redirect_uri` is available during `oauth2.refresh` ([#444](https://github.com/zapier/zapier-platform/pull/444))
+
 ## 3.8.2
 
 - :bug: Merge `request.url` to `request.params` before making a request ([#435](https://github.com/zapier/zapier-platform/pull/435))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1051,6 +1051,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
     body.client_id = clientId;
     body.client_secret = clientSecret;
     body.refresh_token = bundle.authData.refresh_token;
+    body.redirect_uri = bundle.inputData.redirect_uri;
     body.grant_type = 'refresh_token';
 
     let result;
@@ -1068,6 +1069,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       params.client_id = clientId;
       params.client_secret = clientSecret;
       params.refresh_token = bundle.authData.refresh_token;
+      body.redirect_uri = bundle.inputData.redirect_uri;
       params.grant_type = 'refresh_token';
 
       result = await runEventCombo(bundle, '', 'auth.oauth2.refresh.pre');

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1072,7 +1072,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       params.client_id = clientId;
       params.client_secret = clientSecret;
       params.refresh_token = bundle.authData.refresh_token;
-      body.redirect_uri = bundle.inputData.redirect_uri;
+      params.redirect_uri = bundle.inputData.redirect_uri;
       params.grant_type = 'refresh_token';
 
       result = await runEventCombo(bundle, '', 'auth.oauth2.refresh.pre');

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -515,6 +515,9 @@ describe('Integration Test', () => {
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
       };
+      input.bundle.inputData = {
+        redirect_uri: 'https://zapier.rodeo/auth/abc123',
+      };
       return app(input).then((output) => {
         const data = output.results.form;
         const params = output.results.args;
@@ -524,6 +527,7 @@ describe('Integration Test', () => {
           client_secret: [process.env.CLIENT_SECRET],
           grant_type: ['refresh_token'],
           refresh_token: ['my_refresh_token'],
+          redirect_uri: ['https://zapier.rodeo/auth/abc123'],
         });
         should.deepEqual(params, {});
       });
@@ -546,6 +550,9 @@ describe('Integration Test', () => {
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
       };
+      input.bundle.inputData = {
+        redirect_uri: 'https://zapier.rodeo/auth/abc123',
+      };
       return app(input).then((output) => {
         const response = output.results;
         should.not.exist(response.headers.Authorization);
@@ -554,6 +561,7 @@ describe('Integration Test', () => {
           client_secret: [process.env.CLIENT_SECRET],
           grant_type: ['refresh_token'],
           refresh_token: ['my_refresh_token'],
+          redirect_uri: ['https://zapier.rodeo/auth/abc123'],
         });
       });
     });

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -480,6 +480,9 @@ describe('Integration Test', () => {
         refresh_token: 'my_refresh_token',
         access_token: 'my_access_token',
       };
+      input.bundle.inputData = {
+        redirect_uri: 'https://zapier.rodeo/auth/abc123',
+      };
       return app(input).then((output) => {
         const data = output.results.form;
 
@@ -490,6 +493,7 @@ describe('Integration Test', () => {
           foo: ['hello'],
           grant_type: ['refresh_token'],
           refresh_token: ['my_refresh_token'],
+          redirect_uri: ['https://zapier.rodeo/auth/abc123'],
         });
       });
     });


### PR DESCRIPTION
Fixes [PDE-2871](https://zapierorg.atlassian.net/browse/PDE-2871), where a partner's API depends on `redirect_uri` always being there (even for refresh)

I'm _pretty_ sure this'll fix it, but it's worth double checking the GL links in the jira ticket.