### PR TITLE
[SUPPORTESC-307] docs(cli): Clarify auth section wording, especially authData vs inputData

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1143,9 +1143,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Most applications require some sort of authentication - and Zapier provides a handful of methods for helping your users authenticate with your application. Zapier will provide some of the core behaviors, but you&apos;ll likely need to handle the rest.</p><blockquote>
-<p>Hint: You can access the data tied to your authentication via the <code>bundle.authData</code> property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.</p>
-</blockquote>
+      <p>Most applications require some sort of authentication. The Zapier platform provides core behaviors for several authentication methods that might be used with your application, as well as the ability to configure or customize authentication further for certain methods.</p><p>Data tied to authentication is included in the <a href="#bundle-object">bundle object</a>. Data used on an ongoing basis to authenticate requests is included in <code>bundle.authData</code>, while temporary values used in the establishment of <a href="#oauth1">OAuth</a> and <a href="#session">Session auth</a> are stored in <code>bundle.inputData</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1243,7 +1241,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass data returned from the authentication process by adding/computing needed headers.</p><blockquote>
+      <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth</a> for a working example app for custom auth.</p>
 </blockquote>
     </div>
@@ -1510,7 +1508,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have fields like <code>redirect_uri</code> and the temporary credentials in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. After <code>getAccessToken</code> runs, the resulting token value(s) will be stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
+      <p>For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have fields like <code>redirect_uri</code> and the temporary credentials in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. After <code>getAccessToken</code> runs, the resulting token value(s) will be stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1539,7 +1537,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </ol><p>You are required to define:</p><ul>
 <li><code>authorizeUrl</code>: The authorization URL</li>
 <li><code>getAccessToken</code>: The API call to fetch the access token</li>
-</ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh. You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>
+</ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh (<code>refreshAccessToken</code>). You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
@@ -1629,7 +1627,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -1199,10 +1199,10 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users will provide Zapier their username and password and Zapier will handle all the nonce and quality of protection details automatically.</p><blockquote>
+      <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth</a> for a working example app for digest auth.</p>
 </blockquote><blockquote>
-<p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will sends an additional request beforehand to get the server nonce.</p>
+<p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will send an additional request beforehand to get the server nonce.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1243,7 +1243,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This is what most &quot;API Key&quot; driven apps should default to using. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> to complete the authentication by adding/computing needed headers.</p><blockquote>
+      <p>Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass data returned from the authentication process by adding/computing needed headers.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth</a> for a working example app for custom auth.</p>
 </blockquote>
     </div>
@@ -1302,7 +1302,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Probably the most &quot;powerful&quot; mechanism for authentication - it gives you the ability to exchange some user provided data for some authentication data (IE: username &amp; password for a session key).</p><blockquote>
+      <p>Session auth gives you the ability to exchange some user provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth</a> for a working example app for session auth.</p>
 </blockquote>
     </div>
@@ -1376,9 +1376,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <blockquote>
-<p>Note: For Session auth, <code>authentication.sessionConfig.perform</code> will have the provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code> because <code>bundle.authData</code> will only have &quot;previously existing&quot; values, which will be empty the first time the Zap runs.</p>
-</blockquote>
+      <p>For Session auth, the function that fetches the additional authentication data needed to make API calls ( <code>authentication.sessionConfig.perform</code>) will have the user-provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. Afterwards, <code>bundle.authData</code> will contain the data provided by that function (usually the session key or token).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1396,7 +1394,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/basics/authentication/overview">Twitter&apos;s</a> and <a href="https://developers.trello.com/page/authorization">Trello&apos;s</a> implementation of the 3-legged OAuth flow.</p><blockquote>
+      <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a">Twitter</a> and <a href="https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth">Trello</a> implementations of the 3-legged OAuth flow.</p><blockquote>
 <p>Example Apps: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
 </blockquote><p>The flow works like this:</p><ol>
 <li>Zapier makes a call to your API requesting a &quot;request token&quot; (also known as &quot;temporary credentials&quot;).</li>
