### PR TITLE
feat(cli) add support for pnpm package manager in test command (PDE-3000)

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -1014,6 +1014,7 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is a wrapper around <code>npm test</code> that also validates the structure of your integration and sets up extra environment variables.</p><p>You can pass any args/flags after a <code>--</code>; they will get forwarded onto your test script.</p><p><strong>Flags</strong></p><ul>
 <li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before tests are run. This will speed up tests if you&apos;re modifying functionality of an existing integration rather than adding new actions.</li>
 <li><code>--yarn</code> | Use <code>yarn</code> instead of <code>npm</code>. This happens automatically if there&apos;s a <code>yarn.lock</code> file, but you can manually force <code>yarn</code> if you run tests from a sub-directory.</li>
+<li><code>--pnpm</code> | Use <code>pnpm</code> instead of <code>npm</code>. This happens automatically if there&apos;s a <code>pnpm-lock.yaml</code> file, but you can manually force <code>pnpm</code> if you run tests from a sub-directory.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier test</code></li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -526,6 +526,7 @@ You can pass any args/flags after a `--`; they will get forwarded onto your test
 **Flags**
 * `--skip-validate` | Forgo running `zapier validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.
 * `--yarn` | Use `yarn` instead of `npm`. This happens automatically if there's a `yarn.lock` file, but you can manually force `yarn` if you run tests from a sub-directory.
+* `--pnpm` | Use `pnpm` instead of `npm`. This happens automatically if there's a `pnpm-lock.yaml` file, but you can manually force `pnpm` if you run tests from a sub-directory.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -1014,6 +1014,7 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier test</code></p><p>This command is a wrapper around <code>npm test</code> that also validates the structure of your integration and sets up extra environment variables.</p><p>You can pass any args/flags after a <code>--</code>; they will get forwarded onto your test script.</p><p><strong>Flags</strong></p><ul>
 <li><code>--skip-validate</code> | Forgo running <code>zapier validate</code> before tests are run. This will speed up tests if you&apos;re modifying functionality of an existing integration rather than adding new actions.</li>
 <li><code>--yarn</code> | Use <code>yarn</code> instead of <code>npm</code>. This happens automatically if there&apos;s a <code>yarn.lock</code> file, but you can manually force <code>yarn</code> if you run tests from a sub-directory.</li>
+<li><code>--pnpm</code> | Use <code>pnpm</code> instead of <code>npm</code>. This happens automatically if there&apos;s a <code>pnpm-lock.yaml</code> file, but you can manually force <code>pnpm</code> if you run tests from a sub-directory.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier test</code></li>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -526,6 +526,7 @@ You can pass any args/flags after a `--`; they will get forwarded onto your test
 **Flags**
 * `--skip-validate` | Forgo running `zapier validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.
 * `--yarn` | Use `yarn` instead of `npm`. This happens automatically if there's a `yarn.lock` file, but you can manually force `yarn` if you run tests from a sub-directory.
