### PR TITLE
PDE-2826 fix(core): backpressure issue with node-fetch patch (9.x backport)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "bluebird": "3.5.5",
     "content-disposition": "0.5.3",
     "dotenv": "8.1.0",
-    "form-data": "2.5.0",
+    "form-data": "4.0.0",
     "lodash": "4.17.15",
     "mime-types": "2.1.34",
     "node-fetch": "2.6.0",

--- a/packages/core/src/tools/create-file-stasher.js
+++ b/packages/core/src/tools/create-file-stasher.js
@@ -60,7 +60,11 @@ const resolveRemoteStream = async (stream) => {
   try {
     await streamPipeline(stream, fs.createWriteStream(tmpFilePath));
   } catch (error) {
-    fs.unlinkSync(tmpFilePath);
+    try {
+      fs.unlinkSync(tmpFilePath);
+    } catch (e) {
+      // File doesn't exist? Probably okay
+    }
     throw error;
   }
 
@@ -69,7 +73,11 @@ const resolveRemoteStream = async (stream) => {
 
   readStream.on('end', () => {
     // Burn after reading
-    fs.unlinkSync(tmpFilePath);
+    try {
+      fs.unlinkSync(tmpFilePath);
+    } catch (e) {
+      // TODO: We probably want to log warning here
+    }
   });
 
   return {

--- a/packages/core/test/tools/fetch.js
+++ b/packages/core/test/tools/fetch.js
@@ -1,0 +1,44 @@
+const nock = require('nock');
+const should = require('should');
+
+const fetch = require('../../src/tools/fetch');
+const FormData = require('form-data');
+
+const HTTPBIN_URL = 'https://httpbin.zapier-tooling.com';
+
+describe('node-fetch patch', () => {
+  it('should not hang due to backpressure', async () => {
+    nock('https://fake.zapier.com')
+      .put('/upload')
+      .reply(200, (uri, responseBody) => {
+        return {
+          length: Buffer.from(responseBody, 'hex').length,
+        };
+      });
+
+    const downloadResponse = await fetch(`${HTTPBIN_URL}/stream-bytes/35000`);
+    const uploadResponse = await fetch('https://fake.zapier.com/upload', {
+      method: 'PUT',
+      body: downloadResponse.body,
+    });
+
+    const result = await uploadResponse.json();
+    should(result).eql({ length: 35000 });
+  });
+
+  it('should upload form data', async () => {
+    const downloadResponse = await fetch(`${HTTPBIN_URL}/stream-bytes/100`);
+
+    const form = new FormData();
+    form.append('name', 'hello');
+    form.append('data', downloadResponse.body);
+
+    const uploadResponse = await fetch(`${HTTPBIN_URL}/post`, {
+      method: 'POST',
+      body: form,
+    });
+
+    const result = await uploadResponse.json();
+    should(result.form.name).eql(['hello']);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,7 +3852,7 @@ combine-source-map@^0.8.0, combine-source-map@~0.8.0:
     lodash.memoize "~3.0.3"
     source-map "~0.5.3"
 
-combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
+combined-stream@^1.0.5, combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -5752,13 +5752,13 @@ form-data@2.1.4, form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.0.tgz#094ec359dc4b55e7d62e0db4acd76e89fe874d37"
-  integrity sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==
+form-data@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.6"
+    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:


### PR DESCRIPTION

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Same as #461 but for 9.x.