### PR TITLE
[PDE-3149] Update example-apps links to recommend `zapier init`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1156,7 +1156,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Useful if your app requires two pieces of information to authenticate: <code>username</code> and <code>password</code>, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).</p><blockquote>
-<p>To create a new integration with basic authentication, run <code>zapier init [your app name]</code> and select &quot;basic-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">here</a>.</p>
+<p>To create a new integration with basic authentication, run <code>zapier init [your app name] --template basic-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">here</a>.</p>
 </blockquote><p>If your app uses Basic auth with an encoded API key rather than a username and password, like <code>Authorization: Basic APIKEYHERE:x</code>, consider the <a href="#custom">Custom</a> authentication method instead.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1192,7 +1192,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.</p><blockquote>
-<p>To create a new integration with digest authentication, run <code>zapier init [your app name]</code> and select &quot;digest-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">here</a>.</p>
+<p>To create a new integration with digest authentication, run <code>zapier init [your app name] --template digest-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">here</a>.</p>
 </blockquote><blockquote>
 <p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will send an additional request beforehand to get the server nonce.</p>
 </blockquote>
@@ -1236,7 +1236,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
-<p>To create a new integration with custom authentication, run <code>zapier init [your app name]</code> and select &quot;custom-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
+<p>To create a new integration with custom authentication, run <code>zapier init [your app name] --custom-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1295,7 +1295,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.</p><blockquote>
-<p>To create a new integration with session authentication, run <code>zapier init [your app name]</code> and select &quot;session-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">here</a>.</p>
+<p>To create a new integration with session authentication, run <code>zapier init [your app name] --template session-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1387,7 +1387,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a">Twitter</a> and <a href="https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth">Trello</a> implementations of the 3-legged OAuth flow.</p><blockquote>
-<p>To create a new integration with OAuth1, run <code>zapier init [your app name]</code> and select &quot;oauth1-trello&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
+<p>To create a new integration with OAuth1, run <code>zapier init [your app name] --template oauth1-trello</code>. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
 </blockquote><p>The flow works like this:</p><ol>
 <li>Zapier makes a call to your API requesting a &quot;request token&quot; (also known as &quot;temporary credentials&quot;).</li>
 <li>Zapier sends the user to the authorization URL, defined by your app, along with the request token.</li>
@@ -1521,7 +1521,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Zapier&apos;s OAuth2 implementation is based on the <code>authorization_code</code> flow, similar to <a href="https://developer.github.com/v3/oauth/">GitHub</a> and <a href="https://developers.facebook.com/docs/authentication/server-side/">Facebook</a>.</p><blockquote>
-<p>To create a new integration with OAuth2, run <code>zapier init [your app name]</code> and select &quot;oauth2&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">our working example app</a>.</p>
+<p>To create a new integration with OAuth2, run <code>zapier init [your app name] --template oauth2</code>. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">our working example app</a>.</p>
 </blockquote><p>If your app&apos;s OAuth2 flow uses a different grant type, such as <code>client_credentials</code>, try using <a href="#session">Session auth</a> instead.</p><p>The OAuth2 flow looks like this:</p><ol>
 <li>Zapier sends the user to the authorization URL defined by your app.</li>
 <li>Once authorized, your website sends the user to the <code>redirect_uri</code> Zapier provided. Use the <code>zapier describe</code> command to find out what it is: <img src="https://zappy.zapier.com/83E12494-0A03-4DB4-AA46-5A2AF6A9ECCC.png" alt></li>
@@ -4050,7 +4050,7 @@ z.console.log(url);
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>To create a new integration for handling files, run <code>zapier init [your app name]</code> and select &quot;files&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">here</a>.</p>
+<p>To create a new integration for handling files, run <code>zapier init [your app name] --template files</code>. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4898,7 +4898,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>There are a lot of details left out - check out the full example app for a working setup.</p><blockquote>
-<p>To create a new integration with Babel, run <code>zapier init [your app name]</code> and select &quot;babel&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">here</a>.</p>
+<p>To create a new integration with Babel, run <code>zapier init [your app name] --template babel</code>. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/index.html
+++ b/docs/index.html
@@ -744,7 +744,7 @@ npm install
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Note: there are plenty of templates &amp; example apps to choose from! <a href="#example-apps">View all Example Apps here.</a>.</p>
+<p>Note: When you run <code>zapier init</code>, you&apos;ll be presented with a list of templates to start with. Pick the one that matches a feature you&apos;ll need (such as &quot;dynamic-dropdown&quot; for an integration with <a href="#dynamic-dropdowns">dynamic dropdown fields</a>), or select &quot;minimal&quot; for an integration with only the essentials. <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">View more example apps here</a>.</p>
 </blockquote><p>You should now have a working local app. You can run several local commands to try it out.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1156,7 +1156,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Useful if your app requires two pieces of information to authenticate: <code>username</code> and <code>password</code>, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth</a> for a working example app for basic auth.</p>
+<p>To create a new integration with basic authentication, run <code>zapier init [your app name]</code> and select &quot;basic-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">here</a>.</p>
 </blockquote><p>If your app uses Basic auth with an encoded API key rather than a username and password, like <code>Authorization: Basic APIKEYHERE:x</code>, consider the <a href="#custom">Custom</a> authentication method instead.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1192,7 +1192,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth</a> for a working example app for digest auth.</p>
