### PR TITLE
PDE-3210 fix(legacy-scripting-runner): fix `logResponse` import

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.8
+
+- :bug: Make `logResponse` import backward compatible to fix `func.apply is not a function` error ([#548](https://github.com/zapier/zapier-platform/pull/548))
+
 ## 3.8.7
 
 - :bug: Replace deasync with synckit to fix hanging ([#509](https://github.com/zapier/zapier-platform/pull/509))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -27,11 +27,19 @@ const createInternalRequestClient = (input) => {
   const createInjectInputMiddleware = require('zapier-platform-core/src/http-middlewares/before/inject-input');
   const createRequestClient = require('zapier-platform-core/src/tools/create-request-client');
   const disableSSLCertCheck = require('zapier-platform-core/src/http-middlewares/before/disable-ssl-cert-check');
-  const {
-    logResponse,
-  } = require('zapier-platform-core/src/http-middlewares/after/log-response');
+  const logResponseModule = require('zapier-platform-core/src/http-middlewares/after/log-response');
   const prepareRequest = require('zapier-platform-core/src/http-middlewares/before/prepare-request');
   const prepareResponse = require('zapier-platform-core/src/http-middlewares/after/prepare-response');
+
+  // Before core 12.0.3, log-response.js module exported the logResponse()
+  // function, and it's the only export. Since core 12.0.3, logResponse()
+  // function is inside an exported object. So we do the following to make sure
+  // legacy-scripting-runner works before and after 12.0.3.
+  // Related PR: https://github.com/zapier/zapier-platform/pull/525
+  const logResponse =
+    typeof logResponseModule === 'function'
+      ? logResponseModule
+      : logResponseModule.logResponse;
 
   const options = {
     skipDefaultMiddle: true,

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.7",
+  "version": "3.8.8",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Makes a `logResponse` import backward compatible with core 12.0.2 and 12.0.3.