### PR TITLE
PDE-3153 cli(fix): fix grammar on `team:add`

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -956,7 +956,7 @@ a code {
 </li>
 </ul><p>Team members can be freely added and removed.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>email</code> | The user to be invited. If they don&apos;t have a Zapier account, they&apos;ll be prompted to create one.</li>
-<li>(required) <code>role</code> | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators has read-access to the app and get email updates. Subscribers only get email updates.</li>
+<li>(required) <code>role</code> | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators have read-access to the app and get email updates. Subscribers only get email updates.</li>
 <li><code>message</code> | A message sent in the email to your team member, if you need to provide context. Wrap the message in quotes to ensure spaces get saved.</li>
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -490,7 +490,7 @@ Team members can be freely added and removed.
 
 **Arguments**
 * (required) `email` | The user to be invited. If they don't have a Zapier account, they'll be prompted to create one.
-* (required) `role` | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators has read-access to the app and get email updates. Subscribers only get email updates.
+* (required) `role` | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators have read-access to the app and get email updates. Subscribers only get email updates.
 * `message` | A message sent in the email to your team member, if you need to provide context. Wrap the message in quotes to ensure spaces get saved.
 
 **Flags**

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -956,7 +956,7 @@ a code {
 </li>
 </ul><p>Team members can be freely added and removed.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>email</code> | The user to be invited. If they don&apos;t have a Zapier account, they&apos;ll be prompted to create one.</li>
-<li>(required) <code>role</code> | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators has read-access to the app and get email updates. Subscribers only get email updates.</li>
+<li>(required) <code>role</code> | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators have read-access to the app and get email updates. Subscribers only get email updates.</li>
 <li><code>message</code> | A message sent in the email to your team member, if you need to provide context. Wrap the message in quotes to ensure spaces get saved.</li>
 </ul><p><strong>Flags</strong></p><ul>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -490,7 +490,7 @@ Team members can be freely added and removed.
 
 **Arguments**
 * (required) `email` | The user to be invited. If they don't have a Zapier account, they'll be prompted to create one.
-* (required) `role` | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators has read-access to the app and get email updates. Subscribers only get email updates.
+* (required) `role` | The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators have read-access to the app and get email updates. Subscribers only get email updates.
 * `message` | A message sent in the email to your team member, if you need to provide context. Wrap the message in quotes to ensure spaces get saved.
 
 **Flags**

--- a/packages/cli/src/oclif/commands/team/add.js
+++ b/packages/cli/src/oclif/commands/team/add.js
@@ -56,7 +56,7 @@ TeamAddCommand.args = [
   {
     name: 'role',
     description:
-      'The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators has read-access to the app and get email updates. Subscribers only get email updates.',
+      'The level the invited team member should be at. Admins can edit everything and get email updates. Collaborators have read-access to the app and get email updates. Subscribers only get email updates.',
     options: ['admin', 'collaborator', 'subscriber'],
     required: true,
   },


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes a grammar error (`has -> have`) on `team:add` help text.

Relates to https://github.com/zapier/zapier-platform/pull/539.