### PR TITLE
PDE-3251 fix(core): abort logger connection at the end of invocation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "form-data": "4.0.0",
     "lodash": "4.17.21",
     "mime-types": "2.1.34",
+    "node-abort-controller": "3.0.1",
     "node-fetch": "2.6.7",
     "oauth-sign": "0.9.0",
     "semver": "7.3.5",

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -199,12 +199,7 @@ class LogStream extends Transform {
       // Swallow logging errors. This will show up in AWS logs at least.
       // Don't need to log for AbortError because that happens when we abort
       // on purpose.
-      console.error(
-        'Error making log request:',
-        err,
-        'http options:',
-        httpOptions
-      );
+      console.error('Error making log request:', err);
     });
   }
 

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -245,8 +245,7 @@ class LogStreamFactory {
 
   // Ends the logger and gets a response from the log server. Optionally takes
   // timeoutToAbort to specify how many milliseconds we want to wait before
-  // force aborting the connection to the log server. timeoutToAbort defaults to
-  // 0, meaning to immediately abort.
+  // force aborting the connection to the log server.
   async end(timeoutToAbort = DEFAULT_LOGGER_TIMEOUT) {
     // Mark the factory as ended. This suggests that any logStream.write() that
     // follows should end() right away.

--- a/packages/core/test/tools/mocky.js
+++ b/packages/core/test/tools/mocky.js
@@ -156,9 +156,10 @@ const mockUpload = () => {
     });
 };
 
-const mockLogServer = () => {
+const mockLogServer = (delay = 0) => {
   nock(FAKE_LOG_URL)
     .post('/input')
+    .delay(delay)
     .reply(function (uri, requestBody, cb) {
       const lines = requestBody.split('\n');
       const logs = lines

--- a/yarn.lock
+++ b/yarn.lock
@@ -7316,6 +7316,11 @@ nock@13.0.11, nock@^13.0.11:
     lodash.set "^4.3.2"
     propagate "^2.0.0"
 
+node-abort-controller@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.0.1.tgz#f91fa50b1dee3f909afabb7e261b1e1d6b0cb74e"
+  integrity sha512-/ujIVxthRs+7q6hsdjHMaj8hRG9NuWmwrz+JdRwZ14jdFoKSkm+vDsCbF9PLpnSqjaWQJuTmVtcWHNLr+vrOFw==
+
 node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes the issue where a Lambda invocation can take ~1 minute before a `socket hang up` error with the log server shows up.

You can find the steps to reproduce the error on [Slack](https://zapier.slack.com/archives/C5Z9BP4U9/p1657183594848969?thread_ts=1656322076.695299&cid=C5Z9BP4U9).

I’m not sure under what situations the log server would stop responding to an open connection on production. (Maybe the log server sometimes crashes?) But we should at least make the core more resilient and not affected by a hanging connection.

The idea is to limit the wait time for the log server to respond. We use node-fetch to make requests to the log server. And to abort a node-fetch request, we can use AbortController. See node-fetch's [README](https://github.com/node-fetch/node-fetch/tree/v2.6.7#request-cancellation-with-abortsignal) for example. Since AbortController only became natively supported on Node.js 15+, I'm using the [node-abort-controller](https://github.com/southpolesteve/node-abort-controller) package.