@@ -1512,9 +1510,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <blockquote>
-<p>Note: For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have the provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code> because <code>bundle.authData</code> will only have &quot;previously existing&quot; values, which will be empty when the user hasn&apos;t connected their account on your service to Zapier. Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the users return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
-</blockquote>
+      <p>For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have fields like <code>redirect_uri</code> and the temporary credentials in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. After <code>getAccessToken</code> runs, the resulting token value(s) will be stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1633,9 +1629,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <blockquote>
-<p>Note: For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  will have the provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code> because <code>bundle.authData</code> will only have &quot;previously existing&quot; values, which will be empty when the user hasn&apos;t connected their account on your service to Zapier. Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the users return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
-</blockquote>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3398,7 +3392,7 @@ zapier env:get 1.0.0
 <li><strong>Shorthand HTTP Requests</strong> - these are simple object literals that make it easy to define simple requests.</li>
 <li><strong>Manual HTTP Requests</strong> - you use <code>z.request([url], options)</code> to make the requests and control the response. Use this when you need to change options for certain requests (for all requests, use middleware).</li>
 </ol><p>There are also a few helper constructs you can use to reduce boilerplate:</p><ol>
-<li><code>requestTemplate</code> which is an shorthand HTTP request that will be merged with every request.</li>
+<li><code>requestTemplate</code> which is a shorthand HTTP request that will be merged with every request.</li>
 <li><code>beforeRequest</code> middleware which is an array of functions to mutate a request before it is sent.</li>
 <li><code>afterResponse</code> middleware which is an array of functions to mutate a response before it is completed.</li>
 </ol><blockquote>
@@ -3421,7 +3415,7 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For simple HTTP requests that do not require special pre or post processing, you can specify the HTTP options as an object literal in your app definition.</p><p>This features:</p><ol>
+      <p>For simple HTTP requests that do not require special pre- or post-processing, you can specify the HTTP options as an object literal in your app definition.</p><p>This features:</p><ol>
 <li>Lazy <code>{{curly}}</code> replacement.</li>
 <li>JSON and form body de-serialization.</li>
 <li>Automatic non-2xx error raising.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1627,7 +1627,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code> have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -436,7 +436,7 @@ Your auth definition would look something like this:
 [insert-file:./snippets/oauth2.js]
 ```
 
-For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
+For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken` have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
 
 Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example, from the query string).
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -301,9 +301,9 @@ zapier convert 1234 --version 1.0.1 my-app
 
 ## Authentication
 
-Most applications require some sort of authentication - and Zapier provides a handful of methods for helping your users authenticate with your application. Zapier will provide some of the core behaviors, but you'll likely need to handle the rest.
+Most applications require some sort of authentication. The Zapier platform provides core behaviors for several authentication methods that might be used with your application, as well as the ability to configure or customize authentication further for certain methods.
 
-> Hint: You can access the data tied to your authentication via the `bundle.authData` property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.
+Data tied to authentication is included in the [bundle object](#bundle-object). Data used on an ongoing basis to authenticate requests is included in `bundle.authData`, while temporary values used in the establishment of [OAuth](#oauth1) and [Session auth](#session) are stored in `bundle.inputData`.
 
 ### Basic
 
@@ -333,7 +333,7 @@ The setup and user experience of Digest Auth is identical to Basic Auth. Users p
 
 ### Custom
 
-Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass data returned from the authentication process by adding/computing needed headers.
+Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
 > Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth for a working example app for custom auth.
 
@@ -394,7 +394,7 @@ Your auth definition would look something like this:
 
 For OAuth1, `authentication.oauth1Config.getRequestToken`, `authentication.oauth1Config.authorizeUrl`, and `authentication.oauth1Config.getAccessToken` will have fields like `redirect_uri` and the temporary credentials in `bundle.inputData` instead of `bundle.authData`. After `getAccessToken` runs, the resulting token value(s) will be stored in `bundle.authData` for long-term use.
 
-Also note that `authentication.oauth1Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+Also note that `authentication.oauth1Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example, from the query string).
 
 ### OAuth2
 
@@ -417,7 +417,7 @@ You are required to define:
   * `authorizeUrl`: The authorization URL
   * `getAccessToken`: The API call to fetch the access token
 
