### PR TITLE
[SUPPORTENG-379] docs(cli): Provide field type details under Input Fields in README

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1975,7 +1975,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.</p>
+      <p>Notably, fields come in different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -1940,7 +1940,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>On each trigger, search, or create in the <code>operation</code> directive - you can provide an array of objects as fields under the <code>inputFields</code>. Input Fields are what your users would see in the main Zapier user interface. For example, you might have a &quot;Create Contact&quot; action with fields like &quot;First name&quot;, &quot;Last name&quot;, &quot;Email&quot;, etc. These fields will be able to accept input from previous steps in a Zap, for example:</p><p><img src="https://cdn.zappy.app/52721a3cb202446b7c298e303b710471.gif" alt="gif of setting up an action field in Zap Editor"></p><p>You can find more details about setting action fields from a user perspective in <a href="https://zapier.com/help/creating-zap/#set-up-action-template">our help documentation</a>.</p><p>Those fields have various options you can provide, here is a succinct example:</p>
+      <p>On each trigger, search, or create in the <code>operation</code> directive, you can provide fields as an array of objects under <code>inputFields</code>. Input Fields are what your users see in Zapier when setting up your app&apos;s triggers and actions. For example, you might have a &quot;Create Contact&quot; action with fields like &quot;First name&quot;, &quot;Last name&quot;, &quot;Email&quot;, etc. These fields will be able to accept input from the user, or from previous steps in a Zap. For example:</p><p><img src="https://cdn.zappy.app/52721a3cb202446b7c298e303b710471.gif" alt="gif of setting up an action field in Zap Editor"></p><p>You can find more details about setting action fields from a user perspective in <a href="https://zapier.com/help/creating-zap/">our help documentation</a>.</p><p>Those fields have various options you can provide. Here is a brief example:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {
@@ -1970,6 +1970,73 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 };
 
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>String</td>
+<td>Accepts text input.</td>
+</tr>
+<tr>
+<td>Text</td>
+<td>Displays large, <textarea>-style entry box, accepts text input.</textarea></td>
+</tr>
+<tr>
+<td>Code</td>
+<td>Displays large, <textarea>-style box with a fixed-width font, accepts text input.</textarea></td>
+</tr>
+<tr>
+<td>Integer</td>
+<td>Accepts integer number values.</td>
+</tr>
+<tr>
+<td>Number</td>
+<td>Accepts any numeric value, including decimal numbers.</td>
+</tr>
+<tr>
+<td>Boolean</td>
+<td>Displays dropdown menu offering true and false options. Passes along <code>true</code> or <code>false</code>.</td>
+</tr>
+<tr>
+<td>Datetime</td>
+<td>Accepts both <a href="https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0">precise and human-readable date-time values</a>. Passes along an ISO-formatted time string.</td>
+</tr>
+<tr>
+<td>File</td>
+<td>Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated.</td>
+</tr>
+<tr>
+<td>Password</td>
+<td>Displays entered characters as hidden, accepts text input. Does not accept input from previous steps.</td>
+</tr>
+<tr>
+<td>Copy</td>
+<td>Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users.</td>
+</tr>
+</tbody>
+</table>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1993,43 +1993,43 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </thead>
 <tbody>
 <tr>
-<td>String</td>
+<td><code>string</code></td>
 <td>Accepts text input.</td>
 </tr>
 <tr>
-<td>Text</td>
-<td>Displays large, <textarea>-style entry box, accepts text input.</textarea></td>
+<td><code>text</code></td>
+<td>Displays large, <code>&lt;textarea&gt;</code>-style entry box, accepts text input.</td>
 </tr>
 <tr>
-<td>Code</td>
-<td>Displays large, <textarea>-style box with a fixed-width font, accepts text input.</textarea></td>
+<td><code>code</code></td>
+<td>Displays large, <code>&lt;textarea&gt;</code>-style box with a fixed-width font, accepts text input.</td>
 </tr>
 <tr>
-<td>Integer</td>
+<td><code>integer</code></td>
 <td>Accepts integer number values.</td>
 </tr>
 <tr>
-<td>Number</td>
+<td><code>number</code></td>
 <td>Accepts any numeric value, including decimal numbers.</td>
 </tr>
 <tr>
-<td>Boolean</td>
+<td><code>boolean</code></td>
 <td>Displays dropdown menu offering true and false options. Passes along <code>true</code> or <code>false</code>.</td>
 </tr>
 <tr>
