### PR TITLE
[PDE-3262] Add skip-changelog flag to zapier promote CLI command

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -834,6 +834,7 @@ a code {
 </ul><p>Promotes are an inherently safe operation for all existing users of your integration.</p><p>If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.</p><p>Check <code>zapier jobs</code> to track the status of the promotion. Or use <code>zapier history</code> if you want to see older jobs.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>version</code> | The version you want to promote.</li>
 </ul><p><strong>Flags</strong></p><ul>
+<li><code>--skip-changelog</code> | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier promote 1.0.0</code></li>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -834,7 +834,7 @@ a code {
 </ul><p>Promotes are an inherently safe operation for all existing users of your integration.</p><p>If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.</p><p>Check <code>zapier jobs</code> to track the status of the promotion. Or use <code>zapier history</code> if you want to see older jobs.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>version</code> | The version you want to promote.</li>
 </ul><p><strong>Flags</strong></p><ul>
-<li><code>--skip-changelog</code> | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.</li>
+<li><code>-y, --yes</code> | Automatically answer &quot;yes&quot; to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier promote 1.0.0</code></li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -397,6 +397,7 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * (required) `version` | The version you want to promote.
 
 **Flags**
+* `--skip-changelog` | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -397,7 +397,7 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * (required) `version` | The version you want to promote.
 
 **Flags**
-* `--skip-changelog` | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.
+* `-y, --yes` | Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -834,6 +834,7 @@ a code {
 </ul><p>Promotes are an inherently safe operation for all existing users of your integration.</p><p>If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.</p><p>Check <code>zapier jobs</code> to track the status of the promotion. Or use <code>zapier history</code> if you want to see older jobs.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>version</code> | The version you want to promote.</li>
 </ul><p><strong>Flags</strong></p><ul>
+<li><code>--skip-changelog</code> | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier promote 1.0.0</code></li>

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -834,7 +834,7 @@ a code {
 </ul><p>Promotes are an inherently safe operation for all existing users of your integration.</p><p>If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.</p><p>Check <code>zapier jobs</code> to track the status of the promotion. Or use <code>zapier history</code> if you want to see older jobs.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>version</code> | The version you want to promote.</li>
 </ul><p><strong>Flags</strong></p><ul>
-<li><code>--skip-changelog</code> | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.</li>
+<li><code>-y, --yes</code> | Automatically answer &quot;yes&quot; to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.</li>
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier promote 1.0.0</code></li>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -397,6 +397,7 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * (required) `version` | The version you want to promote.
 
 **Flags**
+* `--skip-changelog` | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -397,7 +397,7 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * (required) `version` | The version you want to promote.
 
 **Flags**
-* `--skip-changelog` | Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote.
+* `-y, --yes` | Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -29,7 +29,7 @@ class PromoteCommand extends BaseCommand {
     const app = await this.getWritableApp();
 
     const version = this.args.version;
-    const skipChangelog = 'skip-changelog' in this.flags;
+    const assumeYes = 'yes' in this.flags;
 
     let shouldContinue;
     const changelog = await getVersionChangelog(version);
@@ -38,7 +38,7 @@ class PromoteCommand extends BaseCommand {
       this.log(`\n---\n${changelog}\n---\n`);
 
       shouldContinue =
-        skipChangelog ||
+        assumeYes ||
         (await this.confirm(
           'Would you like to continue promoting with this changelog?'
         ));
@@ -52,7 +52,7 @@ class PromoteCommand extends BaseCommand {
       );
 
       shouldContinue =
-        skipChangelog ||
+        assumeYes ||
         (await this.confirm(
           'Would you like to continue promoting without a changelog?'
         ));
@@ -125,9 +125,10 @@ class PromoteCommand extends BaseCommand {
 
 PromoteCommand.flags = buildFlags({
   commandFlags: {
-    'skip-changelog': flags.boolean({
+    yes: flags.boolean({
+      char: 'y',
       description:
-        'Suppress prompts asking to confirm a corresponding changelog entry for the version you are attempting to promote. ',
+        'Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.',
     }),
   },
 });


### PR DESCRIPTION
This flag suppresses prompts asking to confirm a corresponding changelog entry when running zapier promote. This is primarily for CI purposes and will still show warnings/info related to the changelog during zapier promote runs. I utilized oclif's [built-in boolean flag type](https://oclif.io/docs/flags) for this flag.

Usage: `zapier promote 1.0.0 --skip-changelog`