### PR TITLE
PDE-2869 fix(legacy-scripting-runner): encode `request.data` in `form-urlencoded` for `pre` methods

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.8.5
+
+- :bug: Prune nulls and undefined's from query params ([#446](https://github.com/zapier/zapier-platform/pull/446))
+- :bug: Handle string array output from a scriptless create/action ([#447](https://github.com/zapier/zapier-platform/pull/447))
+- :bug: Encode `request.data` in `form-urlencoded` for `pre` methods ([#448](https://github.com/zapier/zapier-platform/pull/448))
+
 ## 3.8.4
 
 - :bug: Make sure `redirect_uri` is available during `oauth2.refresh` ([#444](https://github.com/zapier/zapier-platform/pull/444))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -213,11 +213,12 @@ const parseFinalResult = async (result, event) => {
           result.body = result.data;
         }
       }
-      // request.data isn't really used by CLI's z.request()
-      delete result.data;
     } else if (result.data === null || result.data === '') {
       result.body = '';
     }
+
+    // request.data isn't really used by CLI's z.request()
+    delete result.data;
     return result;
   }
 

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -665,6 +665,15 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_write_data_is_object: function(bundle) {
+        bundle.request.url = '${AUTH_JSON_SERVER_URL}/echo';
+        bundle.request.data = {
+          foo: 'bar',
+          apple: 123
+        };
+        return bundle.request;
+      },
+
       movie_write_default_headers: function(bundle) {
         bundle.request.url = '${HTTPBIN_URL}/post';
         bundle.request.data = z.JSON.stringify({

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -669,7 +669,14 @@ const legacyScriptingSource = `
         bundle.request.url = '${AUTH_JSON_SERVER_URL}/echo';
         bundle.request.data = {
           foo: 'bar',
-          apple: 123
+          apple: 123,
+          banana: null,
+          dragonfruit: '&=',
+          eggplant: [1.11, 2.22, null],
+          filbert: true,
+          nest: {foo: 'bar', 'hello': {world: [1.1, 2.2]}},
+          empty_object: {},
+          empty_array: []
         };
         return bundle.request;
       },

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2496,7 +2496,11 @@ describe('Integration Test', () => {
           echoed.headers['content-type'],
           'application/json; charset=utf-8'
         );
-        should.equal(echoed.textBody, 'foo=bar&apple=123');
+        should.equal(
+          echoed.textBody,
+          'foo=bar&apple=123&dragonfruit=%26%3D&eggplant=1.11&eggplant=2.22&' +
+            'filbert=True&nest=foo&nest=hello'
+        );
       });
     });
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -2475,6 +2475,31 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_write, data is object', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_pre_write_data_is_object',
+          'movie_pre_write'
+        );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        const echoed = output.results;
+        should.equal(
+          echoed.headers['content-type'],
+          'application/json; charset=utf-8'
+        );
+        should.equal(echoed.textBody, 'foo=bar&apple=123');
+      });
+    });
+
     it('KEY_post_write', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.url += 's';


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

## Legacy scripting code to reproduce the issue

```js
var Zap = {
  movie_pre_write: function(bundle) {
     bundle.request.url = 'https://auth-json-server.zapier-staging.com/echo';
     bundle.request.data = {
       foo: 'bar',
       apple: 123
     };
     return bundle.request;
   },
};
```

## Expected response from `/echo`

```js
{
  "method": "POST",
  "headers": {
    // ...
    "content-type": "application/json; charset=utf-8"
  },
  "textBody": "foo=bar&apple=123"
}
```

## Current response from `/echo`

```js
{
  "method": "POST",
  "headers": {
    // ...
    "content-type": "application/json; charset=utf-8"
  },
  "textBody": "{\"foo\":\"bar\",\"apple\":123}"
}
```