### PR TITLE
[SUPPORTENG-406] Correcting ThrottledError example to include z.errors

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4371,7 +4371,7 @@ delay in seconds:</p>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
   <span class="hljs-keyword">if</span> (resp.status === <span class="hljs-number">429</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> ThrottledError(<span class="hljs-string">&apos;message here&apos;</span>, <span class="hljs-number">60</span>);  <span class="hljs-comment">// Zapier will retry in 60 seconds</span>
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.ThrottledError(<span class="hljs-string">&apos;message here&apos;</span>, <span class="hljs-number">60</span>);  <span class="hljs-comment">// Zapier will retry in 60 seconds</span>
   }
   <span class="hljs-keyword">return</span> resp;
 };

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1535,7 +1535,7 @@ delay in seconds:
 ```js
 const yourAfterResponse = (resp) => {
   if (resp.status === 429) {
-    throw new ThrottledError('message here', 60);  // Zapier will retry in 60 seconds
+    throw new z.errors.ThrottledError('message here', 60);  // Zapier will retry in 60 seconds
   }
   return resp;
 };

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2688,7 +2688,7 @@ delay in seconds:
 ```js
 const yourAfterResponse = (resp) => {
   if (resp.status === 429) {
-    throw new ThrottledError('message here', 60);  // Zapier will retry in 60 seconds
+    throw new z.errors.ThrottledError('message here', 60);  // Zapier will retry in 60 seconds
   }
   return resp;
 };

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -4371,7 +4371,7 @@ delay in seconds:</p>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> yourAfterResponse = <span class="hljs-function">(<span class="hljs-params">resp</span>) =&gt;</span> {
   <span class="hljs-keyword">if</span> (resp.status === <span class="hljs-number">429</span>) {
-    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> ThrottledError(<span class="hljs-string">&apos;message here&apos;</span>, <span class="hljs-number">60</span>);  <span class="hljs-comment">// Zapier will retry in 60 seconds</span>
+    <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> z.errors.ThrottledError(<span class="hljs-string">&apos;message here&apos;</span>, <span class="hljs-number">60</span>);  <span class="hljs-comment">// Zapier will retry in 60 seconds</span>
   }
   <span class="hljs-keyword">return</span> resp;
 };


### PR DESCRIPTION
I updated the ThrottledError example to call ThrottledError on z.errors. The current example does not use z.errors (`throw new ThrottledError()`).

![current example](https://cdn.zappy.app/99a0fb98b15fdf4a63a04258e1bf0dc8.png)

ThrottledError is listed under z.errors in [the docs](https://github.com/zapier/zapier-platform/blob/master/packages/cli/README.md#zerrors), so this change makes this example consistent with the usage of other errors.

In my own testing, ThrottledError only gets thrown when z.errors is used.
