### PR TITLE
PDE-3152 feat(cli) - Update `team:get` CLI command to fetch Collaborator.

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -983,8 +983,10 @@ a code {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Get team members involved with your integration.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in two levels:</p><ul>
+</blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in three levels:</p><ul>
 <li><p><code>admin</code>, who can edit everything about the integration</p>
+</li>
+<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
 <li><p><code>collaborator</code>, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -986,7 +986,7 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in two levels:</p><ul>
 <li><p><code>admin</code>, who can edit everything about the integration</p>
 </li>
-<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health socores and more.</p>
+<li><p><code>collaborator</code>, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
 </ul><p>Use the <code>zapier team:add</code> and <code>zapier team:remove</code> commands to modify your team.</p><p><strong>Flags</strong></p><ul>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as jq. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -986,9 +986,9 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in three levels:</p><ul>
 <li><p><code>admin</code>, who can edit everything about the integration</p>
 </li>
-<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
+<li><p><code>collaborator</code>, who has read-only access for the app, and will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
-<li><p><code>collaborator</code>, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
+<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
 </ul><p>Use the <code>zapier team:add</code> and <code>zapier team:remove</code> commands to modify your team.</p><p><strong>Flags</strong></p><ul>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as jq. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -512,7 +512,7 @@ These users come in two levels:
 
   * `admin`, who can edit everything about the integration
 
-  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health socores and more.
+  * `collaborator`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the `zapier team:add` and `zapier team:remove` commands to modify your team.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -512,9 +512,9 @@ These users come in three levels:
 
   * `admin`, who can edit everything about the integration
 
-  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
+  * `collaborator`, who has read-only access for the app, and will receive periodic email updates. These updates include quarterly health scores and more.
 
-  * `collaborator`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
+  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the `zapier team:add` and `zapier team:remove` commands to modify your team.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -508,9 +508,11 @@ Team members can be freely added and removed.
 
 **Usage**: `zapier team:get`
 
-These users come in two levels:
+These users come in three levels:
 
   * `admin`, who can edit everything about the integration
+
+  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
   * `collaborator`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -983,8 +983,10 @@ a code {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Get team members involved with your integration.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in two levels:</p><ul>
+</blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in three levels:</p><ul>
 <li><p><code>admin</code>, who can edit everything about the integration</p>
+</li>
+<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
 <li><p><code>collaborator</code>, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -986,7 +986,7 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in two levels:</p><ul>
 <li><p><code>admin</code>, who can edit everything about the integration</p>
 </li>
-<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health socores and more.</p>
+<li><p><code>collaborator</code>, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
 </ul><p>Use the <code>zapier team:add</code> and <code>zapier team:remove</code> commands to modify your team.</p><p><strong>Flags</strong></p><ul>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as jq. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -986,9 +986,9 @@ a code {
 </blockquote><p><strong>Usage</strong>: <code>zapier team:get</code></p><p>These users come in three levels:</p><ul>
 <li><p><code>admin</code>, who can edit everything about the integration</p>
 </li>
-<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
+<li><p><code>collaborator</code>, who has read-only access for the app, and will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
-<li><p><code>collaborator</code>, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
+<li><p><code>subscriber</code>, who can&apos;t directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.</p>
 </li>
 </ul><p>Use the <code>zapier team:add</code> and <code>zapier team:remove</code> commands to modify your team.</p><p><strong>Flags</strong></p><ul>
 <li><code>-f, --format</code> | Change the way structured data is presented. If &quot;json&quot; or &quot;raw&quot;, you can pipe the output of the command into other tools, such as jq. One of <code>[plain | json | raw | row | table]</code>. Defaults to <code>table</code>.</li>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -512,7 +512,7 @@ These users come in two levels:
 
   * `admin`, who can edit everything about the integration
 
-  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health socores and more.
+  * `collaborator`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the `zapier team:add` and `zapier team:remove` commands to modify your team.
 

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -512,9 +512,9 @@ These users come in three levels:
 
   * `admin`, who can edit everything about the integration
 
-  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
+  * `collaborator`, who has read-only access for the app, and will receive periodic email updates. These updates include quarterly health scores and more.
 
-  * `collaborator`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
+  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the `zapier team:add` and `zapier team:remove` commands to modify your team.
 

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -508,9 +508,11 @@ Team members can be freely added and removed.
 
 **Usage**: `zapier team:get`
 
-These users come in two levels:
+These users come in three levels:
 
   * `admin`, who can edit everything about the integration
+
+  * `subscriber`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
   * `collaborator`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 

--- a/packages/cli/src/oclif/commands/team/get.js
+++ b/packages/cli/src/oclif/commands/team/get.js
@@ -2,27 +2,22 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 const { cyan } = require('colors/safe');
 const { listEndpointMulti } = require('../../../utils/api');
 const { buildFlags } = require('../../buildFlags');
-const { BASE_ENDPOINT } = require('../../../constants');
 
 class TeamListCommand extends ZapierBaseCommand {
   async perform() {
     this.startSpinner('Loading team members');
-    const { admins, subscribers } = await listEndpointMulti(
+    const { admins, limitedCollaborators } = await listEndpointMulti(
       { endpoint: 'collaborators', keyOverride: 'admins' },
-      {
-        endpoint: (app) =>
-          `${BASE_ENDPOINT}/api/platform/v3/integrations/${app.id}/subscribers`,
-        keyOverride: 'subscribers',
-      }
+      { endpoint: 'limited_collaborators', keyOverride: 'limitedCollaborators' }
     );
 
     this.stopSpinner();
 
-    const cleanedUsers = [...admins, ...subscribers].map(
+    const cleanedUsers = [...admins, ...limitedCollaborators].map(
       ({ status, name, role, email }) => ({
         status,
         name,
-        role: role === 'collaborator' ? 'admin' : 'subscriber',
+        role: role === 'collaborator' ? 'admin' : 'collaborator',
         email,
       })
     );
@@ -51,7 +46,7 @@ TeamListCommand.description = `Get team members involved with your integration.
 These users come in two levels:
 
   * \`admin\`, who can edit everything about the integration
-  * \`subscriber\`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health socores and more.
+  * \`collaborator\`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the \`zapier team:add\` and \`zapier team:remove\` commands to modify your team.
 `;

--- a/packages/cli/src/oclif/commands/team/get.js
+++ b/packages/cli/src/oclif/commands/team/get.js
@@ -7,31 +7,37 @@ const { BASE_ENDPOINT } = require('../../../constants');
 class TeamListCommand extends ZapierBaseCommand {
   async perform() {
     this.startSpinner('Loading team members');
-    const { admins, limitedCollaborators } = await listEndpointMulti(
-      { endpoint: 'collaborators', keyOverride: 'admins' },
-      {
-        endpoint: (app) =>
-          `${BASE_ENDPOINT}/api/platform/v3/integrations/${app.id}/subscribers`,
-        keyOverride: 'subscribers',
-      },
-      { endpoint: 'limited_collaborators', keyOverride: 'limitedCollaborators' }
-    );
+    const { admins, subscribers, limitedCollaborators } =
+      await listEndpointMulti(
+        { endpoint: 'collaborators', keyOverride: 'admins' },
+        {
+          endpoint: (app) =>
+            `${BASE_ENDPOINT}/api/platform/v3/integrations/${app.id}/subscribers`,
+          keyOverride: 'subscribers',
+        },
+        {
+          endpoint: 'limited_collaborators',
+          keyOverride: 'limitedCollaborators',
+        }
+      );
 
     this.stopSpinner();
 
-    const cleanedUsers = [...admins, ...limitedCollaborators].map(
-      ({ status, name, role, email }) => ({
-        status,
-        name,
-        role:
-          role === 'collaborator'
-            ? 'admin'
-            : role === 'subscriber'
-            ? 'subscriber'
-            : 'collaborator',
-        email,
-      })
-    );
+    const cleanedUsers = [
+      ...admins,
+      ...subscribers,
+      ...limitedCollaborators,
+    ].map(({ status, name, role, email }) => ({
+      status,
+      name,
+      role:
+        role === 'collaborator'
+          ? 'admin'
+          : role === 'subscriber'
+          ? 'subscriber'
+          : 'collaborator',
+      email,
+    }));
 
     this.logTable({
       rows: cleanedUsers,

--- a/packages/cli/src/oclif/commands/team/get.js
+++ b/packages/cli/src/oclif/commands/team/get.js
@@ -63,8 +63,8 @@ TeamListCommand.description = `Get team members involved with your integration.
 These users come in three levels:
 
   * \`admin\`, who can edit everything about the integration
+  * \`collaborator\`, who has read-only access for the app, and will receive periodic email updates. These updates include quarterly health scores and more.
   * \`subscriber\`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
-  * \`collaborator\`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the \`zapier team:add\` and \`zapier team:remove\` commands to modify your team.
 `;

--- a/packages/cli/src/oclif/commands/team/get.js
+++ b/packages/cli/src/oclif/commands/team/get.js
@@ -2,12 +2,18 @@ const ZapierBaseCommand = require('../../ZapierBaseCommand');
 const { cyan } = require('colors/safe');
 const { listEndpointMulti } = require('../../../utils/api');
 const { buildFlags } = require('../../buildFlags');
+const { BASE_ENDPOINT } = require('../../../constants');
 
 class TeamListCommand extends ZapierBaseCommand {
   async perform() {
     this.startSpinner('Loading team members');
     const { admins, limitedCollaborators } = await listEndpointMulti(
       { endpoint: 'collaborators', keyOverride: 'admins' },
+      {
+        endpoint: (app) =>
+          `${BASE_ENDPOINT}/api/platform/v3/integrations/${app.id}/subscribers`,
+        keyOverride: 'subscribers',
+      },
       { endpoint: 'limited_collaborators', keyOverride: 'limitedCollaborators' }
     );
 
@@ -17,7 +23,12 @@ class TeamListCommand extends ZapierBaseCommand {
       ({ status, name, role, email }) => ({
         status,
         name,
-        role: role === 'collaborator' ? 'admin' : 'collaborator',
+        role:
+          role === 'collaborator'
+            ? 'admin'
+            : role === 'subscriber'
+            ? 'subscriber'
+            : 'collaborator',
         email,
       })
     );
@@ -43,9 +54,10 @@ class TeamListCommand extends ZapierBaseCommand {
 TeamListCommand.flags = buildFlags({ opts: { format: true } });
 TeamListCommand.description = `Get team members involved with your integration.
 
-These users come in two levels:
+These users come in three levels:
 
   * \`admin\`, who can edit everything about the integration
+  * \`subscriber\`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
   * \`collaborator\`, who has read-only access for the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
 Use the \`zapier team:add\` and \`zapier team:remove\` commands to modify your team.


### PR DESCRIPTION
JIRA: https://zapierorg.atlassian.net/browse/PDE-3152

Removes `subscribers` from `team:get` command
Fetches `limited collaborators` for `team:get` command.

![](https://cdn.zappy.app/01ed6ed13b2ea2fda39d0ee11502f233.png)