### PR TITLE
PDE-2875 fix(legacy-scripting-runner): handle string array output from a scriptless create/action

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -860,6 +860,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
 
         try {
           result = zcli.JSON.parse(response.content);
+          if (postEventName) {
+            result = await parseFinalResult(result, {
+              key,
+              name: postEventName,
+            });
+          }
         } catch {
           result = {};
         }

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -714,13 +714,6 @@ const legacyScriptingSource = `
       },
 
       movie_returns_array: function(bundle) {
-        var data = z.JSON.parse(bundle.request.data);
-        var response = z.request({
-          method: 'POST',
-          url: '${HTTPBIN_URL}/post',
-          json: true,
-          body: data
-        });
         return [ 'foo', 'bar' ];
       },
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -713,10 +713,6 @@ const legacyScriptingSource = `
         return response.content;
       },
 
-      movie_returns_array: function(bundle) {
-        return [ 'foo', 'bar' ];
-      },
-
       // To be replaced with 'movie_pre_custom_action_fields' at runtime
       movie_pre_custom_action_fields_disabled: function(bundle) {
         bundle.request.url += 's';

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -713,6 +713,17 @@ const legacyScriptingSource = `
         return response.content;
       },
 
+      movie_returns_array: function(bundle) {
+        var data = z.JSON.parse(bundle.request.data);
+        var response = z.request({
+          method: 'POST',
+          url: '${HTTPBIN_URL}/post',
+          json: true,
+          body: data
+        });
+        return [ 'foo', 'bar' ];
+      },
+
       // To be replaced with 'movie_pre_custom_action_fields' at runtime
       movie_pre_custom_action_fields_disabled: function(bundle) {
         bundle.request.url += 's';

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2876,6 +2876,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it.only('KEY_write, returning array instead of object', () => {
+      // https://zapierorg.atlassian.net/browse/PDE-2875
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_returns_array',
+        'movie_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      input.bundle.inputData = {
+        title: 'Us',
+        genre: 'Horror',
+      };
+      return app(input).then((output) => {
+        should.deepEqual(output.results, { message: 'foo' });
+      });
+    });
+
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.inputFieldsUrl += 's';

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2877,22 +2877,25 @@ describe('Integration Test', () => {
     });
 
     it.only('KEY_write, returning array instead of object', () => {
-      // https://zapierorg.atlassian.net/browse/PDE-2875
-      const appDef = _.cloneDeep(appDefinition);
-      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
-        'movie_returns_array',
-        'movie_write'
-      );
-      const compiledApp = schemaTools.prepareApp(appDef);
-      const app = createApp(appDef);
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.creates.movie.operation.url += 's';
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_returns_array',
+          'movie_post_write'
+        );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
 
       const input = createTestInput(
         compiledApp,
         'creates.movie.operation.perform'
       );
+      input.bundle.authData = { api_key: 'secret' };
       input.bundle.inputData = {
-        title: 'Us',
-        genre: 'Horror',
+        title: 'Men In Black',
+        genre: 'Sci Fi',
       };
       return app(input).then((output) => {
         should.deepEqual(output.results, { message: 'foo' });

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2186,6 +2186,29 @@ describe('Integration Test', () => {
       });
     });
 
+    it('scriptingless perform, array of strings', () => {
+      if (!nock.isActive()) {
+        nock.activate();
+      }
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.creates.movie.operation.url += 's';
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      input.bundle.inputData = {
+        title: 'Men in Black',
+      };
+      nock(AUTH_JSON_SERVER_URL).post('/movies').reply(200, ['foo', 'bar']);
+      return app(input).then((output) => {
+        should.deepEqual(output.results, { message: 'foo' });
+      });
+    });
+
     it('KEY_pre_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.scriptingSource =
@@ -2873,32 +2896,6 @@ describe('Integration Test', () => {
       return app(input).then((output) => {
         const echoed = output.results;
         should.equal(echoed.json.hello, 'world');
-      });
-    });
-
-    it.only('KEY_write, returning array instead of object', () => {
-      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
-      appDefWithAuth.legacy.creates.movie.operation.url += 's';
-      appDefWithAuth.legacy.scriptingSource =
-        appDefWithAuth.legacy.scriptingSource.replace(
-          'movie_returns_array',
-          'movie_post_write'
-        );
-
-      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
-      const app = createApp(appDefWithAuth);
-
-      const input = createTestInput(
-        compiledApp,
-        'creates.movie.operation.perform'
-      );
-      input.bundle.authData = { api_key: 'secret' };
-      input.bundle.inputData = {
-        title: 'Men In Black',
-        genre: 'Sci Fi',
-      };
-      return app(input).then((output) => {
-        should.deepEqual(output.results, { message: 'foo' });
       });
     });
 


### PR DESCRIPTION
Some converted apps possess actions which return an array, rather than an object, which causes the platform to raise an error `JSON results object could not be located.`

In these situations, the legacy scripting runner should return an object `{ "message": results[0] }`
