### PR TITLE
PDE-3045 chore(all): bump node-fetch to 2.6.7 (for 9.x)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "lodash": "4.17.15",
     "marked": "0.7.0",
     "marked-terminal": "3.3.0",
-    "node-fetch": "2.6.6",
+    "node-fetch": "2.6.7",
     "ora": "3.4.0",
     "parse-gitignore": "0.4.0",
     "prettier": "1.18.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
     "form-data": "4.0.0",
     "lodash": "4.17.15",
     "mime-types": "2.1.34",
-    "node-fetch": "2.6.6",
+    "node-fetch": "2.6.7",
     "oauth-sign": "0.9.0",
     "semver": "5.6.0",
     "zapier-platform-schema": "9.7.0"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -34,6 +34,6 @@
     "fs-extra": "8.1.0",
     "istanbul": "0.4.5",
     "markdown-toc": "1.2.0",
-    "node-fetch": "2.6.6"
+    "node-fetch": "2.6.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8870,10 +8870,10 @@ node-fetch@1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Backport for #493.