### PR TITLE
BREAKING CHANGE (cli) remove WB conversion functionality

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -379,12 +379,12 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Convert a Legacy Web Builder app or Visual Builder integration to a CLI integration.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>If you&apos;re converting a <strong>Legacy Web Builder</strong> app: the new integration will have a dependency named zapier-platform-legacy-scripting-runner, a shim used to simulate behaviors that are specific to Legacy Web Builder. There could be differences on how the shim simulates and how Legacy Web Builder actually behaves on some edge cases, especially you have custom scripting code.</p><p>If you&apos;re converting a <strong>Visual Builder</strong> app, then it will be identical and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
-<li>(required) <code>integrationId</code> | To get the integration/app ID, go to &quot;<a href="https://zapier.com/app/developer&quot;">https://zapier.com/app/developer&quot;</a>, click on an integration, and copy the number directly after &quot;/app/&quot; in the URL.</li>
+<p>Convert a Visual Builder integration to a CLI integration.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>integrationId</code> | To get the integration/app ID, go to &quot;<a href="https://developer.zapier.com//app/developer&quot;">https://developer.zapier.com//app/developer&quot;</a>, click on an integration, and copy the number directly after &quot;/app/&quot; in the URL.</li>
 <li>(required) <code>path</code> | Relative to your current path - IE: <code>.</code> for current directory.</li>
 </ul><p><strong>Flags</strong></p><ul>
-<li><code>-v, --version</code> | Convert a specific version. Required when converting a Visual Builder integration.</li>
+<li>(required) <code>-v, --version</code> | Convert a specific version. Required when converting a Visual Builder integration.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul>
     </div>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -55,24 +55,22 @@ This command is typically followed by `zapier upload`.
 
 ## convert
 
-> Convert a Legacy Web Builder app or Visual Builder integration to a CLI integration.
+> Convert a Visual Builder integration to a CLI integration.
 
 **Usage**: `zapier convert INTEGRATIONID PATH`
 
-If you're converting a **Legacy Web Builder** app: the new integration will have a dependency named zapier-platform-legacy-scripting-runner, a shim used to simulate behaviors that are specific to Legacy Web Builder. There could be differences on how the shim simulates and how Legacy Web Builder actually behaves on some edge cases, especially you have custom scripting code.
-
-If you're converting a **Visual Builder** app, then it will be identical and ready to push and use immediately!
+The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 
 You'll need to do a `zapier push` before the new version is visible in the editor, but otherwise you're good to go.
 
 **Arguments**
-* (required) `integrationId` | To get the integration/app ID, go to "https://zapier.com/app/developer", click on an integration, and copy the number directly after "/app/" in the URL.
+* (required) `integrationId` | To get the integration/app ID, go to "https://developer.zapier.com//app/developer", click on an integration, and copy the number directly after "/app/" in the URL.
 * (required) `path` | Relative to your current path - IE: `.` for current directory.
 
 **Flags**
-* `-v, --version` | Convert a specific version. Required when converting a Visual Builder integration.
+* (required) `-v, --version` | Convert a specific version. Required when converting a Visual Builder integration.
 * `-d, --debug` | Show extra debugging output.
 
 

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -379,12 +379,12 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Convert a Legacy Web Builder app or Visual Builder integration to a CLI integration.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>If you&apos;re converting a <strong>Legacy Web Builder</strong> app: the new integration will have a dependency named zapier-platform-legacy-scripting-runner, a shim used to simulate behaviors that are specific to Legacy Web Builder. There could be differences on how the shim simulates and how Legacy Web Builder actually behaves on some edge cases, especially you have custom scripting code.</p><p>If you&apos;re converting a <strong>Visual Builder</strong> app, then it will be identical and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
-<li>(required) <code>integrationId</code> | To get the integration/app ID, go to &quot;<a href="https://zapier.com/app/developer&quot;">https://zapier.com/app/developer&quot;</a>, click on an integration, and copy the number directly after &quot;/app/&quot; in the URL.</li>
+<p>Convert a Visual Builder integration to a CLI integration.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
+<li>(required) <code>integrationId</code> | To get the integration/app ID, go to &quot;<a href="https://developer.zapier.com//app/developer&quot;">https://developer.zapier.com//app/developer&quot;</a>, click on an integration, and copy the number directly after &quot;/app/&quot; in the URL.</li>
 <li>(required) <code>path</code> | Relative to your current path - IE: <code>.</code> for current directory.</li>
 </ul><p><strong>Flags</strong></p><ul>
-<li><code>-v, --version</code> | Convert a specific version. Required when converting a Visual Builder integration.</li>
+<li>(required) <code>-v, --version</code> | Convert a specific version. Required when converting a Visual Builder integration.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul>
     </div>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -55,24 +55,22 @@ This command is typically followed by `zapier upload`.
 
 ## convert
 
-> Convert a Legacy Web Builder app or Visual Builder integration to a CLI integration.
+> Convert a Visual Builder integration to a CLI integration.
 
 **Usage**: `zapier convert INTEGRATIONID PATH`
 
