### PR TITLE
PDE-2946 fix(core): fix `value.replace is not a function` when resolving missing curlies (9.x backport)

### DIFF
--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -41,13 +41,13 @@ describe('build (runs slowly)', () => {
   });
 
   it('should list only required files', () => {
-    return build.requiredFiles(tmpDir, [entryPoint]).then(smartPaths => {
+    return build.requiredFiles(tmpDir, [entryPoint]).then((smartPaths) => {
       // check that only the required lodash files are grabbed
       smartPaths.should.containEql('index.js');
       smartPaths.should.containEql('lib/index.js');
       smartPaths.should.containEql('lib/resources/recipe.js');
 
-      smartPaths.filter(p => p.endsWith('.ts')).length.should.equal(0);
+      smartPaths.filter((p) => p.endsWith('.ts')).length.should.equal(0);
       smartPaths.should.not.containEql('tsconfig.json');
 
       smartPaths.length.should.be.within(200, 300);
@@ -55,7 +55,7 @@ describe('build (runs slowly)', () => {
   });
 
   it('should list all the files', () => {
-    return build.listFiles(tmpDir).then(dumbPaths => {
+    return build.listFiles(tmpDir).then((dumbPaths) => {
       // check that way more than the required package files are grabbed
       dumbPaths.should.containEql('index.js');
       dumbPaths.should.containEql('lib/index.js');
@@ -65,7 +65,7 @@ describe('build (runs slowly)', () => {
       dumbPaths.should.containEql('src/resources/recipe.ts');
       dumbPaths.should.containEql('tsconfig.json');
 
-      dumbPaths.length.should.be.within(1500, 2000);
+      dumbPaths.length.should.be.within(1500, 2500);
     });
   });
 
@@ -77,8 +77,8 @@ describe('build (runs slowly)', () => {
       '.env',
       '.environment',
       '.git/HEAD',
-      'build/the-build.zip'
-    ].forEach(file => {
+      'build/the-build.zip',
+    ].forEach((file) => {
       const fileDir = file.split(path.sep);
       fileDir.pop();
       if (fileDir.length > 0) {
@@ -87,7 +87,7 @@ describe('build (runs slowly)', () => {
       fs.outputFileSync(path.join(tmpProjectDir, file), 'the-file');
     });
 
-    return build.listFiles(tmpProjectDir).then(dumbPaths => {
+    return build.listFiles(tmpProjectDir).then((dumbPaths) => {
       dumbPaths.should.containEql('safe.js');
       dumbPaths.should.not.containEql('.env');
       dumbPaths.should.not.containEql('build/the-build.zip');
@@ -116,7 +116,7 @@ describe('build (runs slowly)', () => {
     return build
       .makeZip(tmpProjectDir, tmpZipPath)
       .then(() => decompress(tmpZipPath, tmpUnzipPath))
-      .then(files => {
+      .then((files) => {
         files.length.should.equal(2);
 
         const indexFile = files.find(
@@ -157,7 +157,7 @@ describe('build (runs slowly)', () => {
     return build
       .makeZip(tmpProjectDir, tmpZipPath)
       .then(() => decompress(tmpZipPath, tmpUnzipPath))
-      .then(files => {
+      .then((files) => {
         files.length.should.equal(2);
 
         const indexFile = files.find(
@@ -202,7 +202,7 @@ describe('build (runs slowly)', () => {
     return build
       .makeSourceZip(tmpProjectDir, tmpZipPath)
       .then(() => decompress(tmpZipPath, tmpUnzipPath))
-      .then(files => {
+      .then((files) => {
         files.length.should.equal(4);
 
         const indexFile = files.find(
@@ -261,7 +261,7 @@ describe('build (runs slowly)', () => {
     return build
       .makeSourceZip(tmpProjectDir, tmpZipPath)
       .then(() => decompress(tmpZipPath, tmpUnzipPath))
-      .then(files => {
+      .then((files) => {
         files.length.should.equal(4);
 
         const indexFile = files.find(

--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -156,7 +156,7 @@ const isEmptyQueryParam = (value) =>
   value === '' ||
   value === null ||
   value === undefined ||
-  (typeof value === 'string' && isCurlies.test(value));
+  (typeof value === 'string' && value.search(isCurlies) >= 0);
 
 const normalizeEmptyParamFields = normalizeEmptyRequestFields.bind(
   null,
@@ -165,7 +165,7 @@ const normalizeEmptyParamFields = normalizeEmptyRequestFields.bind(
 );
 const normalizeEmptyBodyFields = normalizeEmptyRequestFields.bind(
   null,
-  (v) => typeof v === 'string' && isCurlies.test(v),
+  (v) => typeof v === 'string' && v.search(isCurlies) >= 0,
   'body'
 );
 

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -713,10 +713,16 @@ describe('request client', () => {
         should(json.empty).eql('');
         should(json.partial).eql('text ');
         should(json.value).eql('exists');
-        should(json.array).eql(['', 'foo', 'bar']);
+
+        // We don't do recursive replacement
+        should(json.array).eql([
+          '{{bundle.inputData.empty}}',
+          'foo{{bundle.inputData.noMatch}}',
+          'bar',
+        ]);
         should(json.obj).eql({
-          empty: '',
-          partial: 'text ',
+          empty: '{{bundle.inputData.empty}}',
+          partial: 'text {{bundle.inputData.partial}}',
           value: 'exists',
         });
       });

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -696,6 +696,16 @@ describe('request client', () => {
           empty: '{{bundle.inputData.empty}}',
           partial: 'text {{bundle.inputData.partial}}',
           value: 'exists',
+          array: [
+            '{{bundle.inputData.empty}}',
+            'foo{{bundle.inputData.noMatch}}',
+            'bar',
+          ],
+          obj: {
+            empty: '{{bundle.inputData.empty}}',
+            partial: 'text {{bundle.inputData.partial}}',
+            value: 'exists',
+          },
         },
       }).then((response) => {
         const { json } = response.json;
@@ -703,6 +713,12 @@ describe('request client', () => {
         should(json.empty).eql('');
         should(json.partial).eql('text ');
         should(json.value).eql('exists');
+        should(json.array).eql(['', 'foo', 'bar']);
+        should(json.obj).eql({
+          empty: '',
+          partial: 'text ',
+          value: 'exists',
+        });
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Given `bundle.inputData.foo` is non-existent, doing this will give you `value.replace is not a function` error:

```javascript
const perform = (z, bundle) => {
  const response = await z.request({
    url: 'https://example.com',
    method: 'POST',
    body: {
      inputs: ['{{bundle.inputData.foo}}'],
    }
  });
  return z.JSON.parse(response.content);
};
```

And this is the traceback:

```
Unhandled error: TypeError: value.replace is not a function
TypeError: value.replace is not a function
    at handleEmpty (:censored:9:d1ba0cf2aa:/node_modules/zapier-platform-core/src/tools/cleaner.js:137:27)
    at :censored:9:d1ba0cf2aa:/node_modules/zapier-platform-core/src/tools/cleaner.js:150:7
    at Array.forEach (<anonymous>)
    at normalizeEmptyRequestFields (:censored:9:d1ba0cf2aa:/node_modules/zapier-platform-core/src/tools/cleaner.js:148:30)
    at coerceBody (:censored:9:d1ba0cf2aa:/node_modules/zapier-platform-core/src/http-middlewares/before/prepare-request.js:63:5)
    at prepareRequest (:censored:9:d1ba0cf2aa:/node_modules/zapier-platform-core/src/http-middlewares/before/prepare-request.js:137:9)
    at Object.<anonymous> (:censored:9:d1ba0cf2aa:/node_modules/zapier-platform-core/src/middleware.js:66:31)
```

There are two problems with the regex `.test()` method.

First, `.test()` method can actually return true even if the input is a non-string. In this case, you can pass in an array and get a true:

```
> isCurlies = /{{.*?}}/g
/{{.*?}}/g
> isCurlies.test(['{{foo}}'])
true      // <- surprise!
```

Second, when working with the "global" (`/.../g`) flag, `.test()` [saves the state](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#using_test_on_a_regex_with_the_global_flag) between calls:

```
> isCurlies = /{{.*?}}/g
/{{.*?}}/g
> s = '{{test}}'
> isCurlies.test(s)
true
> isCurlies.test(s)
false    // <- another surprise!
```

Here is how we fix:
- make sure `value` is a string before we match it with a regex
- don't use `isCurlies.test(value)`; use `value.search(isCurlies) >= 0` instead