### PR TITLE
PDE-2773 fix(cli): byte missing issue with `files` example

### DIFF
--- a/example-apps/files/creates/uploadFile_v10.js
+++ b/example-apps/files/creates/uploadFile_v10.js
@@ -6,18 +6,27 @@ const FormData = require('form-data');
 // 9.x compatible code, see uploadFile_v9.js.
 const makeDownloadStream = (url) =>
   new Promise((resolve, reject) => {
-    http.request(url, resolve).on('error', reject).end();
+    http
+      .request(url, (res) => {
+        // We can risk missing the first n bytes if we don't pause!
+        res.pause();
+        resolve(res);
+      })
+      .on('error', reject)
+      .end();
   });
 
 const perform = async (z, bundle) => {
-  const form = new FormData();
-
-  form.append('filename', bundle.inputData.filename);
-
   // bundle.inputData.file will in fact be an URL where the file data can be
   // downloaded from which we do via a stream
   const stream = await makeDownloadStream(bundle.inputData.file, z);
+
+  const form = new FormData();
+  form.append('filename', bundle.inputData.filename);
   form.append('file', stream);
+
+  // All set! Resume the stream
+  stream.resume();
 
   const response = await z.request({
     url: 'https://auth-json-server.zapier-staging.com/upload',

--- a/example-apps/files/package.json
+++ b/example-apps/files/package.json
@@ -11,7 +11,7 @@
     "form-data": "3.0.0"
   },
   "devDependencies": {
-    "jest": "^25.5.3"
+    "jest": "^26.6.3"
   },
   "private": true
 }

--- a/example-apps/files/package.json
+++ b/example-apps/files/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "zapier-platform-core": "11.2.0",
-    "form-data": "3.0.0"
+    "form-data": "4.0.0"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/packages/cli/src/generators/index.js
+++ b/packages/cli/src/generators/index.js
@@ -124,7 +124,7 @@ const writeForStandaloneTemplate = (gen) => {
     // names. This is going to used to extend the generic package.json.
     files: {
       dependencies: {
-        'form-data': '3.0.0',
+        'form-data': '4.0.0',
       },
     },
     typescript: {

--- a/packages/cli/src/generators/templates/files/creates/uploadFile_v10.js
+++ b/packages/cli/src/generators/templates/files/creates/uploadFile_v10.js
@@ -6,18 +6,24 @@ const FormData = require('form-data');
 // 9.x compatible code, see uploadFile_v9.js.
 const makeDownloadStream = (url) =>
   new Promise((resolve, reject) => {
-    http.request(url, resolve).on('error', reject).end();
+    http.request(url, (res) => {
+      // We can risk missing the first n bytes if we don't pause!
+      res.pause();
+      resolve(res);
+    }).on('error', reject).end();
   });
 
 const perform = async (z, bundle) => {
-  const form = new FormData();
-
-  form.append('filename', bundle.inputData.filename);
-
   // bundle.inputData.file will in fact be an URL where the file data can be
   // downloaded from which we do via a stream
   const stream = await makeDownloadStream(bundle.inputData.file, z);
+
+  const form = new FormData();
+  form.append('filename', bundle.inputData.filename);
   form.append('file', stream);
+
+  // All set! Resume the stream
+  stream.resume();
 
   const response = await z.request({
     url: 'https://auth-json-server.zapier-staging.com/upload',

--- a/packages/cli/src/generators/templates/files/test/creates.test.js
+++ b/packages/cli/src/generators/templates/files/test/creates.test.js
@@ -14,7 +14,7 @@ const FILE_URL =
 // This is what you get when doing `curl <FILE_URL> | sha1sum`
 const EXPECTED_SHA1 = '3cf58b42a0fb1b7cc58de8110096841ece967530';
 
-describe.skip('uploadFile', () => {
+describe('uploadFile', () => {
   test('upload file v10', async () => {
     if (CORE_VERSION[0] < 10) {
       console.warn(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes the flaky smoke test with the `files` example.

This [script](https://gist.github.com/eliangcs/eb8a93ff9a6ed09d777a0838423da0d4) proves that the original implementation of `makeDownloadStream()` in `uploadFile_v10.js` can miss the first chunk of bytes when downloading a file. I can't replicate the issue with a standalone Node.js program. But I found by pausing the file download stream, we can prevent the stream from being consumed too early.