-If you're converting a **Legacy Web Builder** app: the new integration will have a dependency named zapier-platform-legacy-scripting-runner, a shim used to simulate behaviors that are specific to Legacy Web Builder. There could be differences on how the shim simulates and how Legacy Web Builder actually behaves on some edge cases, especially you have custom scripting code.
-
-If you're converting a **Visual Builder** app, then it will be identical and ready to push and use immediately!
+The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 
 You'll need to do a `zapier push` before the new version is visible in the editor, but otherwise you're good to go.
 
 **Arguments**
-* (required) `integrationId` | To get the integration/app ID, go to "https://zapier.com/app/developer", click on an integration, and copy the number directly after "/app/" in the URL.
+* (required) `integrationId` | To get the integration/app ID, go to "https://developer.zapier.com//app/developer", click on an integration, and copy the number directly after "/app/" in the URL.
 * (required) `path` | Relative to your current path - IE: `.` for current directory.
 
 **Flags**
-* `-v, --version` | Convert a specific version. Required when converting a Visual Builder integration.
+* (required) `-v, --version` | Convert a specific version. Required when converting a Visual Builder integration.
 * `-d, --debug` | Show extra debugging output.
 
 

--- a/packages/cli/src/oclif/commands/convert.js
+++ b/packages/cli/src/oclif/commands/convert.js
@@ -5,72 +5,37 @@ const { callAPI } = require('../../utils/api');
 const { convertApp } = require('../../utils/convert');
 const { isExistingEmptyDir } = require('../../utils/files');
 const { initApp } = require('../../utils/init');
