### PR TITLE
PDE-3048 docs: fix and add links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ TBA
 
 ## Releasing a New Version
 
-**Zapier employees only.** Refer to this [internal doc](releasing) on how to cut a release.
+**Zapier employees only.** Refer to this [internal doc][releasing] on how to cut a release.
 
 
 [license]: https://github.com/zapier/zapier-platform/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ This is the main monorepo for all public code that powers the Zapier Platform Ex
 
 It consists of a few main packages:
 
-- `zapier-platform-cli`: The CLI that devs can use to perform common tasks with their apps (such as `push`, `promote`, etc)
-- `zapier-platform-core`: The package which all apps depend on; it provides functionality at runtime.
-- `zapier-platform-schema`: The source of truth for what's allowed in the structure a Zapier app; not typically installed directly
-- `zapier-platform-legacy-scripting-runner`: If your app started as a Legacy Web Builder app, this provides a shim that keeps your app running seamlessly
-- `example-apps/*`: A varied set of example apps to get you started
+- [`zapier-platform-cli`](packages/cli): The CLI that devs can use to perform common tasks with their apps (such as `push`, `promote`, etc)
+- [`zapier-platform-core`](packages/core): The package which all apps depend on; it provides functionality at runtime
+- [`zapier-platform-schema`](packages/schema): The source of truth for what's allowed in the structure a Zapier app; not typically installed directly
+- [`zapier-platform-legacy-scripting-runner`](packages/legacy-scripting-runner): If your app started as a Legacy Web Builder app, this provides a shim that keeps your app running seamlessly
+- [`example-apps/*`](example-apps): A varied set of example apps to get you started
 
 ## Docs
 
 * Public-facing docs:
-  - [Latest CLI developer guide](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md)
-  - [Latest CLI command reference](https://github.com/zapier/zapier-platform/blob/master/packages/cli/docs/cli.md)
-  - [Latest schema docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md)
+  - [Latest CLI developer guide](packages/cli/README.md)
+  - [Latest CLI command reference](packages/cli/docs/cli.md)
+  - [Latest schema docs](packages/schema/docs/build/schema.md)
   - The :point_up: docs are also hosted at https://platform.zapier.com
+  - [CHANGELOG.md](CHANGELOG.md)
 * Internal-facing docs:
-  - Learn about how this repo is structured in [ARCHITECTURE.md](ARCHITECTURE.md).
-  - Looking to contribute to this repo? See [CONTRIBUTING.md](CONTRIBUTING.md).
+  - Learn about how this repo is structured in [ARCHITECTURE.md](ARCHITECTURE.md)
+  - Looking to contribute to this repo? See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes and adds links in docs.