### PR TITLE
fix(core): handle case where scriptingSource is an empty string

### DIFF
--- a/packages/core/ARCHITECTURE.md
+++ b/packages/core/ARCHITECTURE.md
@@ -31,7 +31,7 @@
 
 - At runtime, a developer's `perform` function is invoked with the following signature: `perform(z, bundle)`.
 - The `z` object is a collection of functions used commonly by developers and is defined in `core/src/tools/create-lambda-handler.js`
-- Its functions are either Zapier-specific (such as `z.cursor` and `z.dehyrate`) or wrappers around common JS functionality (such as `z.JSON.parse` and `z.console.log`) with better error handling or extra logging
+- Its functions are either Zapier-specific (such as `z.cursor` and `z.dehydrate`) or wrappers around common JS functionality (such as `z.JSON.parse` and `z.console.log`) with better error handling or extra logging
 - Each of those functions has its own file in `core/src/tools`
 - The most important method is probably `z.request` (from `core/src/tools/create-app-request-client.js`), which devs use to make external requests. This is different from normal http requests in a number of ways:
   - there are `beforeRequest` and `afterResponse` functions that run before and after the request. They can be declared by the developer or inserted automatically based on the authentication type.

--- a/packages/core/src/tools/create-legacy-scripting-runner.js
+++ b/packages/core/src/tools/create-legacy-scripting-runner.js
@@ -8,8 +8,11 @@ const semver = require('semver');
 const createLegacyScriptingRunner = (z, input) => {
   const app = _.get(input, '_zapier.app');
 
-  let source =
-    _.get(app, 'legacy.scriptingSource') || app.legacyScriptingSource;
+  // once we have node 14 everywhere, this can be:
+  // let source = _.get(app, 'legacy.scriptingSource') ?? app.legacyScriptingSource;
+  let source = _.get(app, 'legacy.scriptingSource');
+  source = source === undefined ? app.legacyScriptingSource : source;
+
   if (source === undefined) {
     // Don't initialize z.legacyScripting for a pure CLI app
     return null;
@@ -26,8 +29,8 @@ const createLegacyScriptingRunner = (z, input) => {
   let LegacyScriptingRunner, version;
   try {
     LegacyScriptingRunner = require('zapier-platform-legacy-scripting-runner');
-    version = require('zapier-platform-legacy-scripting-runner/package.json')
-      .version;
+    version =
+      require('zapier-platform-legacy-scripting-runner/package.json').version;
   } catch (e) {
     // Find it in cwd, in case we're developing legacy-scripting-runner itself
     const cwd = process.cwd();

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -655,6 +655,27 @@ describe('Integration Test', () => {
       });
     });
 
+    it('scriptingless, empty scripting string should be fine', () => {
+      if (!nock.isActive()) {
+        nock.activate();
+      }
+      // Mock the response with a string 'null'
+      nock(AUTH_JSON_SERVER_URL).get('/movies').reply(200, '[]');
+
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = ''; // rare case, but it's happened
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        should.deepEqual(output.results, []);
+      });
+    });
+
     it('scriptingless, empty auth mapping', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(


### PR DESCRIPTION
Handle a rare case where `legacy.scriptingSource` is an empty string on a legacy app, so we don't initialize LSR. Then, `z.legacyScripting.run(...)` fails w/ `Cannot read property 'run' of undefined`. 