### PR TITLE
docs(core): document changes to autoRefresh

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3656,7 +3656,50 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p><p>This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here&apos;s a diagram to illustrate that:</p><p><img src="https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png" alt></p><p>Ensure you&apos;re handling errors correctly for your platform version. The latest released version is <strong>11.3.2</strong>.</p>
+      <p>Since <code>v10.0.0</code>, <code>z.request()</code> calls <code>response.throwForStatus()</code> before it returns a response. You can disable automatic error throwing by setting <code>skipThrowForStatus</code> on the request object:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">// Disable automatic error throwing on the request object</span>
+<span class="hljs-keyword">const</span> perform = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
+    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;...&apos;</span>,
+    <span class="hljs-attr">skipThrowForStatus</span>: <span class="hljs-literal">true</span>
+  });
+  <span class="hljs-comment">// Now you handle error response on your own.</span>
+  <span class="hljs-comment">// The following is equivalent to response.throwForStatus(), </span>
+  <span class="hljs-comment">// but you have to remember to do it on every request</span>
+  <span class="hljs-keyword">if</span> (response.status &gt;= <span class="hljs-number">400</span>) {
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.ResponseError(response);
+  }
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>You can also do it in <code>afterResponse</code> if the API uses a status code &gt;= 400 that should not be treated as an error.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">// Don&apos;t throw an error when response status is 456</span>
+<span class="hljs-keyword">const</span> disableAutoThrowOn456 = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
+  <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
+    response.skipThrowForStatus = <span class="hljs-literal">true</span>;
+  }
+  <span class="hljs-keyword">return</span> response;
+};
+<span class="hljs-keyword">const</span> App = {
+  <span class="hljs-comment">// ...</span>
+  <span class="hljs-attr">afterResponse</span>: [disableAutoThrowOn456],
+  <span class="hljs-comment">// ...</span>
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p><p>This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here&apos;s a diagram to illustrate that:</p><p><img src="https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png" alt></p><p>Ensure you&apos;re handling errors correctly for your platform version. The latest released version is <strong>11.3.2</strong>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -3596,7 +3596,15 @@ zapier env:get 1.0.0
 };
 
 <span class="hljs-comment">// This example only works on core v10+!</span>
-<span class="hljs-keyword">const</span> handleErrors = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
+<span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
+  <span class="hljs-comment">// Parse content that is not JSON</span>
+  <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
+  response.data = xml.parse(response.content);
+  <span class="hljs-keyword">return</span> response;
+};
+
+<span class="hljs-comment">// This example only works on core v10+!</span>
+<span class="hljs-keyword">const</span> handleWeirdErrors = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
   <span class="hljs-comment">// Prevent `throwForStatus` from throwing for a certain status.</span>
   <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
     response.skipThrowForStatus = <span class="hljs-literal">true</span>;
@@ -3606,18 +3614,10 @@ zapier env:get 1.0.0
   <span class="hljs-keyword">return</span> response;
 };
 
-<span class="hljs-comment">// This example only works on core v10+!</span>
-<span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
-  <span class="hljs-comment">// Parse content that is not JSON</span>
-  <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
-  response.data = xml.parse(response.content);
-  <span class="hljs-keyword">return</span> response;
-};
-
 <span class="hljs-keyword">const</span> App = {
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">beforeRequest</span>: [addHeader],
-  <span class="hljs-attr">afterResponse</span>: [parseXML, handleErrors],
+  <span class="hljs-attr">afterResponse</span>: [parseXML, handleWeirdErrors],
   <span class="hljs-comment">// ...</span>
 };
 
