### PR TITLE
docs(misc): fix link in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ cd packages/cli
 yarn test
 ```
 
-### Using .only
+### Using `.only`
 
 TBA
 
@@ -59,4 +59,4 @@ TBA
 [license]: https://github.com/zapier/zapier-platform/blob/master/LICENSE
 [yarn]: https://yarnpkg.com
 [ci]: https://github.com/zapier/zapier-platform/actions/workflows/ci.yaml
-[releasing]: https://coda.io/d/Team-Developer-Platform_di0MgBhlCWf
+[releasing]: https://coda.io/d/_di0MgBhlCWf/Releasing-a-New-zapier-platform-Version_su5eD

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It consists of a few main packages:
 - [`zapier-platform-core`](packages/core): The package which all apps depend on; it provides functionality at runtime
 - [`zapier-platform-schema`](packages/schema): The source of truth for what's allowed in the structure a Zapier app; not typically installed directly
 - [`zapier-platform-legacy-scripting-runner`](packages/legacy-scripting-runner): If your app started as a Legacy Web Builder app, this provides a shim that keeps your app running seamlessly
-- [`example-apps/*`](example-apps): A varied set of example apps to get you started
+- [`example-apps/*`](example-apps): A varied set of example apps to help you get started
 
 ## Docs
 

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -97,56 +97,44 @@ describe('request client', () => {
       .catch(done);
   });
 
-  it('should support streaming another request', (done) => {
+  it('should support streaming another request', async () => {
     const fileUrl =
       'https://s3.amazonaws.com/zapier-downloads/just-a-few-lines.txt';
     const fileExpectedContent =
       '0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n';
     const request = createAppRequestClient(input);
-    request({
+    const response = await request({
       method: 'POST',
-      url: 'https://zapier-mockbin.herokuapp.com/request', // httpbin doesn't handle chunked anything :-(
+      url: 'https://httpbin.zapier-tooling.com/post',
       body: request({ url: fileUrl, raw: true }),
-    })
-      .then((response) => {
-        response.status.should.eql(200);
-        const body = JSON.parse(response.content);
-        body.postData.text.should.eql(fileExpectedContent);
-        done();
-      })
-      .catch(done);
+    });
+    response.status.should.eql(200);
+    const body = JSON.parse(response.content);
+    body.data.should.eql(fileExpectedContent);
   });
 
-  it('should handle a buffer upload fine', (done) => {
+  it('should handle a buffer upload fine', async () => {
     const request = createAppRequestClient(input);
-    request({
+    const response = await request({
       method: 'POST',
-      url: 'https://zapier-mockbin.herokuapp.com/request', // httpbin doesn't handle chunked anything :-(
+      url: 'https://httpbin.zapier-tooling.com/post',
       body: Buffer.from('hello world this is a cat (=^..^=)'),
-    })
-      .then((response) => {
-        response.status.should.eql(200);
-        const body = JSON.parse(response.content);
-        body.postData.text.should.eql('hello world this is a cat (=^..^=)');
-        done();
-      })
-      .catch(done);
+    });
+    response.status.should.eql(200);
+    const body = JSON.parse(response.content);
+    body.data.should.eql('hello world this is a cat (=^..^=)');
   });
 
-  it('should handle a stream upload fine', (done) => {
+  it('should handle a stream upload fine', async () => {
     const request = createAppRequestClient(input);
-    request({
+    const response = await request({
       method: 'POST',
-      url: 'https://zapier-mockbin.herokuapp.com/request', // httpbin doesn't handle chunked anything :-(
+      url: 'https://httpbin.zapier-tooling.com/post',
       body: fs.createReadStream(path.join(__dirname, 'test.txt')),
-    })
-      .then((response) => {
-        response.status.should.eql(200);
-        const body = JSON.parse(response.content);
-        body.postData.text.should.eql('hello world this is a cat (=^..^=)');
-        done();
-      })
-      .catch(done);
+    });
+    response.status.should.eql(200);
+    const body = JSON.parse(response.content);
+    body.data.should.eql('hello world this is a cat (=^..^=)');
   });
 
   it('should support single url param', (done) => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes a link in `CONTRIBUTING.md` and few tweaks in the docs.

I also had to replace `zapier-mockbin.herokuapp.com` occurrences with `httpbin.zapier-tooling.com` in some tests because those are no longer available.