### PR TITLE
PDE-2828 docs: fix typo in README-source.md

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -733,7 +733,7 @@ zapier login
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer accont here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
+<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer account here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
 </blockquote><p>Your Zapier CLI should be installed and ready to go at this point. Next up, we&apos;ll create our first app!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1629,7 +1629,7 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code> have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for the connection.</p><p>Also, <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p>
+      <p>For OAuth2, <code>authentication.oauth2Config.authorizeUrl</code>, <code>authentication.oauth2Config.getAccessToken</code>, and <code>authentication.oauth2Config.refreshAccessToken</code> have fields like <code>redirect_uri</code> and <code>state</code> in <code>bundle.inputData</code>. After the code is exchanged for an access token and/or refresh token, those tokens are stored in <code>bundle.authData</code> for the connection.</p><p>Also, <code>authentication.oauth2Config.getAccessToken</code> has access to the additional return values in <code>rawRequest</code> and <code>cleanedRequest</code> should you need to extract other values (for example, from the query string).</p><p>If you define <code>fields</code> to collect additional details from the user, please note that <code>client_id</code> and <code>client_secret</code> are reserved keys and cannot be used as keys for input form fields.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -96,7 +96,7 @@ npm install -g zapier-platform-cli
 # setup auth to Zapier's platform with a deploy key
 zapier login
 ```
-> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer accont here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
+> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
 
 Your Zapier CLI should be installed and ready to go at this point. Next up, we'll create our first app!
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -733,7 +733,7 @@ zapier login
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer accont here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
+<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer account here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
 </blockquote><p>Your Zapier CLI should be installed and ready to go at this point. Next up, we&apos;ll create our first app!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

#592 only fixed the auto generated README.md. This PR copies the fix to README-source.md.