### PR TITLE
fix(legacy-scripting-runner): backport #475; handle empty scripting string

### DIFF
--- a/packages/core/src/tools/create-legacy-scripting-runner.js
+++ b/packages/core/src/tools/create-legacy-scripting-runner.js
@@ -8,8 +8,11 @@ const semver = require('semver');
 const createLegacyScriptingRunner = (z, input) => {
   const app = _.get(input, '_zapier.app');
 
-  let source =
-    _.get(app, 'legacy.scriptingSource') || app.legacyScriptingSource;
+  // once we have node 14 everywhere, this can be:
+  // let source = _.get(app, 'legacy.scriptingSource') ?? app.legacyScriptingSource;
+  let source = _.get(app, 'legacy.scriptingSource');
+  source = source === undefined ? app.legacyScriptingSource : source;
+
   if (source === undefined) {
     // Don't initialize z.legacyScripting for a pure CLI app
     return null;
@@ -26,8 +29,8 @@ const createLegacyScriptingRunner = (z, input) => {
   let LegacyScriptingRunner, version;
   try {
     LegacyScriptingRunner = require('zapier-platform-legacy-scripting-runner');
-    version = require('zapier-platform-legacy-scripting-runner/package.json')
-      .version;
+    version =
+      require('zapier-platform-legacy-scripting-runner/package.json').version;
   } catch (e) {
     // Find it in cwd, in case we're developing legacy-scripting-runner itself
     const cwd = process.cwd();

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1211,6 +1211,27 @@ describe('Integration Test', () => {
       });
     });
 
+    it('scriptingless, empty scripting string should be fine', () => {
+      if (!nock.isActive()) {
+        nock.activate();
+      }
+      // Mock the response with a string 'null'
+      nock(AUTH_JSON_SERVER_URL).get('/movies').reply(200, '[]');
+
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = ''; // rare case, but it's happened
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        should.deepEqual(output.results, []);
+      });
+    });
+
     it('KEY_catch_hook => object', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(


### PR DESCRIPTION
see #475 