### PR TITLE
fix(core): fix another scenario that causes hanging (11.x)

### DIFF
--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -167,6 +167,7 @@ class LogStream extends Transform {
 class LogStreamFactory {
   constructor() {
     this._logStream = null;
+    this.ended = false;
   }
 
   getOrCreate(url, token) {
@@ -185,6 +186,10 @@ class LogStreamFactory {
   }
 
   async end() {
+    // Mark the factory as ended. This suggests that any logStream.write() that
+    // follows should end() right away.
+    this.ended = true;
+
     if (this._logStream) {
       this._logStream.end();
       const response = await this._logStream.request;
@@ -240,6 +245,14 @@ const sendLog = async (logStreamFactory, options, event, message, data) => {
       // no line breaks, and after an object it ends with a line break.
       JSON.stringify({ message: safeMessage, data: safeData }) + '\n'
     );
+
+    if (logStreamFactory.ended) {
+      // Lambda handler calls logger.end() at the end. But what if there's a
+      // (bad) callback that is still running after the Lambda handler returns?
+      // We need to make sure the bad callback ends the logger as well.
+      // Otherwise, it will hang!
+      logStreamFactory.end();
+    }
   }
 };
 

--- a/packages/core/test/tools/mocky.js
+++ b/packages/core/test/tools/mocky.js
@@ -10,6 +10,9 @@ const FAKE_LOG_URL = 'https://fake-logger.zapier.com';
 
 const RPC_URL_PATH = '/platform/rpc/cli';
 
+// Stores logs produced by the mocked log server
+const logbox = [];
+
 const makeRpc = () => {
   return createRpcClient({
     rpc_base: `${FAKE_ZAPIER_URL}${RPC_URL_PATH}`,
@@ -161,6 +164,11 @@ const mockLogServer = () => {
       const logs = lines
         .filter((line) => line.trim())
         .map((line) => JSON.parse(line));
+
+      for (const log of logs) {
+        logbox.push(log);
+      }
+
       cb(null, [
         200,
         {
@@ -172,7 +180,15 @@ const mockLogServer = () => {
     });
 };
 
+const getLogs = () => logbox;
+
+const clearLogs = () => {
+  logbox.length = 0;
+};
+
 module.exports = {
+  clearLogs,
+  getLogs,
   makeRpc,
   mockLogServer,
   mockRpcCall,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Related to #509, #490, and https://github.com/zapier/zapier/issues/53430, this addresses another scenario that causes the Lambda handler to hang/freeze.

Suppose a converted app has this (bad) legacy script:

```js
var Zap = {
  bad_post_write: function(bundle, callback) {
    z.request({ ... }, function(err, response) {
      if (err) {
        callback(err);
      } else {
        callback(null, z.JSON.parse(response.content));
      }
    });
    callback(null, { message: 'ok' }); // double callback?!
  }
};
```

Notice how the `post_write` function returns immediately by calling `callback(null, { message: 'ok' })` while makes an outbound `z.request()` and calls `callback` asynchronously.

When legacy-scripting-runner [promisifies](https://github.com/zapier/zapier-platform/blob/1632992ad4867b6cce1e8abb8fe60a866ba19fbc/packages/legacy-scripting-runner/index.js#L740) this `post_write` function, the `callback` in the `z.request` will come after the Lambda handler [returns](https://github.com/zapier/zapier-platform/blob/1632992ad4867b6cce1e8abb8fe60a866ba19fbc/packages/core/src/tools/create-lambda-handler.js#L164). Since we only [end](https://github.com/zapier/zapier-platform/blob/1632992ad4867b6cce1e8abb8fe60a866ba19fbc/packages/core/src/tools/create-lambda-handler.js#L161) the logger once when the Lambda handler finishes, the HTTP logger corresponding to the `z.request` call, which comes after the Lambda handler, will stay open and never end until a long timeout.

To fix, we need to make sure to end any loggers allocated after the Lambda handler returns.