### PR TITLE
PDE-2981: feature(cli) - Update "promote" and "migrate" to use new endpoint

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -806,7 +806,7 @@ a code {
 <li><p>This does <strong>NOT</strong> recommend old users stop using this version - <code>zapier deprecate 1.0.0 2017-01-01</code> does that.</p>
 </li>
 </ul><p>Promotes are an inherently safe operation for all existing users of your integration.</p><p>If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.</p><p><strong>Arguments</strong></p><ul>
-<li>(required) <code>version</code> | The version you want promote.</li>
+<li>(required) <code>version</code> | The version you want to promote.</li>
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -368,7 +368,7 @@ Promotes are an inherently safe operation for all existing users of your integra
 If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.
 
 **Arguments**
-* (required) `version` | The version you want promote.
+* (required) `version` | The version you want to promote.
 
 **Flags**
 * `-d, --debug` | Show extra debugging output.

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -806,7 +806,7 @@ a code {
 <li><p>This does <strong>NOT</strong> recommend old users stop using this version - <code>zapier deprecate 1.0.0 2017-01-01</code> does that.</p>
 </li>
 </ul><p>Promotes are an inherently safe operation for all existing users of your integration.</p><p>If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.</p><p><strong>Arguments</strong></p><ul>
-<li>(required) <code>version</code> | The version you want promote.</li>
+<li>(required) <code>version</code> | The version you want to promote.</li>
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -368,7 +368,7 @@ Promotes are an inherently safe operation for all existing users of your integra
 If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.
 
 **Arguments**
-* (required) `version` | The version you want promote.
+* (required) `version` | The version you want to promote.
 
 **Flags**
 * `-d, --debug` | Show extra debugging output.

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -15,6 +15,7 @@ class MigrateCommand extends BaseCommand {
     const user = this.flags.user;
     const fromVersion = this.args.fromVersion;
     const toVersion = this.args.toVersion;
+    const email = this.args.email;
 
     if (user && percent !== 100) {
       this.error(
@@ -46,7 +47,9 @@ class MigrateCommand extends BaseCommand {
     }
 
     const body = {
-      percent,
+      name: 'migrate',
+      from_version: fromVersion,
+      to_version: toVersion,
     };
     if (user) {
       body.user = user;
@@ -58,8 +61,16 @@ class MigrateCommand extends BaseCommand {
         `Starting migration from ${fromVersion} to ${toVersion} for ${percent}%`
       );
     }
+    if (percent) {
+      body.percent_human = percent;
+    }
+    if (email) {
+      body.email = email;
+    }
 
-    const url = `/apps/${app.id}/versions/${fromVersion}/migrate-to/${toVersion}`;
+    // const url = `/apps/${app.id}/versions/${fromVersion}/migrate-to/${toVersion}`;
+    const url = `/apps/${app.id}/migrations`;
+
     try {
       await callAPI(url, { method: 'POST', body });
     } finally {

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -47,12 +47,14 @@ class MigrateCommand extends BaseCommand {
     }
 
     const body = {
-      name: 'migrate',
-      from_version: fromVersion,
-      to_version: toVersion,
+      job: {
+        name: 'migrate',
+        from_version: fromVersion,
+        to_version: toVersion,
+      },
     };
     if (user) {
-      body.user = user;
+      body.job.user = user;
       this.startSpinner(
         `Starting migration from ${fromVersion} to ${toVersion} for ${user}`
       );
@@ -62,13 +64,12 @@ class MigrateCommand extends BaseCommand {
       );
     }
     if (percent) {
-      body.percent_human = percent;
+      body.job.percent_human = percent;
     }
     if (email) {
-      body.email = email;
+      body.job.email = email;
     }
 
-    // const url = `/apps/${app.id}/versions/${fromVersion}/migrate-to/${toVersion}`;
     const url = `/apps/${app.id}/migrations`;
 
     try {

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -15,7 +15,6 @@ class MigrateCommand extends BaseCommand {
     const user = this.flags.user;
     const fromVersion = this.args.fromVersion;
     const toVersion = this.args.toVersion;
-    const email = this.args.email;
 
     if (user && percent !== 100) {
       this.error(
@@ -51,10 +50,10 @@ class MigrateCommand extends BaseCommand {
         name: 'migrate',
         from_version: fromVersion,
         to_version: toVersion,
+        email: user,
       },
     };
     if (user) {
-      body.job.user = user;
       this.startSpinner(
         `Starting migration from ${fromVersion} to ${toVersion} for ${user}`
       );
@@ -65,9 +64,6 @@ class MigrateCommand extends BaseCommand {
     }
     if (percent) {
       body.job.percent_human = percent;
-    }
-    if (email) {
-      body.job.email = email;
     }
 
     const url = `/apps/${app.id}/migrations`;

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -28,6 +28,7 @@ class PromoteCommand extends BaseCommand {
     const app = await this.getWritableApp();
 
     const version = this.args.version;
+    console.log('hey buddy!');
 
     let shouldContinue;
     const changelog = await getVersionChangelog(version);
@@ -60,19 +61,22 @@ class PromoteCommand extends BaseCommand {
       `Preparing to promote version ${version} of your integration "${app.title}".`
     );
 
-    const body = {};
+    const body = {
+      name: 'promote',
+      to_version: version, // This is done here: https://github.com/zapier/zapier/blob/develop/web/backend/zapier/app_platform/developer_cli/api/migration_resources.py#L584
+    };
     if (changelog) {
       body.changelog = changelog;
     }
 
     this.startSpinner(`Verifying and promoting ${version}`);
 
-    const url = `/apps/${app.id}/versions/${version}/promote/production`;
+    const url = `/apps/${app.id}/migrations`;
     try {
       await callAPI(
         url,
         {
-          method: 'PUT',
+          method: 'POST',
           body,
         },
         true
@@ -120,7 +124,7 @@ PromoteCommand.args = [
   {
     name: 'version',
     required: true,
-    description: 'The version you want promote.',
+    description: 'The version you want to promote.',
   },
 ];
 

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -62,11 +62,13 @@ class PromoteCommand extends BaseCommand {
     );
 
     const body = {
-      name: 'promote',
-      to_version: version, // This is done here: https://github.com/zapier/zapier/blob/develop/web/backend/zapier/app_platform/developer_cli/api/migration_resources.py#L584
+      job: {
+        name: 'promote',
+        to_version: version, // This is done here: https://github.com/zapier/zapier/blob/develop/web/backend/zapier/app_platform/developer_cli/api/migration_resources.py#L584
+      },
     };
     if (changelog) {
-      body.changelog = changelog;
+      body.job.changelog = changelog;
     }
 
     this.startSpinner(`Verifying and promoting ${version}`);

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -64,7 +64,7 @@ class PromoteCommand extends BaseCommand {
     const body = {
       job: {
         name: 'promote',
-        to_version: version, // This is done here: https://github.com/zapier/zapier/blob/develop/web/backend/zapier/app_platform/developer_cli/api/migration_resources.py#L584
+        to_version: version,
       },
     };
     if (changelog) {

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -28,7 +28,6 @@ class PromoteCommand extends BaseCommand {
     const app = await this.getWritableApp();
 
     const version = this.args.version;
-    console.log('hey buddy!');
 
     let shouldContinue;
     const changelog = await getVersionChangelog(version);
@@ -65,11 +64,9 @@ class PromoteCommand extends BaseCommand {
       job: {
         name: 'promote',
         to_version: version,
+        changelog,
       },
     };
-    if (changelog) {
-      body.job.changelog = changelog;
-    }
 
     this.startSpinner(`Verifying and promoting ${version}`);
 


### PR DESCRIPTION
Internally points the CLI `promote` and `migrate` command to use the new [migration endpoint](https://github.com/zapier/zapier/blob/8379df093af726b2318083282889cd73eda4c81c/web/backend/zapier/app_platform/developer_cli/api/urls.py). 

These commands currently point to an endpoint that calls out to the new migration endpoint so this is work to remove that indirection.

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
