### PR TITLE
PDE-2826 fix(core): backpressure issue with node-fetch patch

### DIFF
--- a/packages/core/src/tools/create-file-stasher.js
+++ b/packages/core/src/tools/create-file-stasher.js
@@ -60,7 +60,11 @@ const resolveRemoteStream = async (stream) => {
   try {
     await streamPipeline(stream, fs.createWriteStream(tmpFilePath));
   } catch (error) {
-    fs.unlinkSync(tmpFilePath);
+    try {
+      fs.unlinkSync(tmpFilePath);
+    } catch (e) {
+      // File doesn't exist? Probably okay
+    }
     throw error;
   }
 
@@ -69,7 +73,11 @@ const resolveRemoteStream = async (stream) => {
 
   readStream.on('end', () => {
     // Burn after reading
-    fs.unlinkSync(tmpFilePath);
+    try {
+      fs.unlinkSync(tmpFilePath);
+    } catch (e) {
+      // TODO: We probably want to log warning here
+    }
   });
 
   return {

--- a/packages/core/test/tools/fetch.js
+++ b/packages/core/test/tools/fetch.js
@@ -2,6 +2,8 @@ const nock = require('nock');
 const should = require('should');
 
 const fetch = require('../../src/tools/fetch');
+const FormData = require('form-data');
+
 const { HTTPBIN_URL } = require('../constants');
 
 describe('node-fetch patch', () => {
@@ -22,5 +24,21 @@ describe('node-fetch patch', () => {
 
     const result = await uploadResponse.json();
     should(result).eql({ length: 35000 });
+  });
+
+  it('should upload form data', async () => {
+    const downloadResponse = await fetch(`${HTTPBIN_URL}/stream-bytes/100`);
+
+    const form = new FormData();
+    form.append('name', 'hello');
+    form.append('data', downloadResponse.body);
+
+    const uploadResponse = await fetch(`${HTTPBIN_URL}/post`, {
+      method: 'POST',
+      body: form,
+    });
+
+    const result = await uploadResponse.json();
+    should(result.form.name).eql(['hello']);
   });
 });

--- a/packages/core/test/tools/fetch.js
+++ b/packages/core/test/tools/fetch.js
@@ -1,0 +1,29 @@
+const { randomBytes } = require('crypto');
+const { Readable } = require('stream');
+
+const nock = require('nock');
+const should = require('should');
+
+const fetch = require('../../src/tools/fetch');
+const { HTTPBIN_URL } = require('../constants');
+
+describe('node-fetch patch', () => {
+  it('should not hang due to backpressure', async () => {
+    nock('https://fake.zapier.com')
+      .put('/upload')
+      .reply(200, (uri, responseBody) => {
+        return {
+          length: Buffer.from(responseBody, 'hex').length,
+        };
+      });
+
+    const downloadResponse = await fetch(`${HTTPBIN_URL}/stream-bytes/35000`);
+    const uploadResponse = await fetch('https://fake.zapier.com/upload', {
+      method: 'PUT',
+      body: downloadResponse.body,
+    });
+
+    const result = await uploadResponse.json();
+    should(result).eql({ length: 35000 });
+  });
+});

--- a/packages/core/test/tools/fetch.js
+++ b/packages/core/test/tools/fetch.js
@@ -1,6 +1,3 @@
-const { randomBytes } = require('crypto');
-const { Readable } = require('stream');
-
 const nock = require('nock');
 const should = require('should');
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Using node-fetch 2.6.6 (Node.js 14), this program hangs on my laptop:

```js
const fs = require('fs');
const fetch = require('node-fetch');

async function main() {
  // 36864 bytes = 16 KB
  // If it's 36863, the bug won't happen
  const downloadUrl = 'https://httpbin.org/stream-bytes/36864';
  const downloadResponse = await fetch(downloadUrl);

  const uploadUrl = 'https://httpbin.org/put';
  const uploadOpts = {
    method: 'PUT',
    body: downloadResponse.body,
  };

  const uploadRequest = new fetch.Request(uploadUrl, uploadOpts);
  const uploadPromise = fetch(uploadRequest);
  const uploadResponse = await uploadPromise;
  console.log(uploadResponse.status);
}

main();
```

When you pass a `fetch.Request` object to `fetch()`, `fetch()` [copies](https://github.com/node-fetch/node-fetch/blob/v2.6.6/src/index.js#L46) the `Request` object. And if the `Request` has a streamable body, the `Request` constructor [clones](https://github.com/node-fetch/node-fetch/blob/v2.6.6/src/request.js#L106) the body by [teeing](https://github.com/node-fetch/node-fetch/blob/v2.6.6/src/body.js#L403-L412) the stream into two [`PassThrough`](https://nodejs.org/docs/latest-v14.x/api/stream.html#stream_class_stream_passthrough) streams. Then we read one of the `PassThrough` stream (A) and not the other (B). This causes B's internal buffer to fill up, so Node.js has to pause reading from the source until someone consumes B's buffer.

To fix, we add that someone to consume B. Right after the `fetch(uploadRequest)` call, we pipe `uploadRequest.body` to `/dev/null`:

```js
  const uploadPromise = fetch(uploadRequest);

  uploadRequest.body.pipe(fs.createWriteStream('/dev/null'));  // <---

  const uploadResponse = await uploadPromise;
```

And that solves the hanging problem.

This PR does something similar with our node-fetch patch.