### PR TITLE
fix(legacy-scripting-runner): support `StopRequestException` in `KEY_catch_hook`, `KEY_poll`, `KEY_write`, `KEY_search`

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.10
+
+- :bug: Add support for `StopRequestException` in more methods ([#561](https://github.com/zapier/zapier-platform/pull/561))
+
 ## 3.8.9
 
 - :bug: `StopRequestException` should be caught instead of thrown ([#558](https://github.com/zapier/zapier-platform/pull/558))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.9",
+  "version": "3.8.10",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -372,6 +372,10 @@ const legacyScriptingSource = `
         return [z.JSON.parse(response.content)];
       },
 
+      movie_poll_stop_request: function(bundle) {
+        throw new StopRequestException('stop');
+      },
+
       recipe_pre_poll_underscore_template: function(bundle) {
         bundle.request.url = _.template(bundle.request.url, {
           urlPath: '/recipes'
@@ -407,6 +411,10 @@ const legacyScriptingSource = `
           querystring: bundle.request.querystring,
           content: bundle.request.content
         };
+      },
+
+      contact_hook_scripting_catch_hook_stop_request: function(bundle) {
+        throw new StopRequestException('stop');
       },
 
       // To be replaced with 'contact_hook_scripting_pre_hook' at runtime to enable
@@ -737,6 +745,10 @@ const legacyScriptingSource = `
         return response.content;
       },
 
+      movie_write_stop_request: function(bundle) {
+        throw new StopRequestException('nothing for you');
+      },
+
       // To be replaced with 'movie_pre_custom_action_fields' at runtime
       movie_pre_custom_action_fields_disabled: function(bundle) {
         bundle.request.url += 's';
@@ -945,6 +957,10 @@ const legacyScriptingSource = `
         return bundle.request;
       },
 
+      movie_pre_search_stop_request: function(bundle) {
+        throw new StopRequestException("don't do it");
+      },
+
       // To be replaced with 'movie_post_search' at runtime
       movie_post_search_disabled: function(bundle) {
         var results = z.JSON.parse(bundle.response.content);
@@ -959,6 +975,10 @@ const legacyScriptingSource = `
         var results = z.JSON.parse(response.content);
         results[0].title += ' (movie_search was here)';
         return results;
+      },
+
+      movie_search_stop_request: function(bundle) {
+        throw new StopRequestException('nothing for you');
       },
 
       // To be replaced with 'movie_pre_read_resource' at runtime

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -823,6 +823,24 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_poll, StopRequestException', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_poll_stop_request',
+        'movie_poll'
+      );
+      const _compiledApp = schemaTools.prepareApp(appDef);
+      const _app = createApp(appDef);
+
+      const input = createTestInput(
+        _compiledApp,
+        'triggers.movie.operation.perform'
+      );
+      return _app(input).then((output) => {
+        should.deepEqual(output.results, []);
+      });
+    });
+
     it('KEY_pre_poll', () => {
       const input = createTestInput(
         compiledApp,
@@ -1824,6 +1842,23 @@ describe('Integration Test', () => {
         should.equal(result.headers['Http-X-Custom'], 'hello');
         should.equal(result.content, '<name>Tom</name>');
         should.equal(result.querystring, 'foo=bar');
+      });
+    });
+
+    it('KEY_catch_hook, StopRequestException', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'contact_hook_scripting_catch_hook_stop_request',
+        'contact_hook_scripting_catch_hook'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
+      const input = createTestInput(
+        compiledApp,
+        'triggers.contact_hook_scripting.operation.perform'
+      );
+      return app(input).then((output) => {
+        should.deepEqual(output.results, []);
       });
     });
 
@@ -2993,6 +3028,24 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_write, StopRequestException', () => {
+      const appDef = _.cloneDeep(appDefinition);
+      appDef.legacy.scriptingSource = appDef.legacy.scriptingSource.replace(
+        'movie_write_stop_request',
+        'movie_write'
+      );
+      const compiledApp = schemaTools.prepareApp(appDef);
+      const app = createApp(appDef);
+
+      const input = createTestInput(
+        compiledApp,
+        'creates.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        should.deepEqual(output.results, {});
+      });
+    });
+
     it('scriptingless input fields', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       appDefWithAuth.legacy.creates.movie.operation.inputFieldsUrl += 's';
@@ -4104,6 +4157,25 @@ describe('Integration Test', () => {
       });
     });
 
+    it('KEY_pre_search, StopRequestException', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_pre_search_stop_request',
+          'movie_pre_search'
+        );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        should.deepEqual(output.results, []);
+      });
+    });
+
     it('KEY_post_search', () => {
       const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
       const legacyProps = appDefWithAuth.legacy.searches.movie.operation;
@@ -4189,6 +4261,25 @@ describe('Integration Test', () => {
         const movie = output.results[0];
         should.equal(movie.id, 12);
         should.equal(movie.title, 'title 12 (movie_search was here)');
+      });
+    });
+
+    it('KEY_search, StopRequestException', () => {
+      const appDefWithAuth = withAuth(appDefinition, apiKeyAuth);
+      appDefWithAuth.legacy.scriptingSource =
+        appDefWithAuth.legacy.scriptingSource.replace(
+          'movie_search_stop_request',
+          'movie_search'
+        );
+      const compiledApp = schemaTools.prepareApp(appDefWithAuth);
+      const app = createApp(appDefWithAuth);
+
+      const input = createTestInput(
+        compiledApp,
+        'searches.movie.operation.perform'
+      );
+      return app(input).then((output) => {
+        should.deepEqual(output.results, []);
       });
     });
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Continues the work of #558, this PR adds support for `StopRequestException` to all the methods, including `KEY_catch_hook`, `KEY_poll`, `KEY_write`, and `KEY_search`.
