### PR TITLE
PDE-3458 docs: document development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,58 @@ yarn test
 
 ### Using `.only`
 
-TBA
+Often you'd need to run a selected subset of tests. You can annotate the test case with
+Mocha's [`.only`][mocha-only] to exclude others.
+
+## Using `zapier` CLI Development Version
+
+Add an alias to your `~/.bashrc`, `~/.zshrc`, or equivalent:
+
+```
+alias zapier-dev="/path/to/zapier-platform/packages/cli/src/bin/run"
+```
+
+This way you can keep stable and development versions separate:
+
+- the `zapier` command keeps pointing the stable version that you installed using `npm install -g zapier-platform-cli`
+- `zapier-dev` points to the development version
+
+Restart your shell. The `zapier-dev` command should be available.
+
+## Using zapier-platform-core Development Version for an Integration Project
+
+When you run `npm install` or `yarn` inside an integration project, you install
+zapier-platform-core and schema from npm. But for development, you may want to link core
+and schema to the ones in your local copy of zapier-platform repo. To do that, you use the
+[`yarn link`][yarn-link] command.
+
+```
+# First, in zapier-platform/packages/core and schema run `yarn link` to "register" the links
+
+cd /path/to/zapier-platform/packages/core
+yarn link
+
+cd /path/to/zapier-platform/packages/schema
+yarn link
+
+# Then in the integration project, run `yarn link <package_name>` to link core and schema.
+# This can be done before or after installing dependencies with `npm install` or `yarn`
+
+cd /path/to/your/awesome-app
+yarn link zapier-platform-core
+yarn link zapier-platform-schema
+```
+
+You can verify that it's working by checking if the core and schema are symlinked.
+
+```
+$ ls -hl node_modules/zapier-platform-*
+... node_modules/zapier-platform-core -> .../.config/yarn/link/zapier-platform-core
+... node_modules/zapier-platform-schema -> .../.config/yarn/link/zapier-platform-schema
+```
+
+To unlink, you use the `yarn unlink <package_name>` command. The integration project will
+go back to use the packages downloaded from npm.
 
 ## Releasing a New Version
 
@@ -60,3 +111,5 @@ TBA
 [yarn]: https://yarnpkg.com
 [ci]: https://github.com/zapier/zapier-platform/actions/workflows/ci.yaml
 [releasing]: https://coda.io/d/_di0MgBhlCWf/Releasing-a-New-zapier-platform-Version_su5eD
+[mocha-only]: https://mochajs.org/#exclusive-tests
+[yarn-link]: https://classic.yarnpkg.com/en/docs/cli/link

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,22 +74,6 @@ zapier-platform-core and schema from npm. But for development, you may want to l
 and schema to the ones in your local copy of zapier-platform repo. To do that, you use the
 [`yarn link`][yarn-link] command.
 
-```
-# First, in zapier-platform/packages/core and schema run `yarn link` to "register" the links
-
-cd /path/to/zapier-platform/packages/core
-yarn link
-
-cd /path/to/zapier-platform/packages/schema
-yarn link
-
-# Then in the integration project, run `yarn link <package_name>` to link core and schema.
-# This can be done before or after installing dependencies with `npm install` or `yarn`
-
-cd /path/to/your/awesome-app
-yarn link zapier-platform-core
-yarn link zapier-platform-schema
-```
 
 You can verify that it's working by checking if the core and schema are symlinked.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ alias zapier-dev="/path/to/zapier-platform/packages/cli/src/bin/run"
 
 This way you can keep stable and development versions separate:
 
-- the `zapier` command keeps pointing the stable version that you installed using `npm install -g zapier-platform-cli`
+- the `zapier` command keeps pointing to the stable version that you installed using
+  `npm install -g zapier-platform-cli`
 - `zapier-dev` points to the development version
 
 Restart your shell. The `zapier-dev` command should be available.
@@ -74,6 +75,26 @@ zapier-platform-core and schema from npm. But for development, you may want to l
 and schema to the ones in your local copy of zapier-platform repo. To do that, you use the
 [`yarn link`][yarn-link] command.
 
+First, in zapier-platform/packages/core and zapier-platform/packages/schema, run `yarn link`
+to "register" the links:
+
+```
+cd /path/to/zapier-platform/packages/core
+yarn link
+cd /path/to/zapier-platform/packages/schema
+yarn link
+```
+
+Then, in the integration project, run `yarn link <package_name>` to link core and schema.
+This can be done before or after installing dependencies with `npm install` or `yarn` in
+your integration project:
+
+```
+cd /path/to/your/awesome-app
+yarn link zapier-platform-core
+yarn link zapier-platform-schema
+```
+
 
 You can verify that it's working by checking if the core and schema are symlinked.
 
@@ -83,8 +104,8 @@ $ ls -hl node_modules/zapier-platform-*
 ... node_modules/zapier-platform-schema -> .../.config/yarn/link/zapier-platform-schema
 ```
 
-To unlink, you use the `yarn unlink <package_name>` command. The integration project will
-go back to use the packages downloaded from npm.
+To unlink, you use the `yarn unlink <package_name>` command to make the integration
+project go back to use the packages downloaded from npm.
 
 ## Releasing a New Version
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