@@ -3627,7 +3627,18 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>A <code>beforeRequest</code> middleware function takes a request options object, and returns a (possibly mutated) request object. An <code>afterResponse</code> middleware function takes a response object, and returns a (possibly mutated) response object. Middleware functions are executed in the order specified in the app definition, and each subsequent middleware receives the request or response object returned by the previous middleware.</p><p>Middleware functions can be asynchronous - just return a promise from the middleware function.</p><p>The second argument for middleware is the <code>z</code> object, but it does <em>not</em> include <code>z.request()</code> as using that would easily create infinite loops.</p>
+      <p>A <code>beforeRequest</code> middleware function takes a request options object, and returns a (possibly mutated) request object. An <code>afterResponse</code> middleware function takes a response object, and returns a (possibly mutated) response object. Middleware functions are executed in the order specified in the app definition, and each subsequent middleware receives the request or response object returned by the previous middleware.</p><p>Middleware functions can be asynchronous - just return a promise from the middleware function.</p><p>The second argument for middleware is the <code>z</code> object, but it does <em>not</em> include <code>z.request()</code> as using that would easily create infinite loops.</p><p>Here is the full request lifecycle when you call <code>z.request({...})</code>:</p><ol>
+<li>set defaults on the <code>request</code> object</li>
+<li>run your <code>beforeRequest</code> middleware functions in order</li>
+<li>add applicable auth headers (e.g. adding <code>Basic ...</code> for <code>basic</code> auth), if applicable</li>
+<li>add <code>request.params</code> to <code>request.url</code></li>
+<li>execute the <code>request</code>, store the result in <code>response</code></li>
+<li>try to auto-parse response body for non-raw requests, store result in <code>response.data</code></li>
+<li>log the request to Zapier&apos;s logging server</li>
+<li>if the status code is <code>401</code>, you&apos;re using a refresh-able auth (such as <code>oauth2</code> or <code>session</code>) <em>and</em> <code>autoRefresh</code> is <code>true</code> in your auth configuration, throw a <code>RefreshAuthError</code>. The server will attempt to refresh the authentication again and retry the whole step</li>
+<li>run your <code>afterResponse</code> middleware functions in order</li>
+<li>call <code>response.throwForStatus()</code> unless <code>response.skipThrowForStatus</code> is <code>true</code></li>
+</ol><p>The resulting response object is returned from <code>z.request()</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3645,7 +3656,7 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p>
+      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p><p>This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here&apos;s a diagram to illustrate that:</p><p><img src="https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png" alt></p><p>Ensure you&apos;re handling errors correctly for your platform version. The latest released version is <strong>11.3.2</strong>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3720,14 +3731,14 @@ zapier env:get 1.0.0
 <li><code>status</code>: The response status code, i.e. <code>200</code>, <code>404</code>, etc.</li>
 <li><code>content</code>: The response content as a String. For Buffer, try <code>options.raw = true</code>.</li>
 <li><code>data</code> (<em>new in v10.0.0</em>): The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
-<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated since v10.0.0: Use <code>data</code> instead.</li>
-<li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise).</li>
-<li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
 <li><code>skipThrowForStatus</code> (<em>new in v10.0.0</em>): don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
-<li><code>throwForStatus()</code>: Throw error if 400 &lt;= <code>status</code> &lt; 600.</li>
+<li><code>throwForStatus()</code>: Throws an error if <code>400 &lt;= statusCode &lt; 600</code>.</li>
 <li><code>request</code>: The original request options object (see above).</li>
+</ul><p>Additionally, if <code>request.raw</code> is <code>true</code>, the raw response has the following properties:</p><ul>
+<li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise). <code>undefined</code> in non-raw requests.</li>
+<li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">