+<p>To create a new integration with digest authentication, run <code>zapier init [your app name]</code> and select &quot;digest-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">here</a>.</p>
 </blockquote><blockquote>
 <p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will send an additional request beforehand to get the server nonce.</p>
 </blockquote>
@@ -1236,7 +1236,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth</a> for a working example app for custom auth.</p>
+<p>To create a new integration with custom authentication, run <code>zapier init [your app name]</code> and select &quot;custom-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1295,7 +1295,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth</a> for a working example app for session auth.</p>
+<p>To create a new integration with session authentication, run <code>zapier init [your app name]</code> and select &quot;session-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1387,7 +1387,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a">Twitter</a> and <a href="https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth">Trello</a> implementations of the 3-legged OAuth flow.</p><blockquote>
-<p>Example Apps: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
+<p>To create a new integration with OAuth1, run <code>zapier init [your app name]</code> and select &quot;oauth1-trello&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
 </blockquote><p>The flow works like this:</p><ol>
 <li>Zapier makes a call to your API requesting a &quot;request token&quot; (also known as &quot;temporary credentials&quot;).</li>
 <li>Zapier sends the user to the authorization URL, defined by your app, along with the request token.</li>
@@ -1521,7 +1521,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Zapier&apos;s OAuth2 implementation is based on the <code>authorization_code</code> flow, similar to <a href="https://developer.github.com/v3/oauth/">GitHub</a> and <a href="https://developers.facebook.com/docs/authentication/server-side/">Facebook</a>.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2</a> for a working example app for OAuth2.</p>
+<p>To create a new integration with OAuth2, run <code>zapier init [your app name]</code> and select &quot;oauth2&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">our working example app</a>.</p>
 </blockquote><p>If your app&apos;s OAuth2 flow uses a different grant type, such as <code>client_credentials</code>, try using <a href="#session">Session auth</a> instead.</p><p>The OAuth2 flow looks like this:</p><ol>
 <li>Zapier sends the user to the authorization URL defined by your app.</li>
 <li>Once authorized, your website sends the user to the <code>redirect_uri</code> Zapier provided. Use the <code>zapier describe</code> command to find out what it is: <img src="https://zappy.zapier.com/83E12494-0A03-4DB4-AA46-5A2AF6A9ECCC.png" alt></li>
@@ -1694,7 +1694,7 @@ read, and search operations on that resource.</p>
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>A resource has a few basic properties. The first is the <code>key</code>, which allows Zapier to identify the resource on our backend.
 The second is the <code>noun</code>, the user-friendly name of the resource that is presented to users throughout the Zapier UI.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/resource">https://github.com/zapier/zapier-platform/tree/master/example-apps/resource</a> for a working example app using resources.</p>
+<p>Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/resource">this working example app</a> to see resources in action.</p>
 </blockquote><p>After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
 The complete list of available methods can be found in the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#resourceschema">Resource Schema Docs</a>.
 For now, let&apos;s focus on two:</p><ul>
@@ -1814,13 +1814,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>You can find more details on the definition for each by looking at the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema">Trigger Schema</a>,
 <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema">Search Schema</a>, and <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema">Create Schema</a>.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/trigger">https://github.com/zapier/zapier-platform/tree/master/example-apps/trigger</a> for a working example app using triggers.</p>
-</blockquote><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/rest-hooks">https://github.com/zapier/zapier-platform/tree/master/example-apps/rest-hooks</a> for a working example app using REST hook triggers.</p>
-</blockquote><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/search">https://github.com/zapier/zapier-platform/tree/master/example-apps/search</a> for a working example app using searches.</p>
-</blockquote><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/create">https://github.com/zapier/zapier-platform/tree/master/example-apps/create</a> for a working example app using creates.</p>
+<p>To create a new integration with a premade trigger, search, or create, run <code>zapier init [your app name]</code> and select from the list that appears. You can also check out our working example apps <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -3572,7 +3566,7 @@ zapier env:get 1.0.0
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>If you need to process all HTTP requests in a certain way, you may be able to use one of utility HTTP middleware functions.</p><blockquote>
-<p>Example App: check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware">https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware</a> for a working example app using HTTP middleware.</p>
+<p>Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware">https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware</a> for a working example app using HTTP middleware.</p>
 </blockquote><p>Try putting them in your app definition:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -4054,7 +4048,7 @@ z.console.log(url);
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Example App: check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">https://github.com/zapier/zapier-platform/tree/master/example-apps/files</a> for a working example app using files.</p>
+<p>To create a new integration for handling files, run <code>zapier init [your app name]</code> and select &quot;files&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4902,7 +4896,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>There are a lot of details left out - check out the full example app for a working setup.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">https://github.com/zapier/zapier-platform/tree/master/example-apps/babel</a> for a working example app using Babel.</p>
+<p>To create a new integration with Babel, run <code>zapier init [your app name]</code> and select &quot;babel&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1814,7 +1814,9 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>You can find more details on the definition for each by looking at the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema">Trigger Schema</a>,
 <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema">Search Schema</a>, and <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema">Create Schema</a>.</p><blockquote>
