### PR TITLE
PDE-3635 docs (cli): Fix custom-auth template command

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1244,7 +1244,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
-<p>To create a new integration with custom authentication, run <code>zapier init [your app name] --custom-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
+<p>To create a new integration with custom authentication, run <code>zapier init [your app name] --template custom-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -340,7 +340,7 @@ The setup and user experience of Digest Auth is identical to Basic Auth. Users p
 
 Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
-> To create a new integration with custom authentication, run `zapier init [your app name] --custom-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
+> To create a new integration with custom authentication, run `zapier init [your app name] --template custom-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
 
 ```js
 [insert-file:./snippets/custom-auth.js]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -518,7 +518,7 @@ const App = {
 
 Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You'll likely provide some custom `beforeRequest` middleware or a `requestTemplate` (see [Making HTTP Requests](#making-http-requests)) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.
 
-> To create a new integration with custom authentication, run `zapier init [your app name] --custom-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
+> To create a new integration with custom authentication, run `zapier init [your app name] --template custom-auth`. You can also review an example of that code [here](https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth).
 
 ```js
 const authentication = {

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1244,7 +1244,7 @@ zapier convert 1234 --version 1.0.1 my-app
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <p>Custom auth is most commonly used for apps that authenticate with API keys, although it also provides flexibility for any unusual authentication setup. You&apos;ll likely provide some custom <code>beforeRequest</code> middleware or a <code>requestTemplate</code> (see <a href="#making-http-requests">Making HTTP Requests</a>) to pass in data returned from the authentication process, most commonly by adding/computing needed headers.</p><blockquote>
-<p>To create a new integration with custom authentication, run <code>zapier init [your app name] --custom-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
+<p>To create a new integration with custom authentication, run <code>zapier init [your app name] --template custom-auth</code>. You can also review an example of that code <a href="https://github.com/zapier/zapier-platform/tree/master/example-apps/custom-auth">here</a>.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">


### PR DESCRIPTION
Changed every `zapier init [your app name] --custom-auth` (doesn't work) to `zapier init [your app name] --template custom-auth` (works)


See example below:

![Screen Shot 2022-12-02 at 10 20 49 AM](https://user-images.githubusercontent.com/10837036/205350051-c5358c88-df2f-4f8a-9cf3-71f01a47d887.png)
