### PR TITLE
PDE-2946 fix(core): fix `value.replace is not a function` error when resolving missing curlies (11.x)

### DIFF
--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -158,7 +158,7 @@ const isEmptyQueryParam = (value) =>
   value === '' ||
   value === null ||
   value === undefined ||
-  isCurlies.test(value);
+  (typeof value === 'string' && value.search(isCurlies) >= 0);
 
 const normalizeEmptyParamFields = normalizeEmptyRequestFields.bind(
   null,
@@ -167,7 +167,7 @@ const normalizeEmptyParamFields = normalizeEmptyRequestFields.bind(
 );
 const normalizeEmptyBodyFields = normalizeEmptyRequestFields.bind(
   null,
-  (v) => isCurlies.test(v),
+  (v) => typeof v === 'string' && v.search(isCurlies) >= 0,
   'body'
 );
 

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -702,6 +702,16 @@ describe('request client', () => {
           empty: '{{bundle.inputData.empty}}',
           partial: 'text {{bundle.inputData.partial}}',
           value: 'exists',
+          array: [
+            '{{bundle.inputData.empty}}',
+            'foo{{bundle.inputData.noMatch}}',
+            'bar',
+          ],
+          obj: {
+            empty: '{{bundle.inputData.empty}}',
+            partial: 'text {{bundle.inputData.partial}}',
+            value: 'exists',
+          },
         },
       }).then((response) => {
         const { json } = response.data;
@@ -709,6 +719,18 @@ describe('request client', () => {
         should(json.empty).eql('');
         should(json.partial).eql('text ');
         should(json.value).eql('exists');
+
+        // We don't do recursive replacement
+        should(json.array).eql([
+          '{{bundle.inputData.empty}}',
+          'foo{{bundle.inputData.noMatch}}',
+          'bar',
+        ]);
+        should(json.obj).eql({
+          empty: '{{bundle.inputData.empty}}',
+          partial: 'text {{bundle.inputData.partial}}',
+          value: 'exists',
+        });
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Same as #467 but for 11.x.