+* `--pnpm` | Use `pnpm` instead of `npm`. This happens automatically if there's a `pnpm-lock.yaml` file, but you can manually force `pnpm` if you run tests from a sub-directory.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/src/tests/utils/package-manager.js
+++ b/packages/cli/src/tests/utils/package-manager.js
@@ -1,0 +1,151 @@
+require('should');
+const mock = require('mock-fs');
+const { getPackageManager } = require('../../utils/package-manager');
+
+describe('package manager utils', () => {
+  describe('getPackageManager', () => {
+    it('should identify npm correctly', async () => {
+      mock(
+        {
+          'package-lock.json': '',
+        },
+        {
+          createCwd: true,
+          createTmp: true,
+        }
+      );
+
+      const man = await getPackageManager({
+        yarn: false,
+        pnpm: false,
+      });
+
+      man.should.containEql({
+        executable: 'npm',
+        useDoubleHyphenBeforeArgs: true,
+      });
+
+      mock.restore();
+    });
+
+    it('should identify yarn correctly', async () => {
+      mock(
+        {
+          'yarn.lock': '',
+        },
+        {
+          createCwd: true,
+          createTmp: true,
+        }
+      );
+
+      const man = await getPackageManager({
+        yarn: false,
+        pnpm: false,
+      });
+
+      man.should.containEql({
+        executable: 'yarn',
+        useDoubleHyphenBeforeArgs: false,
+      });
+
+      mock.restore();
+    });
+
+    it('should identify pnpm correctly', async () => {
+      mock(
+        {
+          'pnpm-lock.yaml': '',
+        },
+        {
+          createCwd: true,
+          createTmp: true,
+        }
+      );
+
+      const man = await getPackageManager({
+        yarn: false,
+        pnpm: false,
+      });
+
+      man.should.containEql({
+        executable: 'pnpm',
+        useDoubleHyphenBeforeArgs: true,
+      });
+
+      mock.restore();
+    });
+
+    it('should force yarn correctly', async () => {
+      mock(
+        {
+          'package-lock.json': '',
+        },
+        {
+          createCwd: true,
+          createTmp: true,
+        }
+      );
+
+      const man = await getPackageManager({
+        yarn: true,
+        pnpm: false,
+      });
+
+      man.should.containEql({
+        executable: 'yarn',
+        useDoubleHyphenBeforeArgs: false,
+      });
+
+      mock.restore();
+    });
+
+    it('should force pnpm correctly', async () => {
+      mock(
+        {
+          'package-lock.json': '',
+        },
+        {
+          createCwd: true,
+          createTmp: true,
+        }
+      );
+
+      const man = await getPackageManager({
+        yarn: false,
+        pnpm: true,
+      });
+
+      man.should.containEql({
+        executable: 'pnpm',
+        useDoubleHyphenBeforeArgs: true,
+      });
+
+      mock.restore();
+    });
+
+    it('should use npm by default', async () => {
+      mock(
+        {
+          'actually-no-package-file.json': '',
+        },
+        {
+          createCwd: true,
+          createTmp: true,
+        }
+      );
+
+      const man = await getPackageManager({
+        yarn: false,
+        pnpm: false,
+      });
+
+      man.should.containEql({
+        executable: 'npm',
+        useDoubleHyphenBeforeArgs: true,
+      });
+
+      mock.restore();
+    });
+  });
+});

--- a/packages/cli/src/utils/package-manager.js
+++ b/packages/cli/src/utils/package-manager.js
@@ -1,0 +1,45 @@
+const { pathExists } = require('fs-extra');
+const path = require('path');
+
+const packageManagers = [
+  {
+    lockFile: 'package-lock.json',
+    forceFlag: undefined,
+    executable: 'npm',
+    useDoubleHyphenBeforeArgs: true,
+  },
+  {
+    lockFile: 'yarn.lock',
+    forceFlag: 'yarn',
+    executable: 'yarn',
+    useDoubleHyphenBeforeArgs: false, // yarn gives a warning if we include `--`
+  },
+  {
+    lockFile: 'pnpm-lock.yaml',
+    forceFlag: 'pnpm',
+    executable: 'pnpm',
+    useDoubleHyphenBeforeArgs: true,
+  },
+];
+
+const defaultPackageManager = packageManagers[0];
+
+const getPackageManager = async (flags) => {
+  for (const man of packageManagers) {
+    if (flags[man.forceFlag]) {
+      return man;
+    }
+  }
+
+  for (const man of packageManagers) {
+    if (await pathExists(path.join(process.cwd(), man.lockFile))) {
+      return man;
+    }
+  }
+
+  return defaultPackageManager;
+};
+
+module.exports = {
+  getPackageManager,
+};


### PR DESCRIPTION
add `pnpm-lock.yaml` as recognized file to decide which package manager to run.

to accomplish this cleanly and future proof, i added a util-module for package managers, their lockfiles and their double-hyphen-needed-ness.

fixes #470 