-If the access token has a limited life and you want to refresh the token when it expires, you'll also need to define the API call to perform that refresh. You can choose to set `autoRefresh: true`, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See [Stale Authentication Credentials](#stale-authentication-credentials) for more details on handling auth refresh.
+If the access token has a limited life and you want to refresh the token when it expires, you'll also need to define the API call to perform that refresh (`refreshAccessToken`). You can choose to set `autoRefresh: true`, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See [Stale Authentication Credentials](#stale-authentication-credentials) for more details on handling auth refresh.
 
 You'll also likely want to set your `CLIENT_ID` and `CLIENT_SECRET` as environment variables:
 
@@ -438,7 +438,7 @@ Your auth definition would look something like this:
 
 For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
 
-Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example, from the query string).
 
 
 ## Resources

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -321,11 +321,11 @@ If your app uses Basic auth with an encoded API key rather than a username and p
 
 *New in v7.4.0.*
 
-The setup and user experience of Digest Auth is identical to Basic Auth. Users will provide Zapier their username and password and Zapier will handle all the nonce and quality of protection details automatically.
+The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.
 
 > Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth for a working example app for digest auth.
 
-> Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every `z.request` call, Zapier will sends an additional request beforehand to get the server nonce.
+> Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every `z.request` call, Zapier will send an additional request beforehand to get the server nonce.
 
 ```js
 [insert-file:./snippets/digest-auth.js]
@@ -333,7 +333,7 @@ The setup and user experience of Digest Auth is identical to Basic Auth. Users w
 
 ### Custom
 
-This is what most "API Key" driven apps should default to using. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` to complete the authentication by adding/computing needed headers.
+Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass data returned from the authentication process by adding/computing needed headers.
 
 > Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth for a working example app for custom auth.
 
@@ -343,7 +343,7 @@ This is what most "API Key" driven apps should default to using. You'll likely p
 
 ### Session
 
-Probably the most "powerful" mechanism for authentication - it gives you the ability to exchange some user provided data for some authentication data (IE: username & password for a session key).
+Session auth gives you the ability to exchange some user provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.
 
 > Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth for a working example app for session auth.
 
@@ -351,13 +351,13 @@ Probably the most "powerful" mechanism for authentication - it gives you the abi
 [insert-file:./snippets/session-auth.js]
 ```
 
-> Note: For Session auth, `authentication.sessionConfig.perform` will have the provided fields in `bundle.inputData` instead of `bundle.authData` because `bundle.authData` will only have "previously existing" values, which will be empty the first time the Zap runs.
+For Session auth, the function that fetches the additional authentication data needed to make API calls ( `authentication.sessionConfig.perform`) will have the user-provided fields in `bundle.inputData` instead of `bundle.authData`. Afterwards, `bundle.authData` will contain the data provided by that function (usually the session key or token).
 
 ### OAuth1
 
 *New in `v7.5.0`.*
 
-Zapier's OAuth1 implementation matches [Twitter's](https://developer.twitter.com/en/docs/basics/authentication/overview) and [Trello's](https://developers.trello.com/page/authorization) implementation of the 3-legged OAuth flow.
+Zapier's OAuth1 implementation matches [Twitter](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a) and [Trello](https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth) implementations of the 3-legged OAuth flow.
 
 > Example Apps: Check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
 
@@ -392,7 +392,9 @@ Your auth definition would look something like this:
 [insert-file:./snippets/oauth1.js]
 ```
 
-> Note: For OAuth1, `authentication.oauth1Config.getRequestToken`, `authentication.oauth1Config.authorizeUrl`, and `authentication.oauth1Config.getAccessToken` will have the provided fields in `bundle.inputData` instead of `bundle.authData` because `bundle.authData` will only have "previously existing" values, which will be empty when the user hasn't connected their account on your service to Zapier. Also note that `authentication.oauth1Config.getAccessToken` has access to the users return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+For OAuth1, `authentication.oauth1Config.getRequestToken`, `authentication.oauth1Config.authorizeUrl`, and `authentication.oauth1Config.getAccessToken` will have fields like `redirect_uri` and the temporary credentials in `bundle.inputData` instead of `bundle.authData`. After `getAccessToken` runs, the resulting token value(s) will be stored in `bundle.authData` for long-term use.
+
+Also note that `authentication.oauth1Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
 
 ### OAuth2
 
@@ -434,7 +436,9 @@ Your auth definition would look something like this:
 [insert-file:./snippets/oauth2.js]
 ```
 
