### PR TITLE
feat(legacy-scripting-runner): pass `legacy.skipEncodingChars` to `z.request()`

### DIFF
--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -849,6 +849,12 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         request.params = pruneQueryParams(request.params);
       }
 
+      if (_.get(app, 'legacy.skipEncodingChars')) {
+        // skipEncodingChars is only supported on core ^9.7.2, ^11.3.2 and >=12.x.
+        // core versions that don't support it will just ignore it.
+        request.skipEncodingChars = app.legacy.skipEncodingChars;
+      }
+
       const response = await zcli.request(request);
 
       if (!options.parseResponse) {


### PR DESCRIPTION
PR #497 and #499 added a `skipEncodingChars` option to `z.request()` and `RequestSchema`. We still need legacy-scripting-runner to utilize this option. If the app definition has a truthy `legacy.skipEncodingChars`, we should let legacy-scripting-runner pass it to `z.request()`.

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
