### PR TITLE
PDE-2872 fix(legacy-scripting-runner): `z.dehydrateFile(url, {})` should not send auth

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -1389,15 +1389,17 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
   const runHydrateFile = (bundle) => {
     const meta = bundle.inputData.meta || {};
+
+    // Legacy z.dehydrateFile(url, request, meta) behavior: if request argument
+    // is provided, the dev is responsible for doing auth themselves, so we use
+    // an internal request client to avoid running the app's http middlewares.
+    const request =
+      bundle.inputData.request === null ||
+      bundle.inputData.request === undefined
+        ? zcli.request
+        : createInternalRequestClient(input);
+
     const requestOptions = bundle.inputData.request || {};
-
-    // Legacy z.dehydrateFile(url, request, meta) behavior: if request argument is
-    // provided, the dev is responsible for doing auth themselves, so we use an internal
-    // request client to avoid running the app's http middlewares.
-    const request = _.isEmpty(requestOptions)
-      ? zcli.request
-      : createInternalRequestClient(input);
-
     requestOptions.url = bundle.inputData.url || requestOptions.url;
     requestOptions.raw = true;
     requestOptions.throwForStatus = true;

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -3763,7 +3763,43 @@ describe('Integration Test', () => {
         return app(input).then((output) => {
           const { response, content, knownLength, filename, contentType } =
             output.results;
-          should.equal(content.headers['X-Api-Key'], 'super secret');
+          should.deepEqual(content.headers['X-Api-Key'], ['super secret']);
+          should.not.exist(knownLength);
+          should.not.exist(filename);
+          should.not.exist(contentType);
+
+          // Make sure prepareResponse middleware was run
+          response.getHeader.should.be.Function();
+          should.equal(
+            response.getHeader('content-type'),
+            'application/json; encoding=utf-8'
+          );
+        });
+      });
+
+      it('should not send auth when empty request options', () => {
+        const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+        const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+        const app = createAppWithCustomBefores(appDefWithAuth, [
+          mockFileStahser,
+        ]);
+
+        const input = createTestInput(
+          compiledApp,
+          'hydrators.legacyFileHydrator'
+        );
+        input.bundle.authData = { api_key: 'super secret' };
+        input.bundle.inputData = {
+          // This endpoint echoes what we send to it, so we know if auth info was sent
+          url: `${HTTPBIN_URL}/get`,
+          // An empty object should behave differently than an undefined request.
+          // An undefined request doesn't clear auth while an empty object does.
+          request: {},
+        };
+        return app(input).then((output) => {
+          const { response, content, knownLength, filename, contentType } =
+            output.results;
+          should.not.exist(content.headers['X-Api-Key']);
           should.not.exist(knownLength);
           should.not.exist(filename);
           should.not.exist(contentType);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Legacy scripting code to reproduce the issue

```js
var Zap = {
  email_catch_hook: {
    bundle.cleaned_request.file = z.dehydrateFile('https://httpbin.zapier-tooling.com/get', {});
    return bundle.cleaned_request;
  }
};
```

## Expected behavior

When hydrated, we should NOT see the auth headers or params in the request.

But if you do `z.dehydrateFile('https://httpbin.zapier-tooling.com/get')` (omitting the second argument for request options), we _should_ see the auth headers or params.

## Current behavior

When hydrated, we see the auth headers or params in the request. Some server doesn't like it when the URL you're requesting for doesn't require auth but you give it auth info. For example, AWS S3 would give you HTTP 400 error saying `Unsupported Authorization Type`.