-> Note: For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  will have the provided fields in `bundle.inputData` instead of `bundle.authData` because `bundle.authData` will only have "previously existing" values, which will be empty when the user hasn't connected their account on your service to Zapier. Also note that `authentication.oauth2Config.getAccessToken` has access to the users return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
+
+Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
 
 
 ## Resources
@@ -1046,7 +1050,7 @@ There are two primary ways to make HTTP requests in the Zapier platform:
 
 There are also a few helper constructs you can use to reduce boilerplate:
 
-1. `requestTemplate` which is an shorthand HTTP request that will be merged with every request.
+1. `requestTemplate` which is a shorthand HTTP request that will be merged with every request.
 2. `beforeRequest` middleware which is an array of functions to mutate a request before it is sent.
 3. `afterResponse` middleware which is an array of functions to mutate a response before it is completed.
 
@@ -1054,7 +1058,7 @@ There are also a few helper constructs you can use to reduce boilerplate:
 
 ### Shorthand HTTP Requests
 
-For simple HTTP requests that do not require special pre or post processing, you can specify the HTTP options as an object literal in your app definition.
+For simple HTTP requests that do not require special pre- or post-processing, you can specify the HTTP options as an object literal in your app definition.
 
 This features:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -443,9 +443,9 @@ zapier convert 1234 --version 1.0.1 my-app
 
 ## Authentication
 
-Most applications require some sort of authentication - and Zapier provides a handful of methods for helping your users authenticate with your application. Zapier will provide some of the core behaviors, but you'll likely need to handle the rest.
+Most applications require some sort of authentication. The Zapier platform provides core behaviors for several authentication methods that might be used with your application, as well as the ability to configure or customize authentication further for certain methods.
 
