### PR TITLE
PDE-3685 chore(cli): upgrade typescript to fix a test

### DIFF
--- a/example-apps/typescript/package.json
+++ b/example-apps/typescript/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^25.2.1",
     "@types/node": "^13.13.5",
     "rimraf": "^3.0.2",
-    "typescript": "^3.8.3"
+    "typescript": "^4.9.4"
   },
   "private": true
 }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

The `should list only required file` test is [failing](https://github.com/zapier/zapier-platform/actions/runs/3676205062/jobs/6216561636#step:5:152):

```
  76 passing (20s)
  2 pending
  1 failing

  1) build (runs slowly)
       "before all" hook for "should list only required files":
     Error: npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1670851568773-0.5350270081264845/node but npm is using /opt/hostedtoolcache/node/12.22.12/x64/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1670851568773-0.5350270081264845/node but npm is using /opt/hostedtoolcache/node/12.22.12/x64/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! typescript@1.0.0 build: `npm run clean && tsc`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the typescript@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-12-12T13_26_28_916Z-debug.log

      at runCommand (src/tests/_helpers.js:13:11)
      at Context.<anonymous> (src/tests/utils/build.js:35:5)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

The test depends on the [typescript](https://github.com/zapier/zapier-platform/tree/f3ffcdbdbf19ab6c3fc92ae14f5f1d7b2bae6edf/example-apps/typescript) example app, which used typescript 3.9. Upgrading it to the latest version 4.9 fixes the issue, but I didn't spend much time finding out why.