### PR TITLE
fix(core): tweak global `skipThrowForStatus` flag to ignore shorthand requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ _released `2022-03-24`_
 
 ### core
 
-- Fix regression where the global `skipThrowForStatus` incorrectly applied to shorthand requests. It's only intended to modify the behavior of requests made with `z.request()`. The docs and changelog have been updated accordingly ([#520](https://github.com/zapier/zapier-platform/pull/520))
+- :bug: Fix regression where the global `skipThrowForStatus` incorrectly applied to shorthand requests. It's only intended to modify the behavior of requests made with `z.request()`. The docs and changelog have been updated accordingly ([#520](https://github.com/zapier/zapier-platform/pull/520))
 
 ### schema
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ _released `2022-03-24`_
 
 ### core
 
-- Fix regression where the global `skipThrowForStatus` incorrectly applied to shorthand requests. It's only intended to modify the behavior of requests made with `z.request()`. The docs and changelog have been updated accordingly.
+- Fix regression where the global `skipThrowForStatus` incorrectly applied to shorthand requests. It's only intended to modify the behavior of requests made with `z.request()`. The docs and changelog have been updated accordingly ([#520](https://github.com/zapier/zapier-platform/pull/520))
 
 ### schema
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
+## 12.0.1
+
+_released `2022-03-24`_
+
+### cli
+
+- None
+
+### core
+
+- Fix regression where the global `skipThrowForStatus` incorrectly applied to shorthand requests. It's only intended to modify the behavior of requests made with `z.request()`. The docs and changelog have been updated accordingly.
+
+### schema
+
+- None!
+
 ## 12.0.0
 
-_Released `2022-03-23`_
+_released `2022-03-23`_
 
 We're breaking slightly from our pattern of a single yearly major release. The `12.0.0` release contains some backwards-incompatible changes to how middleware and auth refreshes work. For the most part, you'll be able to upgrade to this version safely, but as always, it's worth re-running unit tests (especially those related to authentication).
 
@@ -17,7 +33,7 @@ In the coming months, we'll follow up with a `13.0.0` release that will bump the
 
 ### schema
 
-- :nail_care: add app-wide skipThrowForStatus flag. This is helpful for backwards compatibility when migrating from `9.x` to `12.x`, but probably won't be relevant for most developers. ([#511](https://github.com/zapier/zapier-platform/pull/511))
+- :nail_care: add app-wide skipThrowForStatus flag. This is helpful for backwards compatibility when migrating from `9.x` to `12.x`, but probably won't be relevant for most developers. Note that this flag **only affects requests made with `z.request()`** ([#511](https://github.com/zapier/zapier-platform/pull/511))
 
 ## 11.3.3
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3450,7 +3450,7 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>In the URL above, <code>{{bundle.authData.subdomain}}</code> is automatically replaced with the live value from the bundle. If the call returns a non 2xx return code, an error is automatically raised. The response body is automatically parsed as JSON and returned.</p><p>An error will be raised if the response is not valid JSON, so <em>do not use shorthand HTTP requests with non-JSON responses</em>.</p>
+      <p>In the URL above, <code>{{bundle.authData.subdomain}}</code> is automatically replaced with the live value from the bundle. If the call returns a non 2xx return code, an error is automatically raised. The response body is automatically parsed as JSON and returned.</p><p>An error will be raised if the response cannot be parsed as JSON or form-encoded. To use shorthand requests with other response types, add <a href="#using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed response.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1068,7 +1068,7 @@ This features:
 
 In the URL above, `{{bundle.authData.subdomain}}` is automatically replaced with the live value from the bundle. If the call returns a non 2xx return code, an error is automatically raised. The response body is automatically parsed as JSON and returned.
 