-> Hint: You can access the data tied to your authentication via the `bundle.authData` property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.
+Data tied to authentication is included in the [bundle object](#bundle-object). Data used on an ongoing basis to authenticate requests is included in `bundle.authData`, while temporary values used in the establishment of [OAuth](#oauth1) and [Session auth](#session) are stored in `bundle.inputData`.
 
 ### Basic
 
@@ -511,7 +511,7 @@ const App = {
 
 ### Custom
 
-Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass data returned from the authentication process by adding/computing needed headers.
+Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
 > Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth for a working example app for custom auth.
 
@@ -751,7 +751,7 @@ module.exports = App;
 
 For OAuth1, `authentication.oauth1Config.getRequestToken`, `authentication.oauth1Config.authorizeUrl`, and `authentication.oauth1Config.getAccessToken` will have fields like `redirect_uri` and the temporary credentials in `bundle.inputData` instead of `bundle.authData`. After `getAccessToken` runs, the resulting token value(s) will be stored in `bundle.authData` for long-term use.
 
-Also note that `authentication.oauth1Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+Also note that `authentication.oauth1Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example, from the query string).
 
 ### OAuth2
 
@@ -774,7 +774,7 @@ You are required to define:
   * `authorizeUrl`: The authorization URL
   * `getAccessToken`: The API call to fetch the access token
 
-If the access token has a limited life and you want to refresh the token when it expires, you'll also need to define the API call to perform that refresh. You can choose to set `autoRefresh: true`, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See [Stale Authentication Credentials](#stale-authentication-credentials) for more details on handling auth refresh.
+If the access token has a limited life and you want to refresh the token when it expires, you'll also need to define the API call to perform that refresh (`refreshAccessToken`). You can choose to set `autoRefresh: true`, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See [Stale Authentication Credentials](#stale-authentication-credentials) for more details on handling auth refresh.
 
 You'll also likely want to set your `CLIENT_ID` and `CLIENT_SECRET` as environment variables:
 
@@ -860,7 +860,7 @@ module.exports = App;
 
 For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
 
-Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example from the query string).
+Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example, from the query string).
 
 
 ## Resources

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -858,7 +858,7 @@ module.exports = App;
 
 ```
 
-For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken`  have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
+For OAuth2, `authentication.oauth2Config.authorizeUrl`, `authentication.oauth2Config.getAccessToken`, and `authentication.oauth2Config.refreshAccessToken` have fields like `redirect_uri` and `state` in `bundle.inputData`, instead of `bundle.authData`. After the code is exchanged for an access token and/or refresh token, those tokens are stored in `bundle.authData` for long-term use.
 
 Also note that `authentication.oauth2Config.getAccessToken` has access to the additional return values in `rawRequest` and `cleanedRequest` should you need to extract other values (for example, from the query string).
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1143,9 +1143,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Most applications require some sort of authentication - and Zapier provides a handful of methods for helping your users authenticate with your application. Zapier will provide some of the core behaviors, but you&apos;ll likely need to handle the rest.</p><blockquote>
-<p>Hint: You can access the data tied to your authentication via the <code>bundle.authData</code> property in any method called in your app. Exceptions exist in OAuth and Session auth. Please see them below.</p>
-</blockquote>
+      <p>Most applications require some sort of authentication. The Zapier platform provides core behaviors for several authentication methods that might be used with your application, as well as the ability to configure or customize authentication further for certain methods.</p><p>Data tied to authentication is included in the <a href="#bundle-object">bundle object</a>. Data used on an ongoing basis to authenticate requests is included in <code>bundle.authData</code>, while temporary values used in the establishment of <a href="#oauth1">OAuth</a> and <a href="#session">Session auth</a> are stored in <code>bundle.inputData</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1243,7 +1241,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass data returned from the authentication process by adding/computing needed headers.</p><blockquote>
+      <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth</a> for a working example app for custom auth.</p>
 </blockquote>
     </div>
@@ -1510,7 +1508,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have fields like <code>redirect_uri</code> and the temporary credentials in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. After <code>getAccessToken</code> runs, the resulting token value(s) will be stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
+      <p>For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have fields like <code>redirect_uri</code> and the temporary credentials in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. After <code>getAccessToken</code> runs, the resulting token value(s) will be stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1539,7 +1537,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </ol><p>You are required to define:</p><ul>
 <li><code>authorizeUrl</code>: The authorization URL</li>
 <li><code>getAccessToken</code>: The API call to fetch the access token</li>
-</ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh. You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>
+</ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh (<code>refreshAccessToken</code>). You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
@@ -1629,7 +1627,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1199,10 +1199,10 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users will provide Zapier their username and password and Zapier will handle all the nonce and quality of protection details automatically.</p><blockquote>
+      <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth</a> for a working example app for digest auth.</p>
 </blockquote><blockquote>
-<p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will sends an additional request beforehand to get the server nonce.</p>
+<p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will send an additional request beforehand to get the server nonce.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1243,7 +1243,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This is what most &quot;API Key&quot; driven apps should default to using. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> to complete the authentication by adding/computing needed headers.</p><blockquote>
+      <p>Custom auth is most commonly used for apps that use API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass data returned from the authentication process by adding/computing needed headers.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth</a> for a working example app for custom auth.</p>
 </blockquote>
     </div>
@@ -1302,7 +1302,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Probably the most &quot;powerful&quot; mechanism for authentication - it gives you the ability to exchange some user provided data for some authentication data (IE: username &amp; password for a session key).</p><blockquote>
+      <p>Session auth gives you the ability to exchange some user provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.</p><blockquote>
 <p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth</a> for a working example app for session auth.</p>
 </blockquote>
     </div>
