### PR TITLE
PDE-3038 fix(core): dangling logger causes Lambda to hang

### DIFF
--- a/packages/core/src/tools/create-http-patch.js
+++ b/packages/core/src/tools/create-http-patch.js
@@ -6,6 +6,10 @@ const createHttpPatch = (event) => {
   const httpPatch = (object, logger) => {
     const originalRequest = object.request;
 
+    // Important not to reuse logger between calls, because we always destroy
+    // the logger at the end of a Lambda call.
+    object.zapierLogger = logger;
+
     // Avoids multiple patching and memory leaks (mostly when running tests locally)
     if (object.patchedByZapier) {
       return;
@@ -65,7 +69,7 @@ const createHttpPatch = (event) => {
             response_content: responseBody,
           };
 
-          logger(
+          object.zapierLogger(
             `${logData.response_status_code} ${logData.request_method} ${logData.request_url}`,
             logData
           );


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes https://github.com/zapier/zapier/issues/53430.

The bug was introduced by #483. Affected core versions are 11.3.0 and 9.7.0. The root cause is the `httpPatch()` function was reusing the `logger` instance from the previous Lambda invocation. But since we [destroy](https://github.com/zapier/zapier-platform/blob/4d84c23e2965078c5dbe228188abd6a0ab0cff00/packages/core/src/tools/create-lambda-handler.js#L161) the logger at the end of a Lambda call, the logger wouldn't be valid for the subsequent call. This causes the subsequent call to wait for the invalid logger to respond and time out.

The symptoms of this bug:
- Long Lambda execution time, usually > 60 seconds
- Actions being invoked multiple times, because Zapier retries when it doesn't get a response from Lambda 