### PR TITLE
fix(core): properly replace curlies that match multiple times in a row

### DIFF
--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -64,6 +64,11 @@ const recurseReplaceBank = (obj, bank = {}) => {
 
     Object.keys(bank).forEach((key) => {
       const matchesKey = matchesKeyRegexMap[key];
+      // RegExp.test modifies internal state of the regex object
+      // since we're re-using regexes, we have to reset that state between calls
+      // or the second time in a row that the key should match, it misses instead
+      // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
+      matchesKey.lastIndex = 0;
       if (!matchesKey.test(maybeChangedString)) {
         return;
       }

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -826,6 +826,9 @@ describe('request client', () => {
         },
         headers: {
           Authorization: 'Bearer {{bundle.authData.access_token}}',
+          'x-api-key': '{{bundle.authData.access_token}}',
+          'x-cool': '{{bundle.authData.access_token}}',
+          'x-another': '{{bundle.authData.access_token}}',
         },
       });
 
@@ -833,6 +836,10 @@ describe('request client', () => {
       const { url } = JSON.parse(response.content);
       url.should.eql(`${HTTPBIN_URL}/get?limit=20&id=123`);
       headers.Authorization.should.deepEqual(['Bearer Let me in']);
+      // covers the case where replacing the same value in multiple places didn't work
+      headers['X-Api-Key'].should.deepEqual(['Let me in']);
+      headers['X-Cool'].should.deepEqual(['Let me in']);
+      headers['X-Another'].should.deepEqual(['Let me in']);
     });
 
     it('should be able to interpolate arrays/objects to a string', async () => {

--- a/packages/core/test/misc-tools.js
+++ b/packages/core/test/misc-tools.js
@@ -273,20 +273,45 @@ describe('Tools', () => {
 
   describe('recurseReplaceBank', () => {
     it('should replace stuff with recurseReplaceBank', () => {
-      const template = {
+      const obj = {
         multi: '{{somekey}} {{somekey}} hi!',
         thing: '{{somekey}} hi!',
         arr: ['{{somekey}} hi!'],
+        x: {
+          a: '{{somekey}}',
+          c: '{{somekey}} x',
+        },
       };
       const bank = {
         '{{somekey}}': 'lolz',
       };
-      const out = cleaner.recurseReplaceBank(template, bank);
+      const out = cleaner.recurseReplaceBank(obj, bank);
       out.should.eql({
         multi: 'lolz lolz hi!',
         thing: 'lolz hi!',
         arr: ['lolz hi!'],
+        x: {
+          a: 'lolz',
+          c: 'lolz x',
+        },
       });
+    });
+
+    it('should recursively resolve curlies', () => {
+      const req = {
+        headers: {
+          // 2 matches in a row caused a bug, so make sure to test that
+          a: '{{bundle.authData.access_token}}',
+          b: '{{bundle.authData.access_token}}',
+        },
+      };
+      const bank = {
+        '{{bundle.authData.access_token}}': 'Let me in',
+      };
+
+      const res = cleaner.recurseReplaceBank(req, bank);
+      res.headers.a.should.eql('Let me in');
+      res.headers.b.should.eql('Let me in');
     });
   });
 


### PR DESCRIPTION
Fixes bug introduced in core version `11.1.1` where a quirk with regex objects wouldn't replace multiple curly strings in a row