### PR TITLE
PDE-2874 fix(legacy-scripting-runner): prune nulls and undefined's from query params

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -347,12 +347,12 @@ const mergeQueryParams = (req) => {
     return result;
   }, {});
 
-  if (_.isEmpty(params)) {
-    return req;
-  }
-
   // Copy params collected from req.url to req.params
   req.params = _.mergeWith(params, req.params, (dst, src) => {
+    if (src === null) {
+      // Legacy WB relies on Python serializing null, ugh
+      src = 'None';
+    }
     if (dst === undefined) {
       return src;
     }
@@ -380,7 +380,9 @@ const mergeQueryParams = (req) => {
 const pruneQueryParams = (params) => {
   // Only prune nulls and undefined's. Keep empty strings.
   return Object.entries(params).reduce((result, [name, value]) => {
-    if (value != null) {
+    if (Array.isArray(value)) {
+      result[name] = value.filter((v) => v != null);
+    } else if (value != null) {
       result[name] = value;
     }
     return result;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -656,10 +656,12 @@ const legacyScriptingSource = `
       },
 
       movie_pre_write_prune_empty_params: function(bundle) {
-        bundle.request.url = '${HTTPBIN_URL}/post';
+        bundle.request.url = '${HTTPBIN_URL}/post?foo=&bar=';
         bundle.request.params.foo = undefined;
         bundle.request.params.bar = null;
         bundle.request.params.baz = '';
+        bundle.request.params.apple = undefined;
+        bundle.request.params.banana = null;
         return bundle.request;
       },
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -655,6 +655,14 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_write_prune_empty_params: function(bundle) {
+        bundle.request.url = '${HTTPBIN_URL}/post';
+        bundle.request.params.foo = undefined;
+        bundle.request.params.bar = null;
+        bundle.request.params.baz = '';
+        return bundle.request;
+      },
+
       movie_write_default_headers: function(bundle) {
         bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2444,7 +2444,10 @@ describe('Integration Test', () => {
       return app(input).then((output) => {
         const echoed = output.results;
         should.deepEqual(echoed.args, {
+          foo: [''],
+          bar: ['', 'None'],
           baz: [''],
+          banana: ['None'],
         });
       });
     });

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2426,6 +2426,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_write, prune empty params', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_pre_write_prune_empty_params',
+          'movie_pre_write'
+        );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        const echoed = output.results;
+        should.deepEqual(echoed.args, {
+          baz: [''],
+        });
+      });
+    });
+
     it('KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.url += 's';


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Legacy scripting code to reproduce the issue

```js
var Zap = {
  movie_pre_write: {
    bundle.request.url = 'https://httpbin.zapier-tooling.com/post?foo=&bar=';
    bundle.request.params.foo = undefined;
    bundle.request.params.bar = null;
    bundle.request.params.baz = '';
    return bundle.request;
  }
};
```

## Expected outbound request

```js
{
  "url": "https://httpbin.zapier-tooling.com/post",
  "method": "POST",
  "params": {
    "foo": [""],
    "bar": ["", "None"],  // 🤦‍♂️
    "baz": [""]
  }
}
```

## Current outbound request

```js
{
  "url": "https://httpbin.zapier-tooling.com/post",
  "method": "POST",
  "params": {
    "foo": ["", ""],
    "bar": ["", ""],
    "baz": [""]
  }
}
```