--- a/docs/index.html
+++ b/docs/index.html
@@ -343,10 +343,7 @@ a code {
 <li><a href="#error-handling">Error Handling</a><ul>
 <li><a href="#general-errors">General Errors</a></li>
 <li><a href="#halting-execution">Halting Execution</a></li>
-<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a><ul>
-<li><a href="#v10-breaking-change-auth-refresh">v10 Breaking Change: Auth Refresh</a></li>
-</ul>
-</li>
+<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 <li><a href="#handling-throttled-requests">Handling Throttled Requests</a></li>
 </ul>
 </li>
@@ -552,10 +549,7 @@ a code {
 <li><a href="#error-handling">Error Handling</a><ul>
 <li><a href="#general-errors">General Errors</a></li>
 <li><a href="#halting-execution">Halting Execution</a></li>
-<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a><ul>
-<li><a href="#v10-breaking-change-auth-refresh">v10 Breaking Change: Auth Refresh</a></li>
-</ul>
-</li>
+<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 <li><a href="#handling-throttled-requests">Handling Throttled Requests</a></li>
 </ul>
 </li>
@@ -4315,80 +4309,13 @@ is sent out asking the user to refresh the credentials. While the auth is
 disconnected, Zap runs will not be executed, to prevent more calls with expired
 credentials. (The runs will be
 <a href="https://zapier.com/help/manage/history/view-and-manage-your-zap-history#holding">Held</a>,
-and the user will be able to replay them after reconnecting.)</p><p>Example: <code>throw new z.errors.ExpiredAuthError(&apos;Your message.&apos;);</code></p><p>For apps that use OAuth2 with <code>autoRefresh: true</code> or Session Auth, the core injects
+and the user will be able to replay them after reconnecting.)</p><p>Example: <code>throw new z.errors.ExpiredAuthError(&apos;You must manually reconnect this auth.&apos;);</code></p><p>For apps that use OAuth2 with <code>autoRefresh: true</code> or Session Auth, <code>core</code> injects
 a built-in <code>afterResponse</code> middleware that throws an error when the response status
 is 401. The error will signal Zapier to refresh the credentials and then retry the
-failed operation. For some cases, e.g, your server doesn&apos;t use the 401 status
-for auth refresh, you may have to throw the <code>RefreshAuthError</code> on your own,
-which will also signal Zapier to refresh the credentials.</p><p>Example: <code>throw new z.errors.RefreshAuthError();</code></p>
+failed operation. You can also throw this error manually if your server doesn&apos;t use the 401 status or you want to trigger an auth refresh even if the credentials aren&apos;t stale.</p><p>Example: <code>throw new z.errors.RefreshAuthError();</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h4 id="v10-breaking-change-auth-refresh">v10 Breaking Change: Auth Refresh</h4>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>A breaking change on v10+ is that the built-in <code>afterResponse</code> middleware that
-handles auth refresh is changed to happen AFTER your app&apos;s <code>afterResponse</code>. On
-v9 and older, it happens before your app&apos;s <code>afterResponse</code>. So it will break if
-your <code>afterReponse</code> does something like:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-comment">// Auth refresh will stop working on v10 this way!</span>
-<span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
-  <span class="hljs-keyword">if</span> (resp.status !== <span class="hljs-number">200</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;hi&apos;</span>);
-  }
-  <span class="hljs-keyword">return</span> resp;
-};
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This is because on v10 the <code>throw new Error(&apos;hi&apos;)</code> line will take precedence
-over the built-in middleware that does auth refresh. One way to fix is to let
-the 401 response fall back to the built-in middleware that does the auth
-refresh:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
-  <span class="hljs-keyword">if</span> (resp.status !== <span class="hljs-number">200</span> &amp;&amp; resp.status !== <span class="hljs-number">401</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;hi&apos;</span>);
-  }
-  <span class="hljs-keyword">return</span> resp;
-};
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Another way to fix is to handle the 401 response yourself by throwing a
-<code>RefreshAuthError</code>:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
-  <span class="hljs-keyword">if</span> (resp.status === <span class="hljs-number">401</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.RefreshAuthError();
-  }
-  <span class="hljs-keyword">if</span> (resp.status !== <span class="hljs-number">200</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;hi&apos;</span>);
-  }
-  <span class="hljs-keyword">return</span> resp;
-};
-</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1125,7 +1125,40 @@ The resulting response object is returned from `z.request()`.
 
 #### Error Response Handling
 
-Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code >= 400 that should not be treated as an error.
+Since `v10.0.0`, `z.request()` calls `response.throwForStatus()` before it returns a response. You can disable automatic error throwing by setting `skipThrowForStatus` on the request object:
+
+```js
+// Disable automatic error throwing on the request object
+const perform = async (z, bundle) => {
+  const response = await z.request({
+    url: '...',
+    skipThrowForStatus: true
+  });
+  // Now you handle error response on your own.
+  // The following is equivalent to response.throwForStatus(), 
+  // but you have to remember to do it on every request
+  if (response.status >= 400) {
+    throw new z.errors.ResponseError(response);
+  }
+};
+```
+
+You can also do it in `afterResponse` if the API uses a status code >= 400 that should not be treated as an error.
+
+```js
+// Don't throw an error when response status is 456
+const disableAutoThrowOn456 = (response, z) => {
+  if (response.status === 456) {
+    response.skipThrowForStatus = true;
+  }
+  return response;
+};
+const App = {
+  // ...
+  afterResponse: [disableAutoThrowOn456],
+  // ...
+};
+```
 
 For developers using v9.x and below, it's your responsibility to throw an exception for an error response. That means you should call `response.throwForStatus()` or throw an error yourself, likely following the `z.request` call.
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1108,11 +1108,32 @@ Middleware functions can be asynchronous - just return a promise from the middle
 
 The second argument for middleware is the `z` object, but it does *not* include `z.request()` as using that would easily create infinite loops.
 