@@ -1376,9 +1376,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <blockquote>
-<p>Note: For Session auth, <code>authentication.sessionConfig.perform</code> will have the provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code> because <code>bundle.authData</code> will only have &quot;previously existing&quot; values, which will be empty the first time the Zap runs.</p>
-</blockquote>
+      <p>For Session auth, the function that fetches the additional authentication data needed to make API calls ( <code>authentication.sessionConfig.perform</code>) will have the user-provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. Afterwards, <code>bundle.authData</code> will contain the data provided by that function (usually the session key or token).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1396,7 +1394,7 @@ zapier convert 1234 --version 1.0.1 my-app
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/basics/authentication/overview">Twitter&apos;s</a> and <a href="https://developers.trello.com/page/authorization">Trello&apos;s</a> implementation of the 3-legged OAuth flow.</p><blockquote>
+      <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a">Twitter</a> and <a href="https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth">Trello</a> implementations of the 3-legged OAuth flow.</p><blockquote>
 <p>Example Apps: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
 </blockquote><p>The flow works like this:</p><ol>
 <li>Zapier makes a call to your API requesting a &quot;request token&quot; (also known as &quot;temporary credentials&quot;).</li>
@@ -1512,9 +1510,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <blockquote>
-<p>Note: For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have the provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code> because <code>bundle.authData</code> will only have &quot;previously existing&quot; values, which will be empty when the user hasn&apos;t connected their account on your service to Zapier. Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the users return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
-</blockquote>
+      <p>For OAuth1, <code>authentication.oauth1Config.getRequestToken</code>, <code>authentication.oauth1Config.authorizeUrl</code>, and <code>authentication.oauth1Config.getAccessToken</code> will have fields like <code>redirect_uri</code> and the temporary credentials in <code>bundle.inputData</code> instead of <code>bundle.authData</code>. After <code>getAccessToken</code> runs, the resulting token value(s) will be stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth1Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1633,9 +1629,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <blockquote>
-<p>Note: For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  will have the provided fields in <code>bundle.inputData</code> instead of <code>bundle.authData</code> because <code>bundle.authData</code> will only have &quot;previously existing&quot; values, which will be empty when the user hasn&apos;t connected their account on your service to Zapier. Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the users return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
-</blockquote>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3398,7 +3392,7 @@ zapier env:get 1.0.0
 <li><strong>Shorthand HTTP Requests</strong> - these are simple object literals that make it easy to define simple requests.</li>
 <li><strong>Manual HTTP Requests</strong> - you use <code>z.request([url], options)</code> to make the requests and control the response. Use this when you need to change options for certain requests (for all requests, use middleware).</li>
 </ol><p>There are also a few helper constructs you can use to reduce boilerplate:</p><ol>
-<li><code>requestTemplate</code> which is an shorthand HTTP request that will be merged with every request.</li>
+<li><code>requestTemplate</code> which is a shorthand HTTP request that will be merged with every request.</li>
 <li><code>beforeRequest</code> middleware which is an array of functions to mutate a request before it is sent.</li>
 <li><code>afterResponse</code> middleware which is an array of functions to mutate a response before it is completed.</li>
 </ol><blockquote>
@@ -3421,7 +3415,7 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For simple HTTP requests that do not require special pre or post processing, you can specify the HTTP options as an object literal in your app definition.</p><p>This features:</p><ol>
+      <p>For simple HTTP requests that do not require special pre- or post-processing, you can specify the HTTP options as an object literal in your app definition.</p><p>This features:</p><ol>
 <li>Lazy <code>{{curly}}</code> replacement.</li>
 <li>JSON and form body de-serialization.</li>
 <li>Automatic non-2xx error raising.</li>

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1627,7 +1627,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code>  have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code> have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>, instead of <code>bundle.authData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for long-term use.</p><p>Also note that <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
The auth section needed some love, including clarification, additional cross-linking, and updated external links.

The main focus of the update is the slightly confusing wording about authData vs inputData. I've tried to re-write this so that it's still clear which is used where. The original phrasing seemed confusing to me, though, as it wasn't always about data that was pre-existing, or data input by the user. I've gone toward describing the distinction as long-term vs temporary use, as that's the pattern I saw as I worked.

It's possible I've gotten some details slightly wonked up in the process, or even that that distinction isn't quite right either, so please do correct me if anything is now/remains mistaken.