### PR TITLE
PDE-3318 fix(legacy-scripting-runner): `z.request` in legacy script isn't logged

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.11
+
+- :bug: sync `z.request` doesn't produce an HTTP log ([#566](https://github.com/zapier/zapier-platform/pull/566))
+
 ## 3.8.10
 
 - :bug: Add support for `StopRequestException` in more methods ([#561](https://github.com/zapier/zapier-platform/pull/561))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.10",
+  "version": "3.8.11",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -138,11 +138,6 @@ const legacyScriptingSource = `
         return contacts;
       },
 
-      contact_full_poll_z_request_with_url: function(bundle) {
-        var response = z.request({uri: '${HTTPBIN_URL}/get'});
-        return z.JSON.parse(response.content);
-      },
-
       contact_full_pre_custom_trigger_fields: function(bundle) {
         bundle.request.url += 's';
         return bundle.request;

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -138,6 +138,11 @@ const legacyScriptingSource = `
         return contacts;
       },
 
+      contact_full_poll_z_request_with_url: function(bundle) {
+        var response = z.request({uri: '${HTTPBIN_URL}/get'});
+        return z.JSON.parse(response.content);
+      },
+
       contact_full_pre_custom_trigger_fields: function(bundle) {
         bundle.request.url += 's';
         return bundle.request;
@@ -374,6 +379,11 @@ const legacyScriptingSource = `
 
       movie_poll_stop_request: function(bundle) {
         throw new StopRequestException('stop');
+      },
+
+      movie_poll_z_request_uri: function(bundle) {
+        var response = z.request({ uri: '${HTTPBIN_URL}/get', method: 'get' });
+        return [z.JSON.parse(response.content)];
       },
 
       recipe_pre_poll_underscore_template: function(bundle) {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes a regression caused by #509, where calling `z.request` in the legacy script does not (but should) produce an HTTP log.

For an HTTP request to be logged, it must call the patched [`http(s).request`](https://github.com/zapier/zapier-platform/blob/b580d5f781d4b6e1aeff49e906bb9f36f6872589/packages/core/src/tools/create-http-patch.js#L21) function. The patch is done [at the Lambda handler initialization time](https://github.com/zapier/zapier-platform/blob/b580d5f781d4b6e1aeff49e906bb9f36f6872589/packages/core/src/tools/create-lambda-handler.js#L202-L204).

But since #509 adopted [synckit](https://github.com/rx-ts/synckit) to implement the [sync version of `z.request`](https://platform.zapier.com/legacy/scripting#making-outbound-requests-zrequest) in the legacy script, the HTTP request for the sync `z.request` has been happening in a separate thread, where `http(s).request` isn't patched like the main thread. This is why HTTP logs haven't been showing up for a lot of apps converted from Web Builder.

To fix, we let legacy-scripting-runner write the HTTP log explicitly when the sync `z.request` is used.