-const { BASE_ENDPOINT } = require('../../constants');
 
 const { flags } = require('@oclif/command');
 
 class ConvertCommand extends BaseCommand {
-  generateCreateFunc(isVisual, appId, version) {
+  generateCreateFunc(appId, version) {
     return async (tempAppDir) => {
-      if (isVisual) {
-        // has info about the app, such as title
-        // has a CLI version of the actual app implementation
-        this.throwForInvalidVersion(version);
-        this.startSpinner('Downloading integration from Zapier');
-        try {
-          const [appInfo, versionInfo] = await Promise.all([
-            callAPI(`/apps/${appId}`, undefined, true),
-            callAPI(`/apps/${appId}/versions/${version}`, undefined, true),
-          ]);
+      // has info about the app, such as title
+      // has a CLI version of the actual app implementation
+      this.throwForInvalidVersion(version);
+      this.startSpinner('Downloading integration from Zapier');
+      try {
+        const [appInfo, versionInfo] = await Promise.all([
+          callAPI(`/apps/${appId}`, undefined, true),
+          callAPI(`/apps/${appId}/versions/${version}`, undefined, true),
+        ]);
 
-          if (!versionInfo.definition_override) {
-            this.error(
-              `Integration ${appId} @ ${version} is already a CLI integration and can't be converted. Instead, pick a version that was created using the Visual Builder.`
-            );
-          }
-          this.stopSpinner();
-
-          return convertApp(
-            appInfo,
-            versionInfo.definition_override,
-            tempAppDir
+        if (!versionInfo.definition_override) {
+          this.error(
+            `Integration ${appId} @ ${version} is already a CLI integration and can't be converted. Instead, pick a version that was created using the Visual Builder.`
           );
-        } catch (e) {
-          if (e.status === 404) {
-            this.error(
-              `Visual Builder integration ${appId} @ ${version} not found. If you want to convert a Legacy Web Builder app, don't pass a \`--version\` option. Otherwise, double check the integration id and version.`
-            );
-          }
-          this.error(e);
         }
-      } else {
-        // has info about the app, such as title
-        const legacyDumpUrl = `${BASE_ENDPOINT}/api/developer/v1/apps/${appId}/dump`;
-        // has a CLI version of the actual app implementation
-        const cliDumpUrl = `${BASE_ENDPOINT}/api/developer/v1/apps/${appId}/cli-dump`;
+        this.stopSpinner();
 
-        this.startSpinner('Downloading integration from Zapier');
-
-        try {
-          const [legacyApp, appDefinition] = await Promise.all([
-            // these have weird call signatures because we're not calling the platform api
-            callAPI(null, { url: legacyDumpUrl }, true),
-            callAPI(null, { url: cliDumpUrl }, true),
-          ]);
-          // The JSON dump of the app doesn't have app ID, let's add it here
-          legacyApp.general.app_id = appId;
-
-          this.stopSpinner();
-
-          return convertApp(legacyApp, appDefinition, tempAppDir);
-        } catch (e) {
-          if (e.status === 404) {
-            this.error(
-              `Legacy Web Builder app ${appId} not found. If you want to convert a Visual Builder integration, make sure to pass a \`--version\` option.`
-            );
-          }
-          this.error(e);
+        return convertApp(appInfo, versionInfo.definition_override, tempAppDir);
+      } catch (e) {
+        if (e.status === 404) {
+          this.error(
+            `Visual Builder integration ${appId} @ ${version} not found. Double check the integration id and version.`
+          );
         }
+        this.error(e.json.errors[0]);
       }
     };
   }
@@ -83,7 +48,6 @@ class ConvertCommand extends BaseCommand {
         'You must provide an integrationId. See zapier convert --help for more info.'
       );
     }
-    const isVisual = Boolean(this.flags.version);
 
     if (
       (await isExistingEmptyDir(path)) &&
@@ -92,7 +56,7 @@ class ConvertCommand extends BaseCommand {
       this.exit();
     }
 
-    await initApp(path, this.generateCreateFunc(isVisual, appId, version));
+    await initApp(path, this.generateCreateFunc(appId, version));
   }
 }
 
@@ -100,7 +64,7 @@ ConvertCommand.args = [
   {
     name: 'integrationId',
     required: true,
-    description: `To get the integration/app ID, go to "${BASE_ENDPOINT}/app/developer", click on an integration, and copy the number directly after "/app/" in the URL.`,
+    description: `To get the integration/app ID, go to "https://developer.zapier.com//app/developer", click on an integration, and copy the number directly after "/app/" in the URL.`,
     parse: (input) => Number(input),
   },
   {
@@ -116,14 +80,13 @@ ConvertCommand.flags = buildFlags({
       char: 'v',
       description:
         'Convert a specific version. Required when converting a Visual Builder integration.',
+      required: true,
     }),
   },
 });
-ConvertCommand.description = `Convert a Legacy Web Builder app or Visual Builder integration to a CLI integration.
+ConvertCommand.description = `Convert a Visual Builder integration to a CLI integration.
 
-If you're converting a **Legacy Web Builder** app: the new integration will have a dependency named zapier-platform-legacy-scripting-runner, a shim used to simulate behaviors that are specific to Legacy Web Builder. There could be differences on how the shim simulates and how Legacy Web Builder actually behaves on some edge cases, especially you have custom scripting code.
-
-If you're converting a **Visual Builder** app, then it will be identical and ready to push and use immediately!
+The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 

--- a/packages/cli/src/tests/utils/convert.js
+++ b/packages/cli/src/tests/utils/convert.js
@@ -136,8 +136,7 @@ const visualAppDefinition = {
     },
     oauth2Config: {
       authorizeUrl: {
-        url:
-          'https://app.wistia.com/oauth/authorize?client_id=03e84930b97011c7bd674f6d02c04ec9c1a430325a73a0501eb443ef07b6b99c&redirect_uri=https%3A%2F%2Fzapier.com%2Fdashboard%2Fauth%2Foauth%2Freturn%2FApp17741CLIAPI%2F&response_type=code',
+        url: 'https://app.wistia.com/oauth/authorize?client_id=03e84930b97011c7bd674f6d02c04ec9c1a430325a73a0501eb443ef07b6b99c&redirect_uri=https%3A%2F%2Fzapier.com%2Fdashboard%2Fauth%2Foauth%2Freturn%2FApp17741CLIAPI%2F&response_type=code',
         params: {
           state: '{{bundle.inputData.state}}',
           redirect_uri: '{{bundle.inputData.redirect_uri}}',
@@ -298,24 +297,6 @@ describe('convert', () => {
     fs.removeSync(tempAppDir);
   });
 
-  describe('legacy web builder apps', () => {
-    it('should create separate files', async () => {
-      await convertApp(legacyApp, legacyAppDefinition, tempAppDir);
-      [
-        '.zapierapprc',
-        '.gitignore',
-        '.env',
-        'package.json',
-        'index.js',
-        'triggers/movie.js',
-        'test/triggers/movie.js',
-      ].forEach((filename) => {
-        const filepath = path.join(tempAppDir, filename);
-        fs.existsSync(filepath).should.be.true(`failed to create ${filename}`);
-      });
-    });
-  });
-
   describe('visual builder apps', () => {
     it('should create separate files', async () => {
       await convertApp(visualApp, visualAppDefinition, tempAppDir);
@@ -389,22 +370,6 @@ describe('convert', () => {
       appDefinition.triggers.codemode.operation.perform.source +=
         '\n// a comment';
       await convertApp(visualApp, appDefinition, tempAppDir);
-    });
-
-    it('should include legacy stuff if it was from web builder', async () => {
-      const appDefinition = cloneDeep(visualAppDefinition);
-      appDefinition.legacy = {}; // 'legacy' property makes it, well, "legacy"
-
-      await convertApp(visualApp, appDefinition, tempAppDir);
-
-      const rcFile = JSON.parse(readTempFile('.zapierapprc'));
-      const packageJson = JSON.parse(readTempFile('package.json'));
-
-      should(rcFile.id).equal(visualApp.id);
-      should(rcFile.includeInBuild).deepEqual(['scripting.js']);
-      should.exist(
-        packageJson.dependencies['zapier-platform-legacy-scripting-runner']
-      );
     });
   });
 });


### PR DESCRIPTION
- removed WB conversion functionality
- make `--version` required on `zapier convert`. It functionally has been (since the other API was removed), but this makes it official
- improved error handling in convert command
- removed references to converting WB apps in docs