+Here is the full request lifecycle when you call `z.request({...})`:
+
+1. set defaults on the `request` object
+2. run your `beforeRequest` middleware functions in order
+3. add applicable auth headers (e.g. adding `Basic ...` for `basic` auth), if applicable
+4. add `request.params` to `request.url`
+5. execute the `request`, store the result in `response`
+6. try to auto-parse response body for non-raw requests, store result in `response.data`
+7. log the request to Zapier's logging server
+8. if the status code is `401`, you're using a refresh-able auth (such as `oauth2` or `session`) _and_ `autoRefresh` is `true` in your auth configuration, throw a `RefreshAuthError`. The server will attempt to refresh the authentication again and retry the whole step
+9. run your `afterResponse` middleware functions in order
+10. call `response.throwForStatus()` unless `response.skipThrowForStatus` is `true`
+
+The resulting response object is returned from `z.request()`.
+
 #### Error Response Handling
 
 Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code >= 400 that should not be treated as an error.
 
 For developers using v9.x and below, it's your responsibility to throw an exception for an error response. That means you should call `response.throwForStatus()` or throw an error yourself, likely following the `z.request` call.
+
+This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here's a diagram to illustrate that:
+
+![](https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png)
+
+Ensure you're handling errors correctly for your platform version. The latest released version is **PACKAGE_VERSION**.
 
 ### HTTP Request Options
 
@@ -1162,15 +1183,17 @@ The response object returned by `z.request([url], options)` supports the followi
 
 * `status`: The response status code, i.e. `200`, `404`, etc.
 * `content`: The response content as a String. For Buffer, try `options.raw = true`.
-* `data` (_new in v10.0.0_): The response content as an object if the content is JSON or ` application/x-www-form-urlencoded` (`undefined` otherwise).
-* `json`: The response content as an object if the content is JSON (`undefined` otherwise). Deprecated since v10.0.0: Use `data` instead.
-* `json()`: Get the response content as an object, if `options.raw = true` and content is JSON (returns a promise).
-* `body`: A stream available only if you provide `options.raw = true`.
+* `data` (_new in v10.0.0_): The response content as an object if the content is JSON or `application/x-www-form-urlencoded` (`undefined` otherwise).
 * `headers`: Response headers object. The header keys are all lower case.
 * `getHeader(key)`: Retrieve response header, case insensitive: `response.getHeader('My-Header')`
 * `skipThrowForStatus` (_new in v10.0.0_): don't call `throwForStatus()` before resolving the request with this response.
-* `throwForStatus()`: Throw error if 400 <= `status` < 600.
+* `throwForStatus()`: Throws an error if `400 <= statusCode < 600`.
 * `request`: The original request options object (see above).
+
+Additionally, if `request.raw` is `true`, the raw response has the following properties:
+
+* `json()`: Get the response content as an object, if `options.raw = true` and content is JSON (returns a promise). `undefined` in non-raw requests.
+* `body`: A stream available only if you provide `options.raw = true`.
 
 ```js
 const response = await z.request({
@@ -1204,7 +1227,6 @@ if (options.raw === false) { // (default)
   response.body.pipe(otherStream);
 }
 ```
-
 
 ## Dehydration
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2177,7 +2177,40 @@ The resulting response object is returned from `z.request()`.
 
 #### Error Response Handling
 
