### PR TITLE
PDE-3149 Added SSO sign on instructions

### DIFF
--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -92,6 +92,7 @@ npm install -g zapier-platform-cli
 # setup auth to Zapier's platform with a deploy key
 zapier login
 ```
+> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer accont here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
 
 Your Zapier CLI should be installed and ready to go at this point. Next up, we'll create our first app!
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -207,6 +207,7 @@ npm install -g zapier-platform-cli
 # setup auth to Zapier's platform with a deploy key
 zapier login
 ```
+> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer accont here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
 
 Your Zapier CLI should be installed and ready to go at this point. Next up, we'll create our first app!
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -726,7 +726,9 @@ zapier login
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Your Zapier CLI should be installed and ready to go at this point. Next up, we&apos;ll create our first app!</p>
+      <blockquote>
+<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer accont here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
+</blockquote><p>Your Zapier CLI should be installed and ready to go at this point. Next up, we&apos;ll create our first app!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># create a directory with the minimum required files</span>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This PR updates the Getting Started section of the CLI docs here: https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#quick-setup-guide

![](https://cdn.zappy.app/36397d76c7bfcc8af364bf5837497917.png)

At the moment, it's not clear on how you would login to Zapier through the CLI platform if your Zapier account was created using SSO. 

The terminal will give you steps on how to login via SSO:

![](https://cdn.zappy.app/9a8bd2737099d7337d789747634999e8.png)

However, reviewing Zendesk, I did find a handful of tickets where developers wrote in having issues searching "CLI SSO". This is one example: https://zapier.zendesk.com/agent/tickets/62778

And this more recent one: https://zapier.zendesk.com/agent/tickets/587189

I worked with Sydney on the paid support team to get this Look: https://zapier.looker.com/looks/5957

And found that ~58k developers use SSO.

I think that by bringing the SSO information upfront in our docs, we can help reduce a few obstacles for new developers. 