-<td>Datetime</td>
+<td><code>datetime</code></td>
 <td>Accepts both <a href="https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0">precise and human-readable date-time values</a>. Passes along an ISO-formatted time string.</td>
 </tr>
 <tr>
-<td>File</td>
+<td><code>file</code></td>
 <td>Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated.</td>
 </tr>
 <tr>
-<td>Password</td>
+<td><code>password</code></td>
 <td>Displays entered characters as hidden, accepts text input. Does not accept input from previous steps.</td>
 </tr>
 <tr>
-<td>Copy</td>
+<td><code>copy</code></td>
 <td>Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users.</td>
 </tr>
 </tbody>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -561,7 +561,7 @@ Those fields have various options you can provide. Here is a brief example:
 [insert-file:./snippets/fields.js]
 ```
 
-Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.
+Notably, fields come in different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.
 
 | Type | Behavior |
 |------|----------|

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -549,17 +549,32 @@ In cases where Zapier needs to show an example record to the user, but we are un
 
 ## Input Fields
 
-On each trigger, search, or create in the `operation` directive - you can provide an array of objects as fields under the `inputFields`. Input Fields are what your users would see in the main Zapier user interface. For example, you might have a "Create Contact" action with fields like "First name", "Last name", "Email", etc. These fields will be able to accept input from previous steps in a Zap, for example:
+On each trigger, search, or create in the `operation` directive, you can provide fields as an array of objects under `inputFields`. Input Fields are what your users see in Zapier when setting up your app's triggers and actions. For example, you might have a "Create Contact" action with fields like "First name", "Last name", "Email", etc. These fields will be able to accept input from the user, or from previous steps in a Zap. For example:
 
 ![gif of setting up an action field in Zap Editor](https://cdn.zappy.app/52721a3cb202446b7c298e303b710471.gif)
 
-You can find more details about setting action fields from a user perspective in [our help documentation](https://zapier.com/help/creating-zap/#set-up-action-template).
+You can find more details about setting action fields from a user perspective in [our help documentation](https://zapier.com/help/creating-zap/).
 
-Those fields have various options you can provide, here is a succinct example:
+Those fields have various options you can provide. Here is a brief example:
 
 ```js
 [insert-file:./snippets/fields.js]
 ```
+
+Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.
+
+| Type | Behavior |
+|------|----------|
+| String | Accepts text input. |
+| Text | Displays large, <textarea>-style entry box, accepts text input. |
+| Code | Displays large, <textarea>-style box with a fixed-width font, accepts text input. |
+| Integer | Accepts integer number values. |
+| Number | Accepts any numeric value, including decimal numbers. |
+| Boolean | Displays dropdown menu offering true and false options. Passes along `true` or `false`.  |
+| Datetime | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
+| File | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
+| Password | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
+| Copy | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
 
 You can find more details on the different field schema options at [our Field Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#fieldschema).
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -565,16 +565,16 @@ Notably, fields come in different types, which may look and act differently in t
 
 | Type | Behavior |
 |------|----------|
-| String | Accepts text input. |
-| Text | Displays large, <textarea>-style entry box, accepts text input. |
-| Code | Displays large, <textarea>-style box with a fixed-width font, accepts text input. |
-| Integer | Accepts integer number values. |
-| Number | Accepts any numeric value, including decimal numbers. |
-| Boolean | Displays dropdown menu offering true and false options. Passes along `true` or `false`.  |
-| Datetime | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
-| File | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
-| Password | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
-| Copy | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
+| `string` | Accepts text input. |
+| `text` | Displays large, `<textarea>`-style entry box, accepts text input. |
+| `code` | Displays large, `<textarea>`-style box with a fixed-width font, accepts text input. |
+| `integer` | Accepts integer number values. |
+| `number` | Accepts any numeric value, including decimal numbers. |
+| `boolean` | Displays dropdown menu offering true and false options. Passes along `true` or `false`.  |
+| `datetime` | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
+| `file` | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
+| `password` | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
+| `copy` | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
 
 You can find more details on the different field schema options at [our Field Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#fieldschema).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1082,7 +1082,7 @@ const App = {
 
 ```
 
-Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.
+Notably, fields come in different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.
 
 | Type | Behavior |
 |------|----------|

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1045,13 +1045,13 @@ In cases where Zapier needs to show an example record to the user, but we are un
 
 ## Input Fields
 
