### PR TITLE
[SUPPORTESC-368] docs(cli): Fix unqualified use of `username` in connectionLabel for Basic auth

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1168,7 +1168,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <span class="hljs-attr">test</span>: {
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com/api/accounts/me.json&apos;</span>,
   },
-  <span class="hljs-attr">connectionLabel</span>: <span class="hljs-string">&apos;{{username}}&apos;</span>, <span class="hljs-comment">// Can also be a function, check digest auth below for an example</span>
+  <span class="hljs-attr">connectionLabel</span>: <span class="hljs-string">&apos;{{bundle.authData.username}}&apos;</span>, <span class="hljs-comment">// Can also be a function, check Digest auth below for an example</span>
   <span class="hljs-comment">// you can provide additional fields, but we&apos;ll provide `username`/`password` automatically</span>
 };
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -462,7 +462,7 @@ const authentication = {
   test: {
     url: 'https://example.com/api/accounts/me.json',
   },
-  connectionLabel: '{{username}}', // Can also be a function, check digest auth below for an example
+  connectionLabel: '{{bundle.authData.username}}', // Can also be a function, check Digest auth below for an example
   // you can provide additional fields, but we'll provide `username`/`password` automatically
 };
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1168,7 +1168,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <span class="hljs-attr">test</span>: {
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com/api/accounts/me.json&apos;</span>,
   },
-  <span class="hljs-attr">connectionLabel</span>: <span class="hljs-string">&apos;{{username}}&apos;</span>, <span class="hljs-comment">// Can also be a function, check digest auth below for an example</span>
+  <span class="hljs-attr">connectionLabel</span>: <span class="hljs-string">&apos;{{bundle.authData.username}}&apos;</span>, <span class="hljs-comment">// Can also be a function, check Digest auth below for an example</span>
   <span class="hljs-comment">// you can provide additional fields, but we&apos;ll provide `username`/`password` automatically</span>
 };
 

--- a/packages/cli/snippets/basic-auth.js
+++ b/packages/cli/snippets/basic-auth.js
@@ -4,7 +4,7 @@ const authentication = {
   test: {
     url: 'https://example.com/api/accounts/me.json',
   },
-  connectionLabel: '{{username}}', // Can also be a function, check digest auth below for an example
+  connectionLabel: '{{bundle.authData.username}}', // Can also be a function, check Digest auth below for an example
   // you can provide additional fields, but we'll provide `username`/`password` automatically
 };
 


### PR DESCRIPTION
It's possible we previously supported the use of unqualified references like `username` for the connection label, but in the present platform it seems to require either `bundle.authData` or `bundle.inputData` to figure out what to use.