-<p>To create a new integration with a premade trigger, search, or create, run <code>zapier init [your app name]</code> and select from the list that appears. You can also check out our working example apps <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">here</a>.</p>
+<p>To create a new integration with a premade trigger, search, or create, run <code>zapier init [your app name]</code> and select from the list that appears. You can also check out our working example apps <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">here</a>. </p>
+</blockquote><blockquote>
+<p>To add a trigger, search, or create to an existing integration, run <code>zapier scaffold [trigger|search|create] [noun]</code> to create the necessary files to your project. For example, <code>zapier scaffold trigger post</code> will create a new trigger called &quot;New Post&quot;.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -509,8 +509,9 @@ The definition for each of these follows the same structure. Here is an example 
 You can find more details on the definition for each by looking at the [Trigger Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema),
 [Search Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema), and [Create Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema).
 
-> To create a new integration with a premade trigger, search, or create, run `zapier init [your app name]` and select from the list that appears. You can also check out our working example apps [here](https://github.com/zapier/zapier-platform/tree/master/example-apps).
+> To create a new integration with a premade trigger, search, or create, run `zapier init [your app name]` and select from the list that appears. You can also check out our working example apps [here](https://github.com/zapier/zapier-platform/tree/master/example-apps). 
 
+> To add a trigger, search, or create to an existing integration, run `zapier scaffold [trigger|search|create] [noun]` to create the necessary files to your project. For example, `zapier scaffold trigger post` will create a new trigger called "New Post".
 ### Return Types
 
 Each of the 3 types of function expects a certain type of object. As of core v1.0.11, there are automated checks to let you know when you're trying to pass the wrong type back. For reference, each expects:

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -106,7 +106,7 @@ cd example-app
 npm install
 ```
 
-> Note: there are plenty of templates & example apps to choose from! [View all Example Apps here.](#example-apps).
+> Note: When you run `zapier init`, you'll be presented with a list of templates to start with. Pick the one that matches a feature you'll need (such as "dynamic-dropdown" for an integration with [dynamic dropdown fields](#dynamic-dropdowns)), or select "minimal" for an integration with only the essentials. [View more example apps here](https://github.com/zapier/zapier-platform/tree/master/example-apps).
 
 You should now have a working local app. You can run several local commands to try it out.
 
@@ -309,7 +309,7 @@ When a user authenticates to your application through Zapier, a "connection" is 
 
 Useful if your app requires two pieces of information to authenticate: `username` and `password`, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth for a working example app for basic auth.
+> To create a new integration with basic authentication, run `zapier init [your app name]` and select "basic-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth).
 
 If your app uses Basic auth with an encoded API key rather than a username and password, like `Authorization: Basic APIKEYHERE:x`, consider the [Custom](#custom) authentication method instead.
 
@@ -323,7 +323,7 @@ If your app uses Basic auth with an encoded API key rather than a username and p
 
 The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth for a working example app for digest auth.
+> To create a new integration with digest authentication, run `zapier init [your app name]` and select "digest-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth).
 
 > Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every `z.request` call, Zapier will send an additional request beforehand to get the server nonce.
 
@@ -335,7 +335,7 @@ The setup and user experience of Digest Auth is identical to Basic Auth. Users p
 
 Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth for a working example app for custom auth.
+> To create a new integration with custom authentication, run `zapier init [your app name]` and select "custom-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
 
 ```js
 [insert-file:./snippets/custom-auth.js]
@@ -345,7 +345,7 @@ Custom auth is most commonly used for apps that authenticate with API keys, alth
 
 Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth for a working example app for session auth.
+> To create a new integration with session authentication, run `zapier init [your app name]` and select "session-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth).
 
 ```js
 [insert-file:./snippets/session-auth.js]
@@ -359,7 +359,7 @@ For Session auth, the function that fetches the additional authentication data n
 
 Zapier's OAuth1 implementation matches [Twitter](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a) and [Trello](https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth) implementations of the 3-legged OAuth flow.
 
-> Example Apps: Check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
+> To create a new integration with OAuth1, run `zapier init [your app name]` and select "oauth1-trello". You can also check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
 
 The flow works like this:
 
@@ -400,7 +400,7 @@ Also, `authentication.oauth1Config.getAccessToken` has access to the additional 
 
 Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2 for a working example app for OAuth2.
+> To create a new integration with OAuth2, run `zapier init [your app name]` and select "oauth2". You can also check out [our working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2).
 
 If your app's OAuth2 flow uses a different grant type, such as `client_credentials`, try using [Session auth](#session) instead.
 
@@ -465,7 +465,7 @@ This will generate the resource file and add the necessary statements to the `in
 A resource has a few basic properties. The first is the `key`, which allows Zapier to identify the resource on our backend.
 The second is the `noun`, the user-friendly name of the resource that is presented to users throughout the Zapier UI.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/resource for a working example app using resources.
+> Check out [this working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/resource) to see resources in action.
 
 After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
 The complete list of available methods can be found in the [Resource Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#resourceschema).
@@ -509,13 +509,7 @@ The definition for each of these follows the same structure. Here is an example 
 You can find more details on the definition for each by looking at the [Trigger Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema),
 [Search Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema), and [Create Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema).
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/trigger for a working example app using triggers.
-
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/rest-hooks for a working example app using REST hook triggers.
-
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/search for a working example app using searches.
-
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/create for a working example app using creates.
+> To create a new integration with a premade trigger, search, or create, run `zapier init [your app name]` and select from the list that appears. You can also check out our working example apps [here](https://github.com/zapier/zapier-platform/tree/master/example-apps).
 
 ### Return Types
 
@@ -1098,7 +1092,7 @@ To POST or PUT data to your API you can do this:
 
 If you need to process all HTTP requests in a certain way, you may be able to use one of utility HTTP middleware functions.
 
-> Example App: check out https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware for a working example app using HTTP middleware.
+> Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware for a working example app using HTTP middleware.
 
 Try putting them in your app definition:
 
@@ -1358,7 +1352,7 @@ See a full example with dehydration/hydration wired in correctly:
 [insert-file:./snippets/stash-file.js]
 ```
 
-> Example App: check out https://github.com/zapier/zapier-platform/tree/master/example-apps/files for a working example app using files.
+> To create a new integration for handling files, run `zapier init [your app name]` and select "files". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/files).
 
 
 ## Logging
@@ -1789,7 +1783,7 @@ zapier push
 
 There are a lot of details left out - check out the full example app for a working setup.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/babel for a working example app using Babel.
+> To create a new integration with Babel, run `zapier init [your app name]` and select "babel". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/babel).
 
 ## FAQs
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -309,7 +309,7 @@ When a user authenticates to your application through Zapier, a "connection" is 
 
 Useful if your app requires two pieces of information to authenticate: `username` and `password`, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).
 
-> To create a new integration with basic authentication, run `zapier init [your app name]` and select "basic-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth).
+> To create a new integration with basic authentication, run `zapier init [your app name] --template basic-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth).
 
 If your app uses Basic auth with an encoded API key rather than a username and password, like `Authorization: Basic APIKEYHERE:x`, consider the [Custom](#custom) authentication method instead.
 
@@ -323,7 +323,7 @@ If your app uses Basic auth with an encoded API key rather than a username and p
 
 The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.
 
-> To create a new integration with digest authentication, run `zapier init [your app name]` and select "digest-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth).
+> To create a new integration with digest authentication, run `zapier init [your app name] --template digest-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth).
 
 > Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every `z.request` call, Zapier will send an additional request beforehand to get the server nonce.
 
@@ -335,7 +335,7 @@ The setup and user experience of Digest Auth is identical to Basic Auth. Users p
 
 Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
-> To create a new integration with custom authentication, run `zapier init [your app name]` and select "custom-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
+> To create a new integration with custom authentication, run `zapier init [your app name] --custom-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
 
 ```js
 [insert-file:./snippets/custom-auth.js]
@@ -345,7 +345,7 @@ Custom auth is most commonly used for apps that authenticate with API keys, alth
 
 Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.
 
-> To create a new integration with session authentication, run `zapier init [your app name]` and select "session-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth).
+> To create a new integration with session authentication, run `zapier init [your app name] --template session-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth).
 
 ```js
 [insert-file:./snippets/session-auth.js]
@@ -359,7 +359,7 @@ For Session auth, the function that fetches the additional authentication data n
 
 Zapier's OAuth1 implementation matches [Twitter](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a) and [Trello](https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth) implementations of the 3-legged OAuth flow.
 
-> To create a new integration with OAuth1, run `zapier init [your app name]` and select "oauth1-trello". You can also check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
+> To create a new integration with OAuth1, run `zapier init [your app name] --template oauth1-trello`. You can also check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
 
 The flow works like this:
 
@@ -400,7 +400,7 @@ Also, `authentication.oauth1Config.getAccessToken` has access to the additional 
 
 Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
-> To create a new integration with OAuth2, run `zapier init [your app name]` and select "oauth2". You can also check out [our working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2).
+> To create a new integration with OAuth2, run `zapier init [your app name] --template oauth2`. You can also check out [our working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2).
 
 If your app's OAuth2 flow uses a different grant type, such as `client_credentials`, try using [Session auth](#session) instead.
 
@@ -1353,7 +1353,7 @@ See a full example with dehydration/hydration wired in correctly:
 [insert-file:./snippets/stash-file.js]
 ```
 
-> To create a new integration for handling files, run `zapier init [your app name]` and select "files". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/files).
+> To create a new integration for handling files, run `zapier init [your app name] --template files`. You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/files).
 
 
 ## Logging
@@ -1784,7 +1784,7 @@ zapier push
 
 There are a lot of details left out - check out the full example app for a working setup.
 
-> To create a new integration with Babel, run `zapier init [your app name]` and select "babel". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/babel).
+> To create a new integration with Babel, run `zapier init [your app name] --template babel`. You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/babel).
 
 ## FAQs
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -450,7 +450,7 @@ When a user authenticates to your application through Zapier, a "connection" is 
 
 Useful if your app requires two pieces of information to authenticate: `username` and `password`, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).
 
