### PR TITLE
PDE-3048 docs: `CONTRIBUTING.md` and release guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ boilerplate/build
 .vscode
 
 .idea/
+
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,10 @@ TBA
 
 ## Releasing a New Version
 
-**Zapier employees only.** Refer to this [internal doc](https://coda.io/d/Team-Developer-Platform_di0MgBhlCWf/Releasing-a-New-zapier-platform-Version_su5eD#_luJIF) for more detail.
+**Zapier employees only.** Refer to this [internal doc](releasing) on how to cut a release.
 
 
 [license]: https://github.com/zapier/zapier-platform/blob/master/LICENSE
 [yarn]: https://yarnpkg.com
 [ci]: https://github.com/zapier/zapier-platform/actions/workflows/ci.yaml
+[releasing]: https://coda.io/d/Team-Developer-Platform_di0MgBhlCWf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+
+## Terms
+
+This contributor guide is mainly for Zapier employees. However, zapier-platform is a
+public repo. Everyone is welcome to submit a pull request (PR). For non-employees, you
+must agree to the terms of service listed on https://zapier.com/platform/tos or the
+[LICENSE][license] file of the repo before contributing.
+
+## Local Setup
+
+Install [Yarn][yarn] if you haven't. We use Yarn to manage packages.
+
+Clone this repo with git:
+
+```bash
+git clone git@github.com:zapier/zapier-platform.git
+cd zapier-platform
+```
+
+In the repo directory, install dependencies with yarn:
+
+```bash
+yarn
+```
+
+That's it! Now you have a local environment for development.
+
+## Running Tests
+
+You can run all tests for all packages with yarn test:
+
+```bash
+yarn test
+```
+
+You seldom need to run all the tests because we have [CI][ci] do it. You have several ways to
+filter running tests.
+
+### Running All Tests in a Package
+
+To run tests for a single package, you go into the package directory and run yarn test.
+For example, this is how you run all the tests for the cli package:
+
+```bash
+cd packages/cli
+yarn test
+```
+
+### Using .only
+
+TBA
+
+## Releasing a New Version
+
+**Zapier employees only.** Refer to this [internal doc](https://coda.io/d/Team-Developer-Platform_di0MgBhlCWf/Releasing-a-New-zapier-platform-Version_su5eD#_luJIF) for more detail.
+
+
+[license]: https://github.com/zapier/zapier-platform/blob/master/LICENSE
+[yarn]: https://yarnpkg.com
+[ci]: https://github.com/zapier/zapier-platform/actions/workflows/ci.yaml

--- a/README.md
+++ b/README.md
@@ -14,23 +14,13 @@ It consists of a few main packages:
 - `zapier-platform-legacy-scripting-runner`: If your app started as a Legacy Web Builder app, this provides a shim that keeps your app running seamlessly
 - `example-apps/*`: A varied set of example apps to get you started
 
-## Getting Started
+## Docs
 
-```bash
-# Install Yarn if you haven't
-brew install yarn
-
-# Clone this repo
-git clone git@github.com:zapier/zapier-platform.git
-cd zapier-platform
-
-# Install dependencies
-yarn
-
-# Run tests for all packages
-yarn test
-
-# Run tests for an individual package
-cd packages/cli
-yarn test
-```
+* Public-facing docs:
+  - [Latest CLI developer guide](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md)
+  - [Latest CLI command reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
+  - [Latest schema docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
+  - The :point_up: docs are also hosted at https://platform.zapier.com
+* Internal-facing docs:
+  - Learn about how this repo is structured in [ARCHITECTURE.md](ARCHITECTURE.md).
+  - Looking to contribute to this repo? See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.8.6
 
-- :nail_care: Fix issues with file uploading ([#496](https://github.com/zapier/zapier-platform/pull/496))
+- :bug: Fix issues with file uploading ([#496](https://github.com/zapier/zapier-platform/pull/496))
 - :nail_care: Pass `legacy.skipEncodingChars` to `z.request()` ([#501](https://github.com/zapier/zapier-platform/pull/501))
 
 ## 3.8.5


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Adds `CONTRIBUTING.md` and links to the internal release guide.