### PR TITLE
PDE-2085 chore(cli, schema): bump node-fetch to 2.6.6 (9.x backport)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "lodash": "4.17.15",
     "marked": "0.7.0",
     "marked-terminal": "3.3.0",
-    "node-fetch": "2.6.0",
+    "node-fetch": "2.6.6",
     "ora": "3.4.0",
     "parse-gitignore": "0.4.0",
     "prettier": "1.18.2",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -34,6 +34,6 @@
     "fs-extra": "8.1.0",
     "istanbul": "0.4.5",
     "markdown-toc": "1.2.0",
-    "node-fetch": "2.6.0"
+    "node-fetch": "2.6.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8690,17 +8690,17 @@ node-fetch@1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@2.6.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
-
 node-fetch@2.6.6:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^2.3.0, node-fetch@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-gyp@^5.0.2:
   version "5.0.5"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Bumps node-fetch for zapier-platform-cli and zapier-platform.schema. Forgot to do it in https://github.com/zapier/zapier-platform/pull/458.