### PR TITLE
PDE-3006 fix(legacy-scripting-runner): fix issues with file uploading

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -103,7 +103,7 @@ const stringifyForFormData = (value) => {
 
 // Makes a multipart/form-data request body that can be set to request.body for
 // node-fetch.
-const makeMultipartBody = async (data, lazyFilesObject) => {
+const makeMultipartForm = async (data, lazyFilesObject) => {
   const form = new FormData();
   if (data) {
     if (_.isPlainObject(data)) {
@@ -165,8 +165,11 @@ const addFilesToRequestBodyFromPreResult = async (request, event) => {
     {}
   );
 
-  request.body = await makeMultipartBody(request.data || '{}', lazyFiles);
   delete request.headers['Content-Type'];
+
+  const form = await makeMultipartForm(request.data || '{}', lazyFiles);
+  request.body = form;
+  request.headers = { ...request.headers, ...form.getHeaders() };
   return request;
 };
 
@@ -184,9 +187,12 @@ const addFilesToRequestBodyFromBody = async (request, bundle) => {
     }
   });
 
-  request.body = await makeMultipartBody(JSON.stringify(data), lazyFiles);
-  request.headers.Accept = '*/*';
   delete request.headers['Content-Type'];
+
+  const form = await makeMultipartForm(JSON.stringify(data), lazyFiles);
+  request.body = form;
+  request.headers.Accept = '*/*';
+  request.headers = { ...request.headers, ...form.getHeaders() };
   return request;
 };
 

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -30,6 +30,7 @@
     "jsdom": "7.0.0",
     "lodash": "4.17.21",
     "moment-timezone": "0.5.28",
+    "node-fetch": "2.6.7",
     "request": "2.88.2",
     "underscore": "1.4.4",
     "xmldom": "0.3.0"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes two bugs with file uploading.

1. The `Content-Type` header should be set to `multipart/form-data` when uploading a file. We were using [form-data](https://www.npmjs.com/package/form-data) to generate the request body, but we should also use `form.getHeaders()` to generate a header like `Content-Type: multipart/form-data; boundary=----12345678`.

2. Hanging issue. We were using the [request](https://www.npmjs.com/package/request) package for 1) `z.request` in the legacy script and 2) downloading files. I found when there's a **sync** `z.request` call in the legacy script, the `request` call to download a file can hang the entire process. I'm not sure why but I guess it's related to [deasync](https://www.npmjs.com/package/deasync). This PR fixes the issue by replacing `request` with `node-fetch` to download files.