### PR TITLE
feat(core,schema): enable skipping encoding specific characters from query params

### DIFF
--- a/packages/core/src/http-middlewares/before/add-query-params.js
+++ b/packages/core/src/http-middlewares/before/add-query-params.js
@@ -16,21 +16,22 @@ const addQueryParams = (req) => {
 
     let stringifiedParams = querystring.stringify(req.params);
 
-    // it goes against spec, but for compatibility, some APIs want certain characters (mostly $) unencoded
-    (req.skipEncodingChars || []).forEach((char) => {
-      if (char.length > 1) {
-        throw new Error('only pass single characters to skipEncodingChars');
+    // it goes against spec, but for compatibility, some APIs want certain
+    // characters (mostly $) unencoded
+    if (req.skipEncodingChars) {
+      for (let i = 0; i < req.skipEncodingChars.length; i++) {
+        const char = req.skipEncodingChars.charAt(i);
+        const valToReplace = querystring.escape(char);
+        if (valToReplace === char) {
+          continue;
+        }
+        // no replaceAll in JS yet, coming in a node version soon!
+        stringifiedParams = stringifiedParams.replace(
+          new RegExp(valToReplace, 'g'),
+          char
+        );
       }
-      const valToReplace = querystring.escape(char);
-      if (valToReplace === char) {
-        return;
-      }
-      // no replaceAll in JS yet, coming in a node version soon!
-      stringifiedParams = stringifiedParams.replace(
-        new RegExp(valToReplace, 'g'),
-        char
-      );
-    });
+    }
 
     if (stringifiedParams) {
       req.url += `${splitter}${stringifiedParams}`;

--- a/packages/core/src/http-middlewares/before/add-query-params.js
+++ b/packages/core/src/http-middlewares/before/add-query-params.js
@@ -14,7 +14,23 @@ const addQueryParams = (req) => {
 
     normalizeEmptyParamFields(req);
 
-    const stringifiedParams = querystring.stringify(req.params);
+    let stringifiedParams = querystring.stringify(req.params);
+
+    // it goes against spec, but for compatibility, some APIs want certain characters (mostly $) unencoded
+    (req.skipEncodingChars || []).forEach((char) => {
+      if (char.length > 1) {
+        throw new Error('only pass single characters to skipEncodingChars');
+      }
+      const valToReplace = querystring.escape(char);
+      if (valToReplace === char) {
+        return;
+      }
+      // no replaceAll in JS yet, coming in a node version soon!
+      stringifiedParams = stringifiedParams.replace(
+        new RegExp(valToReplace, 'g'),
+        char
+      );
+    });
 
     if (stringifiedParams) {
       req.url += `${splitter}${stringifiedParams}`;

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -295,7 +295,7 @@ describe('http prepareRequest', () => {
   });
 });
 
-describe('http querystring before middleware', () => {
+describe.only('http querystring before middleware', () => {
   it('should encode dollars by default', () => {
     const req = {
       url: 'https://example.com',
@@ -305,11 +305,11 @@ describe('http querystring before middleware', () => {
     should(req.url).eql('https://example.com?cool=qwer%24%24qwer');
   });
 
-  it('should skip encoding dollars by on request', () => {
+  it('should skip encoding dollars', () => {
     const req = {
       url: 'https://example.com',
       params: { cool: 'qwer$$qwer' },
-      skipEncodingChars: ['$'],
+      skipEncodingChars: '$',
     };
     addQueryParams(req);
     should(req.url).eql('https://example.com?cool=qwer$$qwer');
@@ -319,7 +319,7 @@ describe('http querystring before middleware', () => {
     const req = {
       url: 'https://example.com?name=asdf%24%24asdf',
       params: { cool: 'qwer$$qwer' },
-      skipEncodingChars: ['$'],
+      skipEncodingChars: '$',
     };
     addQueryParams(req);
     should(req.url).eql(
@@ -331,19 +331,20 @@ describe('http querystring before middleware', () => {
     const req = {
       url: 'https://example.com',
       params: { cool: 'qwer$$qwer' },
-      skipEncodingChars: ['q'],
+      skipEncodingChars: 'q',
     };
     addQueryParams(req);
     should(req.url).eql('https://example.com?cool=qwer%24%24qwer');
   });
 
-  it('should error when passing a multi-character string to skip', () => {
+  it('should skip encoding multiple chars', () => {
     const req = {
       url: 'https://example.com',
-      params: { cool: 'qwer$$qwer' },
-      skipEncodingChars: ['$$'],
+      params: { cool: '烏龜@$å' },
+      skipEncodingChars: '$å龜',
     };
-    should(() => addQueryParams(req)).throw();
+    addQueryParams(req);
+    should(req.url).eql('https://example.com?cool=%E7%83%8F龜%40$å');
   });
 });
 

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -295,7 +295,7 @@ describe('http prepareRequest', () => {
   });
 });
 
-describe.only('http querystring before middleware', () => {
+describe('http querystring before middleware', () => {
   it('should encode dollars by default', () => {
     const req = {
       url: 'https://example.com',

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -12,6 +12,7 @@ const createInput = require('../src/tools/create-input');
 const request = require('../src/tools/request-client');
 
 const prepareRequest = require('../src/http-middlewares/before/prepare-request');
+const addQueryParams = require('../src/http-middlewares/before/add-query-params');
 const addBasicAuthHeader = require('../src/http-middlewares/before/add-basic-auth-header');
 const addDigestAuthHeader = require('../src/http-middlewares/before/add-digest-auth-header');
 const prepareResponse = require('../src/http-middlewares/after/prepare-response');
@@ -291,6 +292,58 @@ describe('http prepareRequest', () => {
       'Content-Type': 'application/json',
       'user-agent': 'Zapier',
     });
+  });
+});
+
+describe('http querystring before middleware', () => {
+  it('should encode dollars by default', () => {
+    const req = {
+      url: 'https://example.com',
+      params: { cool: 'qwer$$qwer' },
+    };
+    addQueryParams(req);
+    should(req.url).eql('https://example.com?cool=qwer%24%24qwer');
+  });
+
+  it('should skip encoding dollars by on request', () => {
+    const req = {
+      url: 'https://example.com',
+      params: { cool: 'qwer$$qwer' },
+      skipEncodingChars: ['$'],
+    };
+    addQueryParams(req);
+    should(req.url).eql('https://example.com?cool=qwer$$qwer');
+  });
+
+  it('should not replace existing characters in url', () => {
+    const req = {
+      url: 'https://example.com?name=asdf%24%24asdf',
+      params: { cool: 'qwer$$qwer' },
+      skipEncodingChars: ['$'],
+    };
+    addQueryParams(req);
+    should(req.url).eql(
+      'https://example.com?name=asdf%24%24asdf&cool=qwer$$qwer'
+    );
+  });
+
+  it('should no-op on non-encodable characters', () => {
+    const req = {
+      url: 'https://example.com',
+      params: { cool: 'qwer$$qwer' },
+      skipEncodingChars: ['q'],
+    };
+    addQueryParams(req);
+    should(req.url).eql('https://example.com?cool=qwer%24%24qwer');
+  });
+
+  it('should error when passing a multi-character string to skip', () => {
+    const req = {
+      url: 'https://example.com',
+      params: { cool: 'qwer$$qwer' },
+      skipEncodingChars: ['$$'],
+    };
+    should(() => addQueryParams(req)).throw();
   });
 });
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -1236,6 +1236,7 @@ Key | Required | Type | Description
 `removeMissingValuesFrom` | no | `object` | Should missing values be sent? (empty strings, `null`, and `undefined` only — `[]`, `{}`, and `false` will still be sent). Allowed fields are `params` and `body`. The default is `false`, ex: ```removeMissingValuesFrom: { params: false, body: false }```
 `serializeValueForCurlies` | no | [/FunctionSchema](#functionschema) | A function to customize how to serialize a value for curlies `{{var}}` in the request object. By default, when this is unspecified, the request client only replaces curlies where variables are strings, and would throw an error for non-strings. The function should accepts a single argument as the value to be serialized and return the string representation of the argument.
 `skipThrowForStatus` | no | `boolean` | If `true`, don't throw an exception for response 400 <= status < 600 automatically before resolving with the response. Defaults to `false`.
+`skipEncodingChars` | no | `string` | Contains the characters that you want left unencoded in the query params (`req.params`). If unspecified, `z.request()` will percent-encode non-ascii characters and these reserved characters: ``:$/?#[]@$&+,;=^@`\``.
 
 #### Examples
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -417,6 +417,10 @@
           "description": "If `true`, don't throw an exception for response 400 <= status < 600 automatically before resolving with the response. Defaults to `false`.",
           "type": "boolean",
           "default": false
+        },
+        "skipEncodingChars": {
+          "description": "Contains the characters that you want left unencoded in the query params (`req.params`). If unspecified, `z.request()` will percent-encode non-ascii characters and these reserved characters: ``:$/?#[]@$&+,;=^@`\\``.",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/packages/schema/lib/schemas/RequestSchema.js
+++ b/packages/schema/lib/schemas/RequestSchema.js
@@ -87,6 +87,11 @@ module.exports = makeSchema(
         type: 'boolean',
         default: false,
       },
+      skipEncodingChars: {
+        description:
+          'Contains the characters that you want left unencoded in the query params (`req.params`). If unspecified, `z.request()` will percent-encode non-ascii characters and these reserved characters: ``:$/?#[]@$&+,;=^@`\\``.',
+        type: 'string',
+      },
     },
     additionalProperties: false,
     examples: [


### PR DESCRIPTION
Proof of concept to enable apps (especially legacy apps) to skip encoding certain params. 

Once thing I noticed (but didn't have time to dig into) was that if the url already includes params, we pull them out before the request object reaches `addQueryParams`:

```js
z.request('https://httpbin.org/get?in_url=asdf$$asdf')

// in `addQueryParams`
console.log(req)

{
  method: 'GET',
  params: { in_url: 'asdf$$asdf' },
  url: 'https://httpbin.org/get',
  // ...
}

// in request-client.js, directly before the call to `fetch(url, options)`
console.log('calling', url)
// calling https://httpbin.org/get?in_url=asdf%24%24asdf
```


But, as written, this will at least partially unblock us