-On each trigger, search, or create in the `operation` directive - you can provide an array of objects as fields under the `inputFields`. Input Fields are what your users would see in the main Zapier user interface. For example, you might have a "Create Contact" action with fields like "First name", "Last name", "Email", etc. These fields will be able to accept input from previous steps in a Zap, for example:
+On each trigger, search, or create in the `operation` directive, you can provide fields as an array of objects under `inputFields`. Input Fields are what your users see in Zapier when setting up your app's triggers and actions. For example, you might have a "Create Contact" action with fields like "First name", "Last name", "Email", etc. These fields will be able to accept input from the user, or from previous steps in a Zap. For example:
 
 ![gif of setting up an action field in Zap Editor](https://cdn.zappy.app/52721a3cb202446b7c298e303b710471.gif)
 
-You can find more details about setting action fields from a user perspective in [our help documentation](https://zapier.com/help/creating-zap/#set-up-action-template).
+You can find more details about setting action fields from a user perspective in [our help documentation](https://zapier.com/help/creating-zap/).
 
-Those fields have various options you can provide, here is a succinct example:
+Those fields have various options you can provide. Here is a brief example:
 
 ```js
 const App = {
@@ -1081,6 +1081,21 @@ const App = {
 };
 
 ```
+
+Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.
+
+| Type | Behavior |
+|------|----------|
+| String | Accepts text input. |
+| Text | Displays large, <textarea>-style entry box, accepts text input. |
+| Code | Displays large, <textarea>-style box with a fixed-width font, accepts text input. |
+| Integer | Accepts integer number values. |
+| Number | Accepts any numeric value, including decimal numbers. |
+| Boolean | Displays dropdown menu offering true and false options. Passes along `true` or `false`.  |
+| Datetime | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
+| File | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
+| Password | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
+| Copy | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
 
 You can find more details on the different field schema options at [our Field Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#fieldschema).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1086,16 +1086,16 @@ Notably, fields come in different types, which may look and act differently in t
 
 | Type | Behavior |
 |------|----------|
-| String | Accepts text input. |
-| Text | Displays large, <textarea>-style entry box, accepts text input. |
-| Code | Displays large, <textarea>-style box with a fixed-width font, accepts text input. |
-| Integer | Accepts integer number values. |
-| Number | Accepts any numeric value, including decimal numbers. |
-| Boolean | Displays dropdown menu offering true and false options. Passes along `true` or `false`.  |
-| Datetime | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
-| File | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
-| Password | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
-| Copy | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
+| `string` | Accepts text input. |
+| `text` | Displays large, `<textarea>`-style entry box, accepts text input. |
+| `code` | Displays large, `<textarea>`-style box with a fixed-width font, accepts text input. |
+| `integer` | Accepts integer number values. |
+| `number` | Accepts any numeric value, including decimal numbers. |
+| `boolean` | Displays dropdown menu offering true and false options. Passes along `true` or `false`.  |
+| `datetime` | Accepts both [precise and human-readable date-time values](https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0). Passes along an ISO-formatted time string. |
+| `file` | Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated. |
+| `password` | Displays entered characters as hidden, accepts text input. Does not accept input from previous steps. |
+| `copy` | Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users. |
 
 You can find more details on the different field schema options at [our Field Schema](https://github.com/zapier/zapier-platform/blob/master/packages/schema/docs/build/schema.md#fieldschema).
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1975,7 +1975,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.</p>
+      <p>Notably, fields come in different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1940,7 +1940,7 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>On each trigger, search, or create in the <code>operation</code> directive - you can provide an array of objects as fields under the <code>inputFields</code>. Input Fields are what your users would see in the main Zapier user interface. For example, you might have a &quot;Create Contact&quot; action with fields like &quot;First name&quot;, &quot;Last name&quot;, &quot;Email&quot;, etc. These fields will be able to accept input from previous steps in a Zap, for example:</p><p><img src="https://cdn.zappy.app/52721a3cb202446b7c298e303b710471.gif" alt="gif of setting up an action field in Zap Editor"></p><p>You can find more details about setting action fields from a user perspective in <a href="https://zapier.com/help/creating-zap/#set-up-action-template">our help documentation</a>.</p><p>Those fields have various options you can provide, here is a succinct example:</p>
+      <p>On each trigger, search, or create in the <code>operation</code> directive, you can provide fields as an array of objects under <code>inputFields</code>. Input Fields are what your users see in Zapier when setting up your app&apos;s triggers and actions. For example, you might have a &quot;Create Contact&quot; action with fields like &quot;First name&quot;, &quot;Last name&quot;, &quot;Email&quot;, etc. These fields will be able to accept input from the user, or from previous steps in a Zap. For example:</p><p><img src="https://cdn.zappy.app/52721a3cb202446b7c298e303b710471.gif" alt="gif of setting up an action field in Zap Editor"></p><p>You can find more details about setting action fields from a user perspective in <a href="https://zapier.com/help/creating-zap/">our help documentation</a>.</p><p>Those fields have various options you can provide. Here is a brief example:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {
@@ -1970,6 +1970,73 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 };
 
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Notably, fields come in several different types, which may look and act differently in the Zap editor. The default field display is a single-line input field.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <table>
+<thead>
+<tr>
+<th>Type</th>
+<th>Behavior</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>String</td>
+<td>Accepts text input.</td>
+</tr>
+<tr>
+<td>Text</td>
+<td>Displays large, <textarea>-style entry box, accepts text input.</textarea></td>
+</tr>
+<tr>
+<td>Code</td>
+<td>Displays large, <textarea>-style box with a fixed-width font, accepts text input.</textarea></td>
+</tr>
+<tr>
+<td>Integer</td>
+<td>Accepts integer number values.</td>
+</tr>
+<tr>
+<td>Number</td>
+<td>Accepts any numeric value, including decimal numbers.</td>
+</tr>
+<tr>
+<td>Boolean</td>
+<td>Displays dropdown menu offering true and false options. Passes along <code>true</code> or <code>false</code>.</td>
+</tr>
+<tr>
+<td>Datetime</td>
+<td>Accepts both <a href="https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0">precise and human-readable date-time values</a>. Passes along an ISO-formatted time string.</td>
+</tr>
+<tr>
+<td>File</td>
+<td>Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated.</td>
+</tr>
+<tr>
+<td>Password</td>
+<td>Displays entered characters as hidden, accepts text input. Does not accept input from previous steps.</td>
+</tr>
+<tr>
+<td>Copy</td>
+<td>Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users.</td>
+</tr>
+</tbody>
+</table>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1993,43 +1993,43 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </thead>
 <tbody>
 <tr>
-<td>String</td>
+<td><code>string</code></td>
 <td>Accepts text input.</td>
 </tr>
 <tr>
-<td>Text</td>
-<td>Displays large, <textarea>-style entry box, accepts text input.</textarea></td>
+<td><code>text</code></td>
+<td>Displays large, <code>&lt;textarea&gt;</code>-style entry box, accepts text input.</td>
 </tr>
 <tr>
-<td>Code</td>
-<td>Displays large, <textarea>-style box with a fixed-width font, accepts text input.</textarea></td>
+<td><code>code</code></td>
+<td>Displays large, <code>&lt;textarea&gt;</code>-style box with a fixed-width font, accepts text input.</td>
 </tr>
 <tr>
-<td>Integer</td>
+<td><code>integer</code></td>
 <td>Accepts integer number values.</td>
 </tr>
 <tr>
-<td>Number</td>
+<td><code>number</code></td>
 <td>Accepts any numeric value, including decimal numbers.</td>
 </tr>
 <tr>
-<td>Boolean</td>
+<td><code>boolean</code></td>
 <td>Displays dropdown menu offering true and false options. Passes along <code>true</code> or <code>false</code>.</td>
 </tr>
 <tr>
-<td>Datetime</td>
+<td><code>datetime</code></td>
 <td>Accepts both <a href="https://help.zapier.com/hc/en-us/articles/8496259603341-Different-field-types-in-Zaps#date-time-fields-0-0">precise and human-readable date-time values</a>. Passes along an ISO-formatted time string.</td>
 </tr>
 <tr>
-<td>File</td>
+<td><code>file</code></td>
 <td>Accepts a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a text file will be generated.</td>
 </tr>
 <tr>
-<td>Password</td>
+<td><code>password</code></td>
 <td>Displays entered characters as hidden, accepts text input. Does not accept input from previous steps.</td>
 </tr>
 <tr>
-<td>Copy</td>
+<td><code>copy</code></td>
 <td>Does not allow users enter data. Shows the value of the Markdown-formatted Help Text for the field as a rich text note in the Zap editor. Good for important notices to users.</td>
 </tr>
 </tbody>


### PR DESCRIPTION
The original goal of this work was to add information about the Copy field type (which we don't touch on in the current version). 

However, there wasn't much detail on field types in the CLI README at all. The schema had some information, but adding more details would probably make it unwieldy, so I thought it might be most helpful to update the README with a longer table about field types.

As the topic of type coercion in fields can be complex, I elected not to get into it too much, only covering some extreme basics.