-> To create a new integration with basic authentication, run `zapier init [your app name]` and select "basic-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth).
+> To create a new integration with basic authentication, run `zapier init [your app name] --template basic-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth).
 
 If your app uses Basic auth with an encoded API key rather than a username and password, like `Authorization: Basic APIKEYHERE:x`, consider the [Custom](#custom) authentication method instead.
 
@@ -479,7 +479,7 @@ const App = {
 
 The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.
 
-> To create a new integration with digest authentication, run `zapier init [your app name]` and select "digest-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth).
+> To create a new integration with digest authentication, run `zapier init [your app name] --template digest-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth).
 
 > Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every `z.request` call, Zapier will send an additional request beforehand to get the server nonce.
 
@@ -512,7 +512,7 @@ const App = {
 
 Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
-> To create a new integration with custom authentication, run `zapier init [your app name]` and select "custom-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
+> To create a new integration with custom authentication, run `zapier init [your app name] --custom-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
 
 ```js
 const authentication = {
@@ -560,7 +560,7 @@ const App = {
 
 Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.
 
-> To create a new integration with session authentication, run `zapier init [your app name]` and select "session-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth).
+> To create a new integration with session authentication, run `zapier init [your app name] --template session-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth).
 
 ```js
 const getSessionKey = async (z, bundle) => {
@@ -636,7 +636,7 @@ For Session auth, the function that fetches the additional authentication data n
 
 Zapier's OAuth1 implementation matches [Twitter](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a) and [Trello](https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth) implementations of the 3-legged OAuth flow.
 
-> To create a new integration with OAuth1, run `zapier init [your app name]` and select "oauth1-trello". You can also check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
+> To create a new integration with OAuth1, run `zapier init [your app name] --template oauth1-trello`. You can also check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
 
 The flow works like this:
 
@@ -756,7 +756,7 @@ Also, `authentication.oauth1Config.getAccessToken` has access to the additional 
 
 Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
-> To create a new integration with OAuth2, run `zapier init [your app name]` and select "oauth2". You can also check out [our working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2).
+> To create a new integration with OAuth2, run `zapier init [your app name] --template oauth2`. You can also check out [our working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2).
 
 If your app's OAuth2 flow uses a different grant type, such as `client_credentials`, try using [Session auth](#session) instead.
 
@@ -2501,7 +2501,7 @@ module.exports = App;
 
 ```
 
-> To create a new integration for handling files, run `zapier init [your app name]` and select "files". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/files).
+> To create a new integration for handling files, run `zapier init [your app name] --template files`. You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/files).
 
 
 ## Logging
@@ -3048,7 +3048,7 @@ zapier push
 
 There are a lot of details left out - check out the full example app for a working setup.
 
-> To create a new integration with Babel, run `zapier init [your app name]` and select "babel". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/babel).
+> To create a new integration with Babel, run `zapier init [your app name] --template babel`. You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/babel).
 
 ## FAQs
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1004,8 +1004,9 @@ const App = {
 You can find more details on the definition for each by looking at the [Trigger Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema),
 [Search Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema), and [Create Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema).
 
-> To create a new integration with a premade trigger, search, or create, run `zapier init [your app name]` and select from the list that appears. You can also check out our working example apps [here](https://github.com/zapier/zapier-platform/tree/master/example-apps).
+> To create a new integration with a premade trigger, search, or create, run `zapier init [your app name]` and select from the list that appears. You can also check out our working example apps [here](https://github.com/zapier/zapier-platform/tree/master/example-apps). 
 
+> To add a trigger, search, or create to an existing integration, run `zapier scaffold [trigger|search|create] [noun]` to create the necessary files to your project. For example, `zapier scaffold trigger post` will create a new trigger called "New Post".
 ### Return Types
 
 Each of the 3 types of function expects a certain type of object. As of core v1.0.11, there are automated checks to let you know when you're trying to pass the wrong type back. For reference, each expects:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -221,7 +221,7 @@ cd example-app
 npm install
 ```
 
-> Note: there are plenty of templates & example apps to choose from! [View all Example Apps here.](#example-apps).
+> Note: When you run `zapier init`, you'll be presented with a list of templates to start with. Pick the one that matches a feature you'll need (such as "dynamic-dropdown" for an integration with [dynamic dropdown fields](#dynamic-dropdowns)), or select "minimal" for an integration with only the essentials. [View more example apps here](https://github.com/zapier/zapier-platform/tree/master/example-apps).
 
 You should now have a working local app. You can run several local commands to try it out.
 
@@ -450,7 +450,7 @@ When a user authenticates to your application through Zapier, a "connection" is 
 
 Useful if your app requires two pieces of information to authenticate: `username` and `password`, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth for a working example app for basic auth.
+> To create a new integration with basic authentication, run `zapier init [your app name]` and select "basic-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth).
 
 If your app uses Basic auth with an encoded API key rather than a username and password, like `Authorization: Basic APIKEYHERE:x`, consider the [Custom](#custom) authentication method instead.
 
@@ -479,7 +479,7 @@ const App = {
 
 The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth for a working example app for digest auth.
+> To create a new integration with digest authentication, run `zapier init [your app name]` and select "digest-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth).
 
 > Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every `z.request` call, Zapier will send an additional request beforehand to get the server nonce.
 
@@ -512,7 +512,7 @@ const App = {
 
 Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth for a working example app for custom auth.
+> To create a new integration with custom authentication, run `zapier init [your app name]` and select "custom-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
 
 ```js
 const authentication = {
@@ -560,7 +560,7 @@ const App = {
 
 Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth for a working example app for session auth.
+> To create a new integration with session authentication, run `zapier init [your app name]` and select "session-auth" from the list that appears. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth).
 
 ```js
 const getSessionKey = async (z, bundle) => {
@@ -636,7 +636,7 @@ For Session auth, the function that fetches the additional authentication data n
 
 Zapier's OAuth1 implementation matches [Twitter](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a) and [Trello](https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth) implementations of the 3-legged OAuth flow.
 
-> Example Apps: Check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
+> To create a new integration with OAuth1, run `zapier init [your app name]` and select "oauth1-trello". You can also check out [oauth1-trello](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello), [oauth1-tumblr](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr), and [oauth1-twitter](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter) for working example apps with OAuth1.
 
 The flow works like this:
 
@@ -756,7 +756,7 @@ Also, `authentication.oauth1Config.getAccessToken` has access to the additional 
 
 Zapier's OAuth2 implementation is based on the `authorization_code` flow, similar to [GitHub](https://developer.github.com/v3/oauth/) and [Facebook](https://developers.facebook.com/docs/authentication/server-side/).
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2 for a working example app for OAuth2.
+> To create a new integration with OAuth2, run `zapier init [your app name]` and select "oauth2". You can also check out [our working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2).
 
 If your app's OAuth2 flow uses a different grant type, such as `client_credentials`, try using [Session auth](#session) instead.
 
@@ -899,7 +899,7 @@ This will generate the resource file and add the necessary statements to the `in
 A resource has a few basic properties. The first is the `key`, which allows Zapier to identify the resource on our backend.
 The second is the `noun`, the user-friendly name of the resource that is presented to users throughout the Zapier UI.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/resource for a working example app using resources.
+> Check out [this working example app](https://github.com/zapier/zapier-platform/tree/master/example-apps/resource) to see resources in action.
 
 After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
 The complete list of available methods can be found in the [Resource Schema Docs](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#resourceschema).
@@ -1004,13 +1004,7 @@ const App = {
 You can find more details on the definition for each by looking at the [Trigger Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema),
 [Search Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema), and [Create Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema).
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/trigger for a working example app using triggers.
-
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/rest-hooks for a working example app using REST hook triggers.
-
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/search for a working example app using searches.
-
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/create for a working example app using creates.
+> To create a new integration with a premade trigger, search, or create, run `zapier init [your app name]` and select from the list that appears. You can also check out our working example apps [here](https://github.com/zapier/zapier-platform/tree/master/example-apps).
 
 ### Return Types
 
@@ -2119,7 +2113,7 @@ const App = {
 
 If you need to process all HTTP requests in a certain way, you may be able to use one of utility HTTP middleware functions.
 
-> Example App: check out https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware for a working example app using HTTP middleware.
+> Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware for a working example app using HTTP middleware.
 
 Try putting them in your app definition:
 
@@ -2506,7 +2500,7 @@ module.exports = App;
 
 ```
 
-> Example App: check out https://github.com/zapier/zapier-platform/tree/master/example-apps/files for a working example app using files.
+> To create a new integration for handling files, run `zapier init [your app name]` and select "files". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/files).
 
 
 ## Logging
@@ -3053,7 +3047,7 @@ zapier push
 
 There are a lot of details left out - check out the full example app for a working setup.
 
-> Example App: Check out https://github.com/zapier/zapier-platform/tree/master/example-apps/babel for a working example app using Babel.
+> To create a new integration with Babel, run `zapier init [your app name]` and select "babel". You can also check out our working example app [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/babel).
 
 ## FAQs
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1156,7 +1156,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Useful if your app requires two pieces of information to authenticate: <code>username</code> and <code>password</code>, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).</p><blockquote>
-<p>To create a new integration with basic authentication, run <code>zapier init [your app name]</code> and select &quot;basic-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">here</a>.</p>
+<p>To create a new integration with basic authentication, run <code>zapier init [your app name] --template basic-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">here</a>.</p>
 </blockquote><p>If your app uses Basic auth with an encoded API key rather than a username and password, like <code>Authorization: Basic APIKEYHERE:x</code>, consider the <a href="#custom">Custom</a> authentication method instead.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1192,7 +1192,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.</p><blockquote>
-<p>To create a new integration with digest authentication, run <code>zapier init [your app name]</code> and select &quot;digest-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">here</a>.</p>
+<p>To create a new integration with digest authentication, run <code>zapier init [your app name] --template digest-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">here</a>.</p>
 </blockquote><blockquote>
 <p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will send an additional request beforehand to get the server nonce.</p>
 </blockquote>
@@ -1236,7 +1236,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
-<p>To create a new integration with custom authentication, run <code>zapier init [your app name]</code> and select &quot;custom-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
+<p>To create a new integration with custom authentication, run <code>zapier init [your app name] --custom-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1295,7 +1295,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.</p><blockquote>
-<p>To create a new integration with session authentication, run <code>zapier init [your app name]</code> and select &quot;session-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">here</a>.</p>
+<p>To create a new integration with session authentication, run <code>zapier init [your app name] --template session-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1387,7 +1387,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a">Twitter</a> and <a href="https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth">Trello</a> implementations of the 3-legged OAuth flow.</p><blockquote>
-<p>To create a new integration with OAuth1, run <code>zapier init [your app name]</code> and select &quot;oauth1-trello&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
+<p>To create a new integration with OAuth1, run <code>zapier init [your app name] --template oauth1-trello</code>. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
 </blockquote><p>The flow works like this:</p><ol>
 <li>Zapier makes a call to your API requesting a &quot;request token&quot; (also known as &quot;temporary credentials&quot;).</li>
 <li>Zapier sends the user to the authorization URL, defined by your app, along with the request token.</li>
@@ -1521,7 +1521,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Zapier&apos;s OAuth2 implementation is based on the <code>authorization_code</code> flow, similar to <a href="https://developer.github.com/v3/oauth/">GitHub</a> and <a href="https://developers.facebook.com/docs/authentication/server-side/">Facebook</a>.</p><blockquote>
-<p>To create a new integration with OAuth2, run <code>zapier init [your app name]</code> and select &quot;oauth2&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">our working example app</a>.</p>
+<p>To create a new integration with OAuth2, run <code>zapier init [your app name] --template oauth2</code>. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">our working example app</a>.</p>
 </blockquote><p>If your app&apos;s OAuth2 flow uses a different grant type, such as <code>client_credentials</code>, try using <a href="#session">Session auth</a> instead.</p><p>The OAuth2 flow looks like this:</p><ol>
 <li>Zapier sends the user to the authorization URL defined by your app.</li>
 <li>Once authorized, your website sends the user to the <code>redirect_uri</code> Zapier provided. Use the <code>zapier describe</code> command to find out what it is: <img src="https://zappy.zapier.com/83E12494-0A03-4DB4-AA46-5A2AF6A9ECCC.png" alt></li>
@@ -4050,7 +4050,7 @@ z.console.log(url);
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>To create a new integration for handling files, run <code>zapier init [your app name]</code> and select &quot;files&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">here</a>.</p>
+<p>To create a new integration for handling files, run <code>zapier init [your app name] --template files</code>. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4898,7 +4898,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>There are a lot of details left out - check out the full example app for a working setup.</p><blockquote>
-<p>To create a new integration with Babel, run <code>zapier init [your app name]</code> and select &quot;babel&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">here</a>.</p>
+<p>To create a new integration with Babel, run <code>zapier init [your app name] --template babel</code>. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -744,7 +744,7 @@ npm install
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Note: there are plenty of templates &amp; example apps to choose from! <a href="#example-apps">View all Example Apps here.</a>.</p>
+<p>Note: When you run <code>zapier init</code>, you&apos;ll be presented with a list of templates to start with. Pick the one that matches a feature you&apos;ll need (such as &quot;dynamic-dropdown&quot; for an integration with <a href="#dynamic-dropdowns">dynamic dropdown fields</a>), or select &quot;minimal&quot; for an integration with only the essentials. <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">View more example apps here</a>.</p>
 </blockquote><p>You should now have a working local app. You can run several local commands to try it out.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1156,7 +1156,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Useful if your app requires two pieces of information to authenticate: <code>username</code> and <code>password</code>, which only the end user can provide. By default, Zapier will do the standard Basic authentication base64 header encoding for you (via an automatically registered middleware).</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth</a> for a working example app for basic auth.</p>
+<p>To create a new integration with basic authentication, run <code>zapier init [your app name]</code> and select &quot;basic-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/basic-auth">here</a>.</p>
 </blockquote><p>If your app uses Basic auth with an encoded API key rather than a username and password, like <code>Authorization: Basic APIKEYHERE:x</code>, consider the <a href="#custom">Custom</a> authentication method instead.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1192,7 +1192,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in v7.4.0.</em></p><p>The setup and user experience of Digest Auth is identical to Basic Auth. Users provide Zapier their username and password, and Zapier handles all the nonce and quality of protection details automatically.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth</a> for a working example app for digest auth.</p>
+<p>To create a new integration with digest authentication, run <code>zapier init [your app name]</code> and select &quot;digest-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/digest-auth">here</a>.</p>
 </blockquote><blockquote>
 <p>Limitation: Currently, MD5-sess and SHA are not implemented. Only the MD5 algorithm is supported. In addition, server nonces are not reused. That means for every <code>z.request</code> call, Zapier will send an additional request beforehand to get the server nonce.</p>
 </blockquote>
@@ -1236,7 +1236,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth</a> for a working example app for custom auth.</p>
+<p>To create a new integration with custom authentication, run <code>zapier init [your app name]</code> and select &quot;custom-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1295,7 +1295,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Session auth gives you the ability to exchange some user-provided data for some authentication data; for example, username and password for a session key. It can be used to implement almost any authentication method that uses that pattern - for example, alternative OAuth flows.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth</a> for a working example app for session auth.</p>
+<p>To create a new integration with session authentication, run <code>zapier init [your app name]</code> and select &quot;session-auth&quot; from the list that appears. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/session-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1387,7 +1387,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p><em>New in <code>v7.5.0</code>.</em></p><p>Zapier&apos;s OAuth1 implementation matches <a href="https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a">Twitter</a> and <a href="https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/#using-basic-oauth">Trello</a> implementations of the 3-legged OAuth flow.</p><blockquote>
-<p>Example Apps: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
+<p>To create a new integration with OAuth1, run <code>zapier init [your app name]</code> and select &quot;oauth1-trello&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-trello">oauth1-trello</a>, <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-tumblr">oauth1-tumblr</a>, and <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth1-twitter">oauth1-twitter</a> for working example apps with OAuth1.</p>
 </blockquote><p>The flow works like this:</p><ol>
 <li>Zapier makes a call to your API requesting a &quot;request token&quot; (also known as &quot;temporary credentials&quot;).</li>
 <li>Zapier sends the user to the authorization URL, defined by your app, along with the request token.</li>
@@ -1521,7 +1521,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Zapier&apos;s OAuth2 implementation is based on the <code>authorization_code</code> flow, similar to <a href="https://developer.github.com/v3/oauth/">GitHub</a> and <a href="https://developers.facebook.com/docs/authentication/server-side/">Facebook</a>.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2</a> for a working example app for OAuth2.</p>
+<p>To create a new integration with OAuth2, run <code>zapier init [your app name]</code> and select &quot;oauth2&quot;. You can also check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/oauth2">our working example app</a>.</p>
 </blockquote><p>If your app&apos;s OAuth2 flow uses a different grant type, such as <code>client_credentials</code>, try using <a href="#session">Session auth</a> instead.</p><p>The OAuth2 flow looks like this:</p><ol>
 <li>Zapier sends the user to the authorization URL defined by your app.</li>
 <li>Once authorized, your website sends the user to the <code>redirect_uri</code> Zapier provided. Use the <code>zapier describe</code> command to find out what it is: <img src="https://zappy.zapier.com/83E12494-0A03-4DB4-AA46-5A2AF6A9ECCC.png" alt></li>
@@ -1694,7 +1694,7 @@ read, and search operations on that resource.</p>
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>A resource has a few basic properties. The first is the <code>key</code>, which allows Zapier to identify the resource on our backend.
 The second is the <code>noun</code>, the user-friendly name of the resource that is presented to users throughout the Zapier UI.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/resource">https://github.com/zapier/zapier-platform/tree/master/example-apps/resource</a> for a working example app using resources.</p>
+<p>Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/resource">this working example app</a> to see resources in action.</p>
 </blockquote><p>After those, there is a set of optional properties that tell Zapier what methods can be performed on the resource.
 The complete list of available methods can be found in the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#resourceschema">Resource Schema Docs</a>.
 For now, let&apos;s focus on two:</p><ul>
@@ -1814,13 +1814,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>You can find more details on the definition for each by looking at the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema">Trigger Schema</a>,
 <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema">Search Schema</a>, and <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema">Create Schema</a>.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/trigger">https://github.com/zapier/zapier-platform/tree/master/example-apps/trigger</a> for a working example app using triggers.</p>
-</blockquote><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/rest-hooks">https://github.com/zapier/zapier-platform/tree/master/example-apps/rest-hooks</a> for a working example app using REST hook triggers.</p>
-</blockquote><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/search">https://github.com/zapier/zapier-platform/tree/master/example-apps/search</a> for a working example app using searches.</p>
-</blockquote><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/create">https://github.com/zapier/zapier-platform/tree/master/example-apps/create</a> for a working example app using creates.</p>
+<p>To create a new integration with a premade trigger, search, or create, run <code>zapier init [your app name]</code> and select from the list that appears. You can also check out our working example apps <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -3572,7 +3566,7 @@ zapier env:get 1.0.0
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>If you need to process all HTTP requests in a certain way, you may be able to use one of utility HTTP middleware functions.</p><blockquote>
-<p>Example App: check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware">https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware</a> for a working example app using HTTP middleware.</p>
+<p>Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware">https://github.com/zapier/zapier-platform/tree/master/example-apps/middleware</a> for a working example app using HTTP middleware.</p>
 </blockquote><p>Try putting them in your app definition:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -4054,7 +4048,7 @@ z.console.log(url);
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Example App: check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">https://github.com/zapier/zapier-platform/tree/master/example-apps/files</a> for a working example app using files.</p>
+<p>To create a new integration for handling files, run <code>zapier init [your app name]</code> and select &quot;files&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/files">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -4902,7 +4896,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>There are a lot of details left out - check out the full example app for a working setup.</p><blockquote>
-<p>Example App: Check out <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">https://github.com/zapier/zapier-platform/tree/master/example-apps/babel</a> for a working example app using Babel.</p>
+<p>To create a new integration with Babel, run <code>zapier init [your app name]</code> and select &quot;babel&quot;. You can also check out our working example app <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/babel">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1814,7 +1814,9 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>You can find more details on the definition for each by looking at the <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#triggerschema">Trigger Schema</a>,
 <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#searchschema">Search Schema</a>, and <a href="https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#createschema">Create Schema</a>.</p><blockquote>
-<p>To create a new integration with a premade trigger, search, or create, run <code>zapier init [your app name]</code> and select from the list that appears. You can also check out our working example apps <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">here</a>.</p>
+<p>To create a new integration with a premade trigger, search, or create, run <code>zapier init [your app name]</code> and select from the list that appears. You can also check out our working example apps <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps">here</a>. </p>
+</blockquote><blockquote>
+<p>To add a trigger, search, or create to an existing integration, run <code>zapier scaffold [trigger|search|create] [noun]</code> to create the necessary files to your project. For example, <code>zapier scaffold trigger post</code> will create a new trigger called &quot;New Post&quot;.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">


### PR DESCRIPTION
Part of _Improve Dev Platform Docs_ for HackWeek 2022 Q1

As the example-apps folder is primarily used for older CLI versions now, we should update the links to point users towards using `zapier init` to build new projects as the first suggestion, with links to example-apps only as reference.