### PR TITLE
fix(legacy-scripting-runner): StopRequestException should be caught instead of thrown

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.9
+
+- :bug: `StopRequestException` should be caught instead of thrown ([#558](https://github.com/zapier/zapier-platform/pull/558))
+
 ## 3.8.8
 
 - :bug: Make `logResponse` import backward compatible to fix `func.apply is not a function` error ([#548](https://github.com/zapier/zapier-platform/pull/548))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -834,9 +834,20 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
       result = await runEvent({ key, name: fullEventName }, zcli, bundle);
     } else {
       const preMethod = preMethodName ? Zap[preMethodName] : null;
-      let request = preMethod
-        ? await runEvent({ key, name: preEventName }, zcli, bundle)
-        : {};
+      let request;
+      if (preMethod) {
+        try {
+          request = await runEvent({ key, name: preEventName }, zcli, bundle);
+        } catch (error) {
+          if (error.name === 'StopRequestError') {
+            return ensureIsType(null, options.ensureType);
+          }
+          throw error;
+        }
+      } else {
+        request = {};
+      }
+
       request = { ...bundle.request, ...request };
 
       const isBodyStream = typeof _.get(request, 'body.pipe') === 'function';

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.8",
+  "version": "3.8.9",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -333,6 +333,10 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_poll_stop_request: function(bundle) {
+        throw new StopRequestException("don't do it");
+      },
+
       movie_post_poll_request_options: function(bundle) {
         // To make sure bundle.request is still available in post_poll
         return [bundle.request];
@@ -679,6 +683,10 @@ const legacyScriptingSource = `
           empty_array: []
         };
         return bundle.request;
+      },
+
+      movie_pre_write_stop_request: function(bundle) {
+        throw new StopRequestException('stop');
       },
 
       movie_write_default_headers: function(bundle) {

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -1304,6 +1304,30 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_poll, StopRequestException', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_pre_poll_stop_request',
+        'movie_pre_poll'
+      );
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_post_poll_make_array',
+        'movie_post_poll'
+      );
+      const _appDefWithAuth = withAuth(appDef, sessionAuthConfig);
+      const _compiledApp = schemaTools.prepareApp(_appDefWithAuth);
+      const _app = createApp(_appDefWithAuth);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        output.results.should.be.an.Array();
+        output.results.length.should.equal(0);
+      });
+    });
+
     it('KEY_pre_poll, merge query params', () => {
       const appDef = _.cloneDeep(appDefinition);
       appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
@@ -2522,6 +2546,26 @@ describe('Integration Test', () => {
           'foo=bar&apple=123&dragonfruit=%26%3D&eggplant=1.11&eggplant=2.22&' +
             'filbert=True&nest=foo&nest=hello'
         );
+      });
+    });
+
+    it('KEY_pre_write, StopRequestException', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_pre_write_stop_request',
+          'movie_pre_write'
+        );
+
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        should.deepEqual(output.results, {});
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->


The legacy scripting [docs](https://platform.zapier.com/legacy/scripting) say `StopRequestException` is to silently cancel the request in a `pre_` method:

> Any pre_XXX call can be interrupted silently with StopRequestException. This will prevent the request from being made and will never cause a user’s Zap to be turned off.

Namely, if a `pre_` method throws a `StopRequestException`, Zapier should cancel the subsequent request sent to the partner and return an empty result.

Current behavior: `StopRequestException` is [transformed](https://github.com/zapier/zapier-platform/blob/69097765d3f6a13a8aa5c755a9824f170b0ccc52/packages/legacy-scripting-runner/exceptions.js#L54) to `StopRequestError` and is thrown as an uncaught error.

New behavior: Catch `StopRequestError` and return an empty array or object, depending on the action type.