### PR TITLE
chore: allow to build boilerplate from local or npm

### DIFF
--- a/boilerplate/scripts/build.sh
+++ b/boilerplate/scripts/build.sh
@@ -1,11 +1,32 @@
 #!/usr/bin/env bash
 #
-# Build with current local code:
-#   ./build.sh
+# Build boilerplate - a zip file that is generated as if you `zapier build` an empty CLI
+# app. This zip file acts as a runtime for all the UI apps.
 #
-# Specify core and legacy-scripting-runner versions to build with published
-# packages on npm:
-#   ./build.sh 9.0.0 3.2.4
+# Usage:
+#
+#   $ ./scripts/build.sh [CORE_VERSION] [LEGACY_SCRIPTING_RUNNER_VERSION]
+#
+# This scripts accepts two optional arguments - core and legacy-scripting-runner
+# versions. If the version is specified, that packgage will be downloaded from npm
+# instead of built from local.
+#
+# For example, this builds core and legacy-scripting-runner from local code:
+#
+#   $ ./scripts/build.sh
+#
+# Download both core and legacy-scripting-runner from npm:
+#
+#   $ ./scripts/build.sh 9.7.1 3.8.5
+#
+# Build core from local and download legacy-scripting-runner from npm:
+#
+#   $ ./scripts/build.sh '' 3.8.5
+#
+# Download core from npm and build legacy-scripting-runner from local:
+#
+#   $ ./scripts/build.sh 9.7.1
+#
 
 update_deps() {
     package_json=$1
@@ -72,31 +93,56 @@ fi
 TARGET_FILE="$BUILD_DIR/$CORE_VERSION.zip"
 rm -f $TARGET_FILE
 
+# Build core and legacy-scripting-runner locally. Needs to generate a unique filename
+# with a timestamp to avoid yarn using cached packages.
+# See https://github.com/yarnpkg/yarn/issues/2165.
+TIMESTAMP=`date +"%s"`
+CORE_PACK_FILENAME="core-$TIMESTAMP.tgz"
+LEGACY_PACK_FILENAME="legacy-$TIMESTAMP.tgz"
+
+echo "Building..."
+
 # Patch boilerplate's package.json with appropriate dependency versions
 if [ "$1" == "" ]; then
-    # Build core and legacy-scripting-runner locally. Needs to generate a unique filename
-    # with a timestamp to avoid yarn using cached packages.
-    # See https://github.com/yarnpkg/yarn/issues/2165.
-    TIMESTAMP=`date +"%s"`
-    echo "Building from local"
-
-    CORE_PACK_FILENAME="core-$TIMESTAMP.tgz"
-    LEGACY_PACK_FILENAME="legacy-$TIMESTAMP.tgz"
+    echo "> core from local, version $CORE_VERSION"
 
     pushd $CORE_DIR > /dev/null
     yarn pack --filename "$BOILERPLATE_DIR/$CORE_PACK_FILENAME"
     popd > /dev/null
 
-    pushd $LEGACY_DIR > /dev/null
-    yarn pack --filename "$BOILERPLATE_DIR/$LEGACY_PACK_FILENAME"
-    popd > /dev/null
+    if [ "$2" == "" ]; then
+        echo "> legacy-scripting-runner from local, version $LEGACY_VERSION"
 
-    # Replace core and legacy-scripting-runner versions in package.json
-    update_deps "$BOILERPLATE_DIR/package.json" "./$CORE_PACK_FILENAME" "./$LEGACY_PACK_FILENAME"
+        pushd $LEGACY_DIR > /dev/null
+        yarn pack --filename "$BOILERPLATE_DIR/$LEGACY_PACK_FILENAME"
+        popd > /dev/null
+
+        # Replace core and legacy-scripting-runner versions in package.json
+        update_deps "$BOILERPLATE_DIR/package.json" "./$CORE_PACK_FILENAME" "./$LEGACY_PACK_FILENAME"
+    else
+        echo "> legacy-scripting-runner from npm, version $LEGACY_VERSION"
+
+        # Replace core and legacy-scripting-runner versions in package.json
+        update_deps "$BOILERPLATE_DIR/package.json" "./$CORE_PACK_FILENAME" $LEGACY_VERSION
+    fi
 else
-    echo "Building from published packages, core $CORE_VERSION"
+    echo "> core from from npm, version $CORE_VERSION"
 
-    update_deps "$BOILERPLATE_DIR/package.json" $CORE_VERSION $LEGACY_VERSION
+    if [ "$2" == "" ]; then
+        echo "> legacy-scripting-runner from local, version $LEGACY_VERSION"
+
+        pushd $LEGACY_DIR > /dev/null
+        yarn pack --filename "$BOILERPLATE_DIR/$LEGACY_PACK_FILENAME"
+        popd > /dev/null
+
+        # Replace core and legacy-scripting-runner versions in package.json
+        update_deps "$BOILERPLATE_DIR/package.json" $CORE_VERSION "./$LEGACY_PACK_FILENAME"
+    else
+        echo "> legacy-scripting-runner from npm, version: $LEGACY_VERSION"
+
+        # Replace core and legacy-scripting-runner versions in package.json
+        update_deps "$BOILERPLATE_DIR/package.json" $CORE_VERSION $LEGACY_VERSION
+    fi
 fi
 
 # Install boilerplate deps
@@ -113,7 +159,7 @@ update_deps "$BOILERPLATE_DIR/package.json" $CORE_VERSION $LEGACY_VERSION
 pushd $BOILERPLATE_DIR > /dev/null
 
 # Build the zip!
-# the node-X segment in the next line should match all node versions where a boilerplate built with this script might run on
+# the node-X segment in the next line should match the latest major version
 zip -R $TARGET_FILE '*.js' '*.json' '*/linux-x64-node-10/*.node' '*/linux-x64-node-12/*.node' '*/linux-x64-node-14/*.node'
 
 # Remove generated files


### PR DESCRIPTION
Allows to build boilerplate with one of these combinations of source:

| core  | legacy-scripting-runner | example command      |
|-------|-------------------------|----------------------|
| local | local                   | `build.sh`             |
| npm   | local                   | `build.sh 9.7.1`       |
| local | npm                     | `build.sh '' 3.8.5`    |
| npm   | npm                     | `build.sh 9.7.1 3.8.5` |