-Since v10, we call `response.throwForStatus()` before we return a response. You can prevent this by setting `skipThrowForStatus` on the request or response object. You can do this in `afterResponse` middleware if the API uses a status code >= 400 that should not be treated as an error.
+Since `v10.0.0`, `z.request()` calls `response.throwForStatus()` before it returns a response. You can disable automatic error throwing by setting `skipThrowForStatus` on the request object:
+
+```js
+// Disable automatic error throwing on the request object
+const perform = async (z, bundle) => {
+  const response = await z.request({
+    url: '...',
+    skipThrowForStatus: true
+  });
+  // Now you handle error response on your own.
+  // The following is equivalent to response.throwForStatus(), 
+  // but you have to remember to do it on every request
+  if (response.status >= 400) {
+    throw new z.errors.ResponseError(response);
+  }
+};
+```
+
+You can also do it in `afterResponse` if the API uses a status code >= 400 that should not be treated as an error.
+
+```js
+// Don't throw an error when response status is 456
+const disableAutoThrowOn456 = (response, z) => {
+  if (response.status === 456) {
+    response.skipThrowForStatus = true;
+  }
+  return response;
+};
+const App = {
+  // ...
+  afterResponse: [disableAutoThrowOn456],
+  // ...
+};
+```
 
 For developers using v9.x and below, it's your responsibility to throw an exception for an error response. That means you should call `response.throwForStatus()` or throw an error yourself, likely following the `z.request` call.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -114,7 +114,6 @@ This doc describes the latest CLI version (**11.3.2**), as of this writing. If y
   * [General Errors](#general-errors)
   * [Halting Execution](#halting-execution)
   * [Stale Authentication Credentials](#stale-authentication-credentials)
-    + [v10 Breaking Change: Auth Refresh](#v10-breaking-change-auth-refresh)
   * [Handling Throttled Requests](#handling-throttled-requests)
 - [Testing](#testing)
   * [Writing Unit Tests](#writing-unit-tests)
@@ -2635,62 +2634,14 @@ credentials. (The runs will be
 [Held](https://zapier.com/help/manage/history/view-and-manage-your-zap-history#holding),
 and the user will be able to replay them after reconnecting.)
 
-Example: `throw new z.errors.ExpiredAuthError('Your message.');`
+Example: `throw new z.errors.ExpiredAuthError('You must manually reconnect this auth.');`
 
-For apps that use OAuth2 with `autoRefresh: true` or Session Auth, the core injects
+For apps that use OAuth2 with `autoRefresh: true` or Session Auth, `core` injects
 a built-in `afterResponse` middleware that throws an error when the response status
 is 401. The error will signal Zapier to refresh the credentials and then retry the
-failed operation. For some cases, e.g, your server doesn't use the 401 status
-for auth refresh, you may have to throw the `RefreshAuthError` on your own,
-which will also signal Zapier to refresh the credentials.
+failed operation. You can also throw this error manually if your server doesn't use the 401 status or you want to trigger an auth refresh even if the credentials aren't stale.
 
 Example: `throw new z.errors.RefreshAuthError();`
-
-#### v10 Breaking Change: Auth Refresh
-
-A breaking change on v10+ is that the built-in `afterResponse` middleware that
-handles auth refresh is changed to happen AFTER your app's `afterResponse`. On
-v9 and older, it happens before your app's `afterResponse`. So it will break if
-your `afterReponse` does something like:
-
-```js
-// Auth refresh will stop working on v10 this way!
-const yourAfterResponse = (resp) => {
-  if (resp.status !== 200) {
-    throw new Error('hi');
-  }
-  return resp;
-};
-```
-
-This is because on v10 the `throw new Error('hi')` line will take precedence
-over the built-in middleware that does auth refresh. One way to fix is to let
-the 401 response fall back to the built-in middleware that does the auth
-refresh:
-
-```js
-const yourAfterResponse = (resp) => {
-  if (resp.status !== 200 && resp.status !== 401) {
-    throw new Error('hi');
-  }
-  return resp;
-};
-```
-
-Another way to fix is to handle the 401 response yourself by throwing a
-`RefreshAuthError`:
-
-```js
-const yourAfterResponse = (resp) => {
-  if (resp.status === 401) {
-    throw new z.errors.RefreshAuthError();
-  }
-  if (resp.status !== 200) {
-    throw new Error('hi');
-  }
-  return resp;
-};
-```
 
 ### Handling Throttled Requests
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3656,7 +3656,50 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p><p>This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here&apos;s a diagram to illustrate that:</p><p><img src="https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png" alt></p><p>Ensure you&apos;re handling errors correctly for your platform version. The latest released version is <strong>11.3.2</strong>.</p>
+      <p>Since <code>v10.0.0</code>, <code>z.request()</code> calls <code>response.throwForStatus()</code> before it returns a response. You can disable automatic error throwing by setting <code>skipThrowForStatus</code> on the request object:</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">// Disable automatic error throwing on the request object</span>
+<span class="hljs-keyword">const</span> perform = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
+  <span class="hljs-keyword">const</span> response = <span class="hljs-keyword">await</span> z.request({
+    <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;...&apos;</span>,
+    <span class="hljs-attr">skipThrowForStatus</span>: <span class="hljs-literal">true</span>
+  });
+  <span class="hljs-comment">// Now you handle error response on your own.</span>
+  <span class="hljs-comment">// The following is equivalent to response.throwForStatus(), </span>
+  <span class="hljs-comment">// but you have to remember to do it on every request</span>
+  <span class="hljs-keyword">if</span> (response.status &gt;= <span class="hljs-number">400</span>) {
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.ResponseError(response);
+  }
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>You can also do it in <code>afterResponse</code> if the API uses a status code &gt;= 400 that should not be treated as an error.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-js"><span class="hljs-comment">// Don&apos;t throw an error when response status is 456</span>
+<span class="hljs-keyword">const</span> disableAutoThrowOn456 = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
+  <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
+    response.skipThrowForStatus = <span class="hljs-literal">true</span>;
+  }
+  <span class="hljs-keyword">return</span> response;
+};
+<span class="hljs-keyword">const</span> App = {
+  <span class="hljs-comment">// ...</span>
+  <span class="hljs-attr">afterResponse</span>: [disableAutoThrowOn456],
+  <span class="hljs-comment">// ...</span>
+};
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p><p>This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here&apos;s a diagram to illustrate that:</p><p><img src="https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png" alt></p><p>Ensure you&apos;re handling errors correctly for your platform version. The latest released version is <strong>11.3.2</strong>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3596,7 +3596,15 @@ zapier env:get 1.0.0
 };
 
 <span class="hljs-comment">// This example only works on core v10+!</span>
-<span class="hljs-keyword">const</span> handleErrors = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
+<span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
+  <span class="hljs-comment">// Parse content that is not JSON</span>
+  <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
+  response.data = xml.parse(response.content);
+  <span class="hljs-keyword">return</span> response;
+};
+
+<span class="hljs-comment">// This example only works on core v10+!</span>
+<span class="hljs-keyword">const</span> handleWeirdErrors = <span class="hljs-function">(<span class="hljs-params">response, z</span>) =&gt;</span> {
   <span class="hljs-comment">// Prevent `throwForStatus` from throwing for a certain status.</span>
   <span class="hljs-keyword">if</span> (response.status === <span class="hljs-number">456</span>) {
     response.skipThrowForStatus = <span class="hljs-literal">true</span>;
@@ -3606,18 +3614,10 @@ zapier env:get 1.0.0
   <span class="hljs-keyword">return</span> response;
 };
 
-<span class="hljs-comment">// This example only works on core v10+!</span>
-<span class="hljs-keyword">const</span> parseXML = <span class="hljs-function">(<span class="hljs-params">response, z, bundle</span>) =&gt;</span> {
-  <span class="hljs-comment">// Parse content that is not JSON</span>
-  <span class="hljs-comment">// eslint-disable-next-line no-undef</span>
-  response.data = xml.parse(response.content);
-  <span class="hljs-keyword">return</span> response;
-};
-
 <span class="hljs-keyword">const</span> App = {
   <span class="hljs-comment">// ...</span>
   <span class="hljs-attr">beforeRequest</span>: [addHeader],
-  <span class="hljs-attr">afterResponse</span>: [parseXML, handleErrors],
+  <span class="hljs-attr">afterResponse</span>: [parseXML, handleWeirdErrors],
   <span class="hljs-comment">// ...</span>
 };
 
@@ -3627,7 +3627,18 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>A <code>beforeRequest</code> middleware function takes a request options object, and returns a (possibly mutated) request object. An <code>afterResponse</code> middleware function takes a response object, and returns a (possibly mutated) response object. Middleware functions are executed in the order specified in the app definition, and each subsequent middleware receives the request or response object returned by the previous middleware.</p><p>Middleware functions can be asynchronous - just return a promise from the middleware function.</p><p>The second argument for middleware is the <code>z</code> object, but it does <em>not</em> include <code>z.request()</code> as using that would easily create infinite loops.</p>
+      <p>A <code>beforeRequest</code> middleware function takes a request options object, and returns a (possibly mutated) request object. An <code>afterResponse</code> middleware function takes a response object, and returns a (possibly mutated) response object. Middleware functions are executed in the order specified in the app definition, and each subsequent middleware receives the request or response object returned by the previous middleware.</p><p>Middleware functions can be asynchronous - just return a promise from the middleware function.</p><p>The second argument for middleware is the <code>z</code> object, but it does <em>not</em> include <code>z.request()</code> as using that would easily create infinite loops.</p><p>Here is the full request lifecycle when you call <code>z.request({...})</code>:</p><ol>
+<li>set defaults on the <code>request</code> object</li>
+<li>run your <code>beforeRequest</code> middleware functions in order</li>
+<li>add applicable auth headers (e.g. adding <code>Basic ...</code> for <code>basic</code> auth), if applicable</li>
+<li>add <code>request.params</code> to <code>request.url</code></li>
+<li>execute the <code>request</code>, store the result in <code>response</code></li>
+<li>try to auto-parse response body for non-raw requests, store result in <code>response.data</code></li>
+<li>log the request to Zapier&apos;s logging server</li>
+<li>if the status code is <code>401</code>, you&apos;re using a refresh-able auth (such as <code>oauth2</code> or <code>session</code>) <em>and</em> <code>autoRefresh</code> is <code>true</code> in your auth configuration, throw a <code>RefreshAuthError</code>. The server will attempt to refresh the authentication again and retry the whole step</li>
+<li>run your <code>afterResponse</code> middleware functions in order</li>
+<li>call <code>response.throwForStatus()</code> unless <code>response.skipThrowForStatus</code> is <code>true</code></li>
+</ol><p>The resulting response object is returned from <code>z.request()</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3645,7 +3656,7 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p>
+      <p>Since v10, we call <code>response.throwForStatus()</code> before we return a response. You can prevent this by setting <code>skipThrowForStatus</code> on the request or response object. You can do this in <code>afterResponse</code> middleware if the API uses a status code &gt;= 400 that should not be treated as an error.</p><p>For developers using v9.x and below, it&apos;s your responsibility to throw an exception for an error response. That means you should call <code>response.throwForStatus()</code> or throw an error yourself, likely following the <code>z.request</code> call.</p><p>This behavior has changed periodically across major versions, which changes how/when you have to worry about handling errors. Here&apos;s a diagram to illustrate that:</p><p><img src="https://cdn.zappy.app/e835d9beca1b6489a065d51a381613f3.png" alt></p><p>Ensure you&apos;re handling errors correctly for your platform version. The latest released version is <strong>11.3.2</strong>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -3720,14 +3731,14 @@ zapier env:get 1.0.0
 <li><code>status</code>: The response status code, i.e. <code>200</code>, <code>404</code>, etc.</li>
 <li><code>content</code>: The response content as a String. For Buffer, try <code>options.raw = true</code>.</li>
 <li><code>data</code> (<em>new in v10.0.0</em>): The response content as an object if the content is JSON or <code>application/x-www-form-urlencoded</code> (<code>undefined</code> otherwise).</li>
-<li><code>json</code>: The response content as an object if the content is JSON (<code>undefined</code> otherwise). Deprecated since v10.0.0: Use <code>data</code> instead.</li>
-<li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise).</li>
-<li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 <li><code>headers</code>: Response headers object. The header keys are all lower case.</li>
 <li><code>getHeader(key)</code>: Retrieve response header, case insensitive: <code>response.getHeader(&apos;My-Header&apos;)</code></li>
 <li><code>skipThrowForStatus</code> (<em>new in v10.0.0</em>): don&apos;t call <code>throwForStatus()</code> before resolving the request with this response.</li>
-<li><code>throwForStatus()</code>: Throw error if 400 &lt;= <code>status</code> &lt; 600.</li>
+<li><code>throwForStatus()</code>: Throws an error if <code>400 &lt;= statusCode &lt; 600</code>.</li>
 <li><code>request</code>: The original request options object (see above).</li>
+</ul><p>Additionally, if <code>request.raw</code> is <code>true</code>, the raw response has the following properties:</p><ul>
+<li><code>json()</code>: Get the response content as an object, if <code>options.raw = true</code> and content is JSON (returns a promise). <code>undefined</code> in non-raw requests.</li>
+<li><code>body</code>: A stream available only if you provide <code>options.raw = true</code>.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -343,10 +343,7 @@ a code {
 <li><a href="#error-handling">Error Handling</a><ul>
 <li><a href="#general-errors">General Errors</a></li>
 <li><a href="#halting-execution">Halting Execution</a></li>
-<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a><ul>
-<li><a href="#v10-breaking-change-auth-refresh">v10 Breaking Change: Auth Refresh</a></li>
-</ul>
-</li>
+<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 <li><a href="#handling-throttled-requests">Handling Throttled Requests</a></li>
 </ul>
 </li>
@@ -552,10 +549,7 @@ a code {
 <li><a href="#error-handling">Error Handling</a><ul>
 <li><a href="#general-errors">General Errors</a></li>
 <li><a href="#halting-execution">Halting Execution</a></li>
-<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a><ul>
-<li><a href="#v10-breaking-change-auth-refresh">v10 Breaking Change: Auth Refresh</a></li>
-</ul>
-</li>
+<li><a href="#stale-authentication-credentials">Stale Authentication Credentials</a></li>
 <li><a href="#handling-throttled-requests">Handling Throttled Requests</a></li>
 </ul>
 </li>
@@ -4315,80 +4309,13 @@ is sent out asking the user to refresh the credentials. While the auth is
 disconnected, Zap runs will not be executed, to prevent more calls with expired
 credentials. (The runs will be
 <a href="https://zapier.com/help/manage/history/view-and-manage-your-zap-history#holding">Held</a>,
-and the user will be able to replay them after reconnecting.)</p><p>Example: <code>throw new z.errors.ExpiredAuthError(&apos;Your message.&apos;);</code></p><p>For apps that use OAuth2 with <code>autoRefresh: true</code> or Session Auth, the core injects
+and the user will be able to replay them after reconnecting.)</p><p>Example: <code>throw new z.errors.ExpiredAuthError(&apos;You must manually reconnect this auth.&apos;);</code></p><p>For apps that use OAuth2 with <code>autoRefresh: true</code> or Session Auth, <code>core</code> injects
 a built-in <code>afterResponse</code> middleware that throws an error when the response status
 is 401. The error will signal Zapier to refresh the credentials and then retry the
-failed operation. For some cases, e.g, your server doesn&apos;t use the 401 status
-for auth refresh, you may have to throw the <code>RefreshAuthError</code> on your own,
-which will also signal Zapier to refresh the credentials.</p><p>Example: <code>throw new z.errors.RefreshAuthError();</code></p>
+failed operation. You can also throw this error manually if your server doesn&apos;t use the 401 status or you want to trigger an auth refresh even if the credentials aren&apos;t stale.</p><p>Example: <code>throw new z.errors.RefreshAuthError();</code></p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <h4 id="v10-breaking-change-auth-refresh">v10 Breaking Change: Auth Refresh</h4>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
-      
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>A breaking change on v10+ is that the built-in <code>afterResponse</code> middleware that
-handles auth refresh is changed to happen AFTER your app&apos;s <code>afterResponse</code>. On
-v9 and older, it happens before your app&apos;s <code>afterResponse</code>. So it will break if
-your <code>afterReponse</code> does something like:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-comment">// Auth refresh will stop working on v10 this way!</span>
-<span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
-  <span class="hljs-keyword">if</span> (resp.status !== <span class="hljs-number">200</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;hi&apos;</span>);
-  }
-  <span class="hljs-keyword">return</span> resp;
-};
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>This is because on v10 the <code>throw new Error(&apos;hi&apos;)</code> line will take precedence
-over the built-in middleware that does auth refresh. One way to fix is to let
-the 401 response fall back to the built-in middleware that does the auth
-refresh:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
-  <span class="hljs-keyword">if</span> (resp.status !== <span class="hljs-number">200</span> &amp;&amp; resp.status !== <span class="hljs-number">401</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;hi&apos;</span>);
-  }
-  <span class="hljs-keyword">return</span> resp;
-};
-</code></pre>
-    </div>
-  </div>
-</div><div class="row">
-  <div class="row-height">
-    <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Another way to fix is to handle the 401 response yourself by throwing a
-<code>RefreshAuthError</code>:</p>
-    </div>
-    <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-js"><span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
-  <span class="hljs-keyword">if</span> (resp.status === <span class="hljs-number">401</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.RefreshAuthError();
-  }
-  <span class="hljs-keyword">if</span> (resp.status !== <span class="hljs-number">200</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">&apos;hi&apos;</span>);
-  }
-  <span class="hljs-keyword">return</span> resp;
-};
-</code></pre>
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/snippets/middleware.js
+++ b/packages/cli/snippets/middleware.js
@@ -4,7 +4,15 @@ const addHeader = (request, z, bundle) => {
 };
 
 // This example only works on core v10+!
-const handleErrors = (response, z) => {
+const parseXML = (response, z, bundle) => {
+  // Parse content that is not JSON
+  // eslint-disable-next-line no-undef
+  response.data = xml.parse(response.content);
+  return response;
+};
+
+// This example only works on core v10+!
+const handleWeirdErrors = (response, z) => {
   // Prevent `throwForStatus` from throwing for a certain status.
   if (response.status === 456) {
     response.skipThrowForStatus = true;
@@ -14,17 +22,9 @@ const handleErrors = (response, z) => {
   return response;
 };
 
-// This example only works on core v10+!
-const parseXML = (response, z, bundle) => {
-  // Parse content that is not JSON
-  // eslint-disable-next-line no-undef
-  response.data = xml.parse(response.content);
-  return response;
-};
-
 const App = {
   // ...
   beforeRequest: [addHeader],
-  afterResponse: [parseXML, handleErrors],
+  afterResponse: [parseXML, handleWeirdErrors],
   // ...
 };


### PR DESCRIPTION
Documentation for #512. The app-wide `skipThrowForStatus` is intentionally not documented because I don't anticipate CLI devs using that - they can do it in middleware if they'd like. 

Did some other cleaning while I was in there.