-An error will be raised if the response is not valid JSON, so _do not use shorthand HTTP requests with non-JSON responses_.
+An error will be raised if the response cannot be parsed as JSON or form-encoded. To use shorthand requests with other response types, add [middleware](#using-http-middleware) that sets `response.data` to the parsed response.
 
 ### Manual HTTP Requests
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2027,7 +2027,7 @@ const App = {
 
 In the URL above, `{{bundle.authData.subdomain}}` is automatically replaced with the live value from the bundle. If the call returns a non 2xx return code, an error is automatically raised. The response body is automatically parsed as JSON and returned.
 
-An error will be raised if the response is not valid JSON, so _do not use shorthand HTTP requests with non-JSON responses_.
+An error will be raised if the response cannot be parsed as JSON or form-encoded. To use shorthand requests with other response types, add [middleware](#using-http-middleware) that sets `response.data` to the parsed response.
 
 ### Manual HTTP Requests
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3450,7 +3450,7 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>In the URL above, <code>{{bundle.authData.subdomain}}</code> is automatically replaced with the live value from the bundle. If the call returns a non 2xx return code, an error is automatically raised. The response body is automatically parsed as JSON and returned.</p><p>An error will be raised if the response is not valid JSON, so <em>do not use shorthand HTTP requests with non-JSON responses</em>.</p>
+      <p>In the URL above, <code>{{bundle.authData.subdomain}}</code> is automatically replaced with the live value from the bundle. If the call returns a non 2xx return code, an error is automatically raised. The response body is automatically parsed as JSON and returned.</p><p>An error will be raised if the response cannot be parsed as JSON or form-encoded. To use shorthand requests with other response types, add <a href="#using-http-middleware">middleware</a> that sets <code>response.data</code> to the parsed response.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/core/src/execute.js
+++ b/packages/core/src/execute.js
@@ -11,7 +11,18 @@ const ZapierPromise = require('./tools/promise');
 const constants = require('./constants');
 
 const executeHttpRequest = (input, options) => {
-  options = _.extend({}, options, constants.REQUEST_OBJECT_SHORTHAND_OPTIONS);
+  options = _.extend(
+    {},
+    // shorthand requests should always throw _unless_ the object specifically opts out
+    // this covers godzilla devs who use shorthand requests (most of them) that rely on the throwing behavior
+    // when we set the app-wide skip for everyone, we don't want their behavior to change
+    // so, this line takes precedence over the global setting, but not the local one (`options`)
+    {
+      skipThrowForStatus: false,
+    },
+    options,
+    constants.REQUEST_OBJECT_SHORTHAND_OPTIONS
+  );
   return input.z.request(options).then((response) => {
     if (response.data === undefined) {
       throw new Error(

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -815,7 +815,7 @@ describe('create-app', () => {
         results[0].message.should.eql('mocked response');
       });
 
-      it('should skip throw if local flag is false and global flag is set', async () => {
+      it('should throw if local flag is false and global flag is set', async () => {
         const appDef = {
           ...appDefinition,
           flags: {

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -814,6 +814,33 @@ describe('create-app', () => {
         results[0].status.should.eql(400);
         results[0].message.should.eql('mocked response');
       });
+
+      it('should skip throw if local flag is false and global flag is set', async () => {
+        const appDef = {
+          ...appDefinition,
+          flags: {
+            skipThrowForStatus: true,
+          },
+        };
+        const app = createApp(appDef);
+
+        const event = {
+          command: 'execute',
+          bundle: {
+            inputData: {
+              options: {
+                url: `${HTTPBIN_URL}/status/400`,
+                skipThrowForStatus: false,
+              },
+            },
+          },
+          method,
+        };
+        const err = await app(
+          createInput(appDefinition, event, testLogger)
+        ).should.be.rejected();
+        JSON.parse(err.message).status.should.eql(400);
+      });
     });
   });
 });

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -665,4 +665,155 @@ describe('create-app', () => {
       );
     });
   });
+
+  describe('error skipping', () => {
+    describe('shorthand requests', () => {
+      const method =
+        'resources.executeRequestAsShorthand.create.operation.perform';
+      it('should throw on shorthand by default', async () => {
+        const app = createApp(appDefinition);
+
+        const event = {
+          command: 'execute',
+          bundle: {
+            inputData: {
+              url: `${HTTPBIN_URL}/status/400`,
+            },
+          },
+          method,
+        };
+        const err = await app(
+          createInput(appDefinition, event, testLogger)
+        ).should.be.rejected();
+        JSON.parse(err.message).status.should.eql(400);
+      });
+
+      it('should throw on shorthand even when global skip flag is present', async () => {
+        const appDef = {
+          ...appDefinition,
+          flags: {
+            // this is ignored for shorthand requests
+            skipThrowForStatus: true,
+          },
+        };
+        const app = createApp(appDef);
+
+        const event = {
+          command: 'execute',
+          bundle: {
+            inputData: {
+              url: `${HTTPBIN_URL}/status/400`,
+            },
+          },
+          method,
+        };
+        const err = await app(
+          createInput(appDef, event, testLogger)
+        ).should.be.rejected();
+        JSON.parse(err.message).status.should.eql(400);
+      });
+
+      it('should skip throw on shorthand if local flag is set', async () => {
+        const appDef = {
+          ...appDefinition,
+        };
+        appDef.resources.executeRequestAsShorthand.create.operation.perform.skipThrowForStatus = true;
+
+        const app = createApp(appDef);
+
+        // httpbin can't return a body w/ the status endpoint
+        const url = 'https://status-with-body.example.com';
+        nock(url)
+          .get('/')
+          .reply(400, { status: 400, message: 'mocked response' });
+
+        const event = {
+          command: 'execute',
+          bundle: { inputData: { url } },
+          method,
+        };
+        const { results } = await app(
+          createInput(appDef, event, testLogger)
+        ).should.be.fulfilled();
+
+        results.status.should.eql(400);
+        results.message.should.eql('mocked response');
+      });
+    });
+
+    describe('z.request requests', () => {
+      const method = 'resources.executeRequestAsFunc.list.operation.perform';
+      it('should throw on request by default', async () => {
+        const app = createApp(appDefinition);
+
+        const event = {
+          command: 'execute',
+          bundle: {
+            inputData: {
+              options: { url: `${HTTPBIN_URL}/status/400` },
+            },
+          },
+          method,
+        };
+        const err = await app(
+          createInput(appDefinition, event, testLogger)
+        ).should.be.rejected();
+
+        JSON.parse(err.message).status.should.eql(400);
+      });
+
+      it('should skip throw when global skip flag is present', async () => {
+        const appDef = {
+          ...appDefinition,
+          flags: {
+            skipThrowForStatus: true,
+          },
+        };
+        // httpbin can't return a body w/ the status endpoint
+        const url = 'https://status-with-body.example.com';
+        nock(url)
+          .get('/')
+          .reply(400, [{ id: 1, status: 400, message: 'mocked response' }]);
+
+        const app = createApp(appDef);
+        const event = {
+          command: 'execute',
+          bundle: {
+            inputData: { options: { url } },
+          },
+          method,
+        };
+        const { results } = await app(
+          createInput(appDef, event, testLogger)
+        ).should.be.fulfilled();
+
+        results[0].status.should.eql(400);
+        results[0].message.should.eql('mocked response');
+      });
+
+      it('should skip throw if local flag is set', async () => {
+        const app = createApp(appDefinition);
+
+        // httpbin can't return a body w/ the status endpoint
+        const url = 'https://status-with-body.example.com';
+        nock(url)
+          .get('/')
+          .reply(400, [{ id: 1, status: 400, message: 'mocked response' }]);
+
+        const event = {
+          command: 'execute',
+          bundle: {
+            inputData: { options: { url, skipThrowForStatus: true } },
+          },
+          method,
+        };
+        const { results } = await app(
+          createInput(appDefinition, event, testLogger)
+        ).should.be.fulfilled();
+
+        results[0].status.should.eql(400);
+        results[0].message.should.eql('mocked response');
+      });
+    });
+  });
 });

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -78,7 +78,7 @@ Codifies high-level options for your integration.
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
 `skipHttpPatch` | no | `boolean` | By default, Zapier patches the core `http` module so that all requests (including those from 3rd-party SDKs) can be logged. Set this to true if you're seeing issues using an SDK (such as AWS).
-`skipThrowForStatus` | no | `boolean` | Starting in `core` version `10.0.0`, `response.throwForStatus()` was called by default. We introduced a per-request way to opt-out of this behavior. This flag takes that a step further and controls that behavior integration-wide. Only takes effect if the request _does not_ specify a value for `skipThrowForStatus` at all.
+`skipThrowForStatus` | no | `boolean` | Starting in `core` version `10.0.0`, `response.throwForStatus()` was called by default. We introduced a per-request way to opt-out of this behavior. This flag takes that a step further and controls that behavior integration-wide **for requests made using `z.request()`**. Unless they specify otherwise (per-request, or via middleware), [Shorthand requests](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#shorthand-http-requests) _always_ call `throwForStatus()`. `z.request()` calls can also ignore this flag if they set `skipThrowForStatus` directly
 
 #### Examples
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -1497,7 +1497,7 @@
           "type": "boolean"
         },
         "skipThrowForStatus": {
-          "description": "Starting in `core` version `10.0.0`, `response.throwForStatus()` was called by default. We introduced a per-request way to opt-out of this behavior. This flag takes that a step further and controls that behavior integration-wide. Only takes effect if the request _does not_ specify a value for `skipThrowForStatus` at all.",
+          "description": "Starting in `core` version `10.0.0`, `response.throwForStatus()` was called by default. We introduced a per-request way to opt-out of this behavior. This flag takes that a step further and controls that behavior integration-wide **for requests made using `z.request()`**. Unless they specify otherwise (per-request, or via middleware), [Shorthand requests](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#shorthand-http-requests) _always_ call `throwForStatus()`. `z.request()` calls can also ignore this flag if they set `skipThrowForStatus` directly",
           "type": "boolean"
         }
       },

--- a/packages/schema/lib/schemas/AppFlagsSchema.js
+++ b/packages/schema/lib/schemas/AppFlagsSchema.js
@@ -14,7 +14,7 @@ module.exports = makeSchema({
     },
     skipThrowForStatus: {
       description:
-        'Starting in `core` version `10.0.0`, `response.throwForStatus()` was called by default. We introduced a per-request way to opt-out of this behavior. This flag takes that a step further and controls that behavior integration-wide. Only takes effect if the request _does not_ specify a value for `skipThrowForStatus` at all.',
+        'Starting in `core` version `10.0.0`, `response.throwForStatus()` was called by default. We introduced a per-request way to opt-out of this behavior. This flag takes that a step further and controls that behavior integration-wide **for requests made using `z.request()`**. Unless they specify otherwise (per-request, or via middleware), [Shorthand requests](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#shorthand-http-requests) _always_ call `throwForStatus()`. `z.request()` calls can also ignore this flag if they set `skipThrowForStatus` directly',
       type: 'boolean',
     },
   },


### PR DESCRIPTION
In `9.x`, shorthand requests (using objects instead of JS functions) _always_ threw for bad responses. We want to maintain that behavior in the 12.x release line. But, the global `skipThrowForStatus` changed the defaults for all requests, not just shorthand. So, this adds an explicit `skipThrowForStatus: false` default to shorthand requests. Native devs can still have specified `skip: true` for shorthand requests. This keeps the default behavior for 9.x shorthand requests even when we set the global flag on all godzilla apps 😵‍💫😵‍💫😵‍💫

Here's a table I made to help myself reason about the change:

> Behavior of a failing shorthand request when migrated between core versions (9 and 12 should match)

|global flag (on 12) | req flag | 9.x   | 10-11.x | 12.x  |
 | ----------- | -------- | ----- | ------- | ----- |
 | false       | false    | throw | throw   | throw |
 | true        | false    | throw | pass    | pass❗️  |
 | false       | true     | pass | pass    | pass  |
 | true        | true     | pass | pass    | pass  |



❗ == bug introduced, should throw

if shorthand request opts out, honor that. Otherwise, always throw (ignoring new flag)