### PR TITLE
[PDE-3393] Log warnings at build time during validation

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -448,6 +448,7 @@ const _buildFunc = async ({
           console.log(colors.yellow(`- ${issue.description}`));
         }
       }
+      console.log(colors.yellow('Run `zapier validate` for more details.'));
     }
   } else {
     debug('\nWarning: Skipping Validation');

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -29,7 +29,12 @@ const {
   removeDir,
 } = require('./files');
 
-const { prettyJSONstringify, startSpinner, endSpinner } = require('./display');
+const {
+  prettyJSONstringify,
+  startSpinner,
+  endSpinner,
+  flattenCheckResult,
+} = require('./display');
 
 const {
   getLinkedAppConfig,
@@ -434,6 +439,16 @@ const _buildFunc = async ({
       );
     }
     endSpinner();
+
+    if (_.get(styleChecksResponse, ['warnings', 'total_failures'])) {
+      console.log(colors.yellow('WARNINGS:'));
+      const checkIssues = flattenCheckResult(styleChecksResponse);
+      for (const issue of checkIssues) {
+        if (issue.category != 'Errors') {
+          console.log(colors.yellow(`- ${issue.description}`));
+        }
+      }
+    }
   } else {
     debug('\nWarning: Skipping Validation');
   }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

 build(cli):  Log warnings at build time during validation
 
 ![](https://cdn.zappy.app/b9821f4a04aa2541a5587c663981f3a3.png)