### PR TITLE
PDE-3680 feat(schema): dynamic field support for upsert

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -1757,7 +1757,7 @@ Key | Required | Type | Description
 `create` | **yes** | [/KeySchema](#keyschema) | The key of the create that powers this search-or-create
 `update` | no | [/KeySchema](#keyschema) | EXPERIMENTAL: The key of the update action (in `creates`) that will be used if a search succeeds.
 `updateInputFromSearchOutput` | no | [/FlatObjectSchema](#flatobjectschema) | EXPERIMENTAL: A mapping where the key represents the input field for the update action, and the value represents the field from the search action's output that should be mapped to the update action's input field.
-`searchUniqueInputToOutputConstraint` | no | [/FlatObjectSchema](#flatobjectschema) | EXPERIMENTAL: A mapping where the key represents an input field for the search action, and the value represents how that field's value will be used to filter down the search output for an exact match.
+`searchUniqueInputToOutputConstraint` | no | `object` | EXPERIMENTAL: A mapping where the key represents an input field for the search action, and the value represents how that field's value will be used to filter down the search output for an exact match.
 
 #### Examples
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -1334,7 +1334,7 @@
         },
         "searchUniqueInputToOutputConstraint": {
           "description": "EXPERIMENTAL: A mapping where the key represents an input field for the search action, and the value represents how that field's value will be used to filter down the search output for an exact match.",
-          "$ref": "/FlatObjectSchema"
+          "type": "object"
         }
       },
       "additionalProperties": false

--- a/packages/schema/lib/functional-constraints/searchOrCreateKeys.js
+++ b/packages/schema/lib/functional-constraints/searchOrCreateKeys.js
@@ -185,6 +185,7 @@ const validateSearchOrCreateKeys = (definition) => {
           );
         }
 
+        debugger;
         if (
           (hasSearchOutputFields || hasSearchOutputSample) &&
           !allSearchOutputKeys.has(searchOutputField)
@@ -232,6 +233,7 @@ const validateSearchOrCreateKeys = (definition) => {
 
         if (
           (hasSearchOutputFields || hasSearchOutputSample) &&
+          typeof searchOutputField === 'string' &&
           !allSearchOutputKeys.has(searchOutputField)
         ) {
           errors.push(

--- a/packages/schema/lib/functional-constraints/searchOrCreateKeys.js
+++ b/packages/schema/lib/functional-constraints/searchOrCreateKeys.js
@@ -185,7 +185,6 @@ const validateSearchOrCreateKeys = (definition) => {
           );
         }
 
-        debugger;
         if (
           (hasSearchOutputFields || hasSearchOutputSample) &&
           !allSearchOutputKeys.has(searchOutputField)

--- a/packages/schema/lib/schemas/SearchOrCreateSchema.js
+++ b/packages/schema/lib/schemas/SearchOrCreateSchema.js
@@ -45,7 +45,7 @@ module.exports = makeSchema(
       searchUniqueInputToOutputConstraint: {
         description:
           "EXPERIMENTAL: A mapping where the key represents an input field for the search action, and the value represents how that field's value will be used to filter down the search output for an exact match.",
-        $ref: FlatObjectSchema.id,
+        type: 'object',
       },
     },
     additionalProperties: false,

--- a/packages/schema/test/functional-constraints/searchOrCreateKeys.js
+++ b/packages/schema/test/functional-constraints/searchOrCreateKeys.js
@@ -1,59 +1,64 @@
 'use strict';
 
 require('should');
+const _ = require('lodash');
+
 const schema = require('../../schema');
 
 describe('searchOrCreateKeys', () => {
+  const baseDefinition = {
+    version: '1.0.0',
+    platformVersion: '1.0.0',
+
+    creates: {
+      add_product: {
+        key: 'add_product',
+        noun: 'Product',
+        display: {
+          label: 'Create Product',
+          description: 'Creates a new Product',
+        },
+        operation: {
+          perform: '$func$0$f$',
+          sample: { id: 1, title: 'Air Jordan' },
+        },
+      },
+
+      update_product: {
+        key: 'update_product',
+        noun: 'Product',
+        display: {
+          label: 'Update Product',
+          description: 'Updates an existing Product',
+        },
+        operation: {
+          perform: '$func$2$f$',
+          sample: { id: 1, title: 'Nike Dunk High Retro' },
+          inputFields: [{ key: 'product_id', type: 'string' }],
+        },
+      },
+    },
+
+    searches: {
+      find_product: {
+        key: 'find_product',
+        noun: 'Product',
+        display: {
+          label: 'Search Product',
+          description: 'Searches for an existing Product',
+        },
+        operation: {
+          perform: '$func$1$f$',
+          inputFields: [{ key: 'product_title', type: 'string' }],
+          sample: { id: 1, title: 'Nike Air' },
+        },
+      },
+    },
+  };
+
   it('should not error on properly defined searchesOrCreates', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -62,9 +67,7 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
         },
       },
@@ -76,55 +79,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should not error on properly defined searchesOrCreates with update key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            inputFields: [{ key: 'product_title' }],
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -133,17 +88,12 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           update: 'update_product',
-
           updateInputFromSearchOutput: {
             product_id: 'id',
           },
-
           searchUniqueInputToOutputConstraint: {
             product_title: 'title',
           },
@@ -157,54 +107,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should error if searchesAndCreates contains an unknown key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchAndCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -213,11 +116,8 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           test: 'wrong', // Unknown key
         },
       },
@@ -230,56 +130,9 @@ describe('searchOrCreateKeys', () => {
     );
   });
 
-  it('should error if searchOrCreate.key does not match a searches key', () => {
+  it('should error if searchOrCreate.key does not match a search key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'search_product', // Different key from any searches.key
@@ -288,9 +141,7 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
         },
       },
@@ -303,56 +154,9 @@ describe('searchOrCreateKeys', () => {
     );
   });
 
-  it('should error if searchOrCreate.key does not match a searches key', () => {
+  it('should error if searchAndCreate.key does not match a search key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchAndCreates: {
         findOrCreateProduct: {
           key: 'search_product', // Different key from any searches.key
@@ -361,9 +165,7 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
         },
       },
@@ -376,42 +178,9 @@ describe('searchOrCreateKeys', () => {
     );
   });
 
-  it('should error if searchesOrCreate.create key not matching an existing creates key', () => {
+  it('should error if searchesOrCreate.create key not matching an existing create key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -420,9 +189,7 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'create_product', // No such key in creates
         },
       },
@@ -431,46 +198,13 @@ describe('searchOrCreateKeys', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql(
-      'instance.searchOrCreates.findOrCreateProduct.create must match a "key" from a create (options: add_product)'
+      'instance.searchOrCreates.findOrCreateProduct.create must match a "key" from a create (options: add_product,update_product)'
     );
   });
 
-  it('should error if searchesAndCreate.create key not matching an existing creates key', () => {
+  it('should error if searchesAndCreate.create key not matching an existing create key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchAndCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -479,9 +213,7 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'create_product', // No such key in creates
         },
       },
@@ -490,60 +222,13 @@ describe('searchOrCreateKeys', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql(
-      'instance.searchAndCreates.findOrCreateProduct.create must match a "key" from a create (options: add_product)'
+      'instance.searchAndCreates.findOrCreateProduct.create must match a "key" from a create (options: add_product,update_product)'
     );
   });
 
-  it('should error if searchesOrCreate.update is defined and does not match a creates key', () => {
+  it('should error if searchesOrCreate.update is defined and does not match a create key', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -552,11 +237,8 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           update: 'create_product', // No such key in creates
         },
       },
@@ -571,41 +253,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should error if searchesOrCreate.updateInputFromSearchOutput is defined and but searchesOrCreate.update is not defined', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -614,11 +262,8 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           updateInputFromSearchOutput: {
             product_id: 'id',
           },
@@ -635,40 +280,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should error if searchesOrCreate.searchUniqueInputToOutputConstraint is defined and but searchesOrCreate.update is not defined', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -677,11 +289,8 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           searchUniqueInputToOutputConstraint: {
             product_title: 'title',
           },
@@ -698,54 +307,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should error if the searchOrCreate.updateInputFromSearchOutput object has a key not in creates.operations.inputFields', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_identity', type: 'string' }], // Mismatch key (should be product_id)
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -754,15 +316,11 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           update: 'update_product',
-
           updateInputFromSearchOutput: {
-            product_id: 'id',
+            productId: 'id',
           },
         },
       },
@@ -771,60 +329,13 @@ describe('searchOrCreateKeys', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql(
-      'instance.searchOrCreates.findOrCreateProduct.updateInputFromSearchOutput object key must match a "key" from a creates.update_product.operation.inputFields (options: product_identity)'
+      'instance.searchOrCreates.findOrCreateProduct.updateInputFromSearchOutput object key must match a "key" from a creates.update_product.operation.inputFields (options: product_id)'
     );
   });
 
   it('should error if the searchOrCreate.updateInputFromSearchOutput object has a value not in searches.operation.outputFields or searches.operation.sample, when these are defined', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { identity: 1, title: 'Nike Air' }, // Mismatched key ('identity' should be 'id')
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -833,15 +344,11 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           update: 'update_product',
-
           updateInputFromSearchOutput: {
-            product_id: 'id',
+            product_id: 'product_id',
           },
         },
       },
@@ -850,157 +357,53 @@ describe('searchOrCreateKeys', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql(
-      'instance.searchOrCreates.findOrCreateProduct.updateInputFromSearchOutput object value must match a "key" from searches.find_product.operation.(outputFields|sample) (options: product_title,identity,title)'
+      'instance.searchOrCreates.findOrCreateProduct.updateInputFromSearchOutput object value must match a "key" from searches.find_product.operation.(outputFields|sample) (options: id,title)'
     );
   });
 
   it('should not error if the searchOrCreate.updateInputFromSearchOutput object has a value but searches.operation.outputFields and searches.operation.sample are not defined', () => {
-    const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
+    const definition = _.cloneDeep(baseDefinition);
+    definition.searchOrCreates = {
+      findOrCreateProduct: {
+        key: 'find_product',
+        display: {
+          label: 'Search or Create',
+          description:
+            'Tries to fetch a product, creates one if it does not find at least one.',
         },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            // Does not contain outputFields or sample keys
-          },
-        },
-      },
-
-      searchOrCreates: {
-        findOrCreateProduct: {
-          key: 'find_product',
-          display: {
-            label: 'Search or Create',
-            description:
-              'Tries to fetch a product, creates one if it does not find at least one.',
-          },
-
-          search: 'find_product',
-
-          create: 'add_product',
-
-          update: 'update_product',
-
-          updateInputFromSearchOutput: {
-            product_id: 'id',
-          },
+        search: 'find_product',
+        create: 'add_product',
+        update: 'update_product',
+        updateInputFromSearchOutput: {
+          product_id: 'id',
         },
       },
     };
+    delete definition.searches.find_product.operation.sample;
 
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(0);
   });
 
   it('should error if the searchOrCreate.searchUniqueInputToOutputConstraint object has a key but searches.operations.inputFields is not defined', () => {
-    const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
+    const definition = _.cloneDeep(baseDefinition);
+    definition.searchOrCreates = {
+      findOrCreateProduct: {
+        key: 'find_product',
+        display: {
+          label: 'Search or Create',
+          description:
+            'Tries to fetch a product, creates one if it does not find at least one.',
         },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_identity', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-            // Does not contain any inputFields
-          },
-        },
-      },
-
-      searchOrCreates: {
-        findOrCreateProduct: {
-          key: 'find_product',
-          display: {
-            label: 'Search or Create',
-            description:
-              'Tries to fetch a product, creates one if it does not find at least one.',
-          },
-
-          search: 'find_product',
-
-          create: 'add_product',
-
-          update: 'update_product',
-
-          searchUniqueInputToOutputConstraint: {
-            product_title: 'title',
-          },
+        search: 'find_product',
+        create: 'add_product',
+        update: 'update_product',
+        searchUniqueInputToOutputConstraint: {
+          product_title: 'title',
         },
       },
     };
+    definition.searches.find_product.operation.inputFields = [];
 
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
@@ -1011,55 +414,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should error if the searchOrCreate.searchUniqueInputToOutputConstraint object has a key not in searches.operations.inputFields', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_identity', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { id: 1, title: 'Nike Air' },
-            inputFields: [{ key: 'product_title', type: 'string' }],
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -1068,15 +423,12 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           update: 'update_product',
-
           searchUniqueInputToOutputConstraint: {
-            title_of_product: 'title', // title_of_product does not exist in searches.operation.(outputFields.key|sample keys)
+            // title_of_product does not exist in searches.operation.(outputFields.key|sample keys)
+            title_of_product: 'title',
           },
         },
       },
@@ -1091,54 +443,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should error if the searchOrCreate.searchUniqueInputToOutputConstraint object has a value not in searches.operation.outputFields or searches.operation.sample, when these are defined', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
-        },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            outputFields: [{ key: 'product_title', type: 'string' }],
-            sample: { identity: 1, title: 'Nike Air' }, // Mismatched key ('identity' should be 'id')
-          },
-        },
-      },
-
+      ...baseDefinition,
       searchOrCreates: {
         findOrCreateProduct: {
           key: 'find_product',
@@ -1147,15 +452,11 @@ describe('searchOrCreateKeys', () => {
             description:
               'Tries to fetch a product, creates one if it does not find at least one.',
           },
-
           search: 'find_product',
-
           create: 'add_product',
-
           update: 'update_product',
-
-          updateInputFromSearchOutput: {
-            product_id: 'id',
+          searchUniqueInputToOutputConstraint: {
+            product_title: 'product_title',
           },
         },
       },
@@ -1164,80 +465,29 @@ describe('searchOrCreateKeys', () => {
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(1);
     results.errors[0].stack.should.eql(
-      'instance.searchOrCreates.findOrCreateProduct.updateInputFromSearchOutput object value must match a "key" from searches.find_product.operation.(outputFields|sample) (options: product_title,identity,title)'
+      'instance.searchOrCreates.findOrCreateProduct.searchUniqueInputToOutputConstraint object value must match a "key" from searches.find_product.operation.(outputFields|sample) (options: id,title)'
     );
   });
 
   it('should not error if the searchOrCreate.searchUniqueInputToOutputConstraint object has a value but searches.operation.outputFields and searches.operation.sample are not defined', () => {
-    const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new Product',
-          },
-          operation: {
-            perform: '$func$0$f$',
-            sample: { id: 1, title: 'Air Jordan' },
-          },
+    const definition = _.cloneDeep(baseDefinition);
+    definition.searchOrCreates = {
+      findOrCreateProduct: {
+        key: 'find_product',
+        display: {
+          label: 'Search or Create',
+          description:
+            'Tries to fetch a product, creates one if it does not find at least one.',
         },
-
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing Product',
-          },
-          operation: {
-            perform: '$func$2$f$',
-            sample: { id: 1, title: 'Nike Dunk High Retro' },
-            inputFields: [{ key: 'product_id', type: 'string' }],
-          },
-        },
-      },
-
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing Product',
-          },
-          operation: {
-            perform: '$func$1$f$',
-            // Does not contain outputFields or sample keys
-          },
-        },
-      },
-
-      searchOrCreates: {
-        findOrCreateProduct: {
-          key: 'find_product',
-          display: {
-            label: 'Search or Create',
-            description:
-              'Tries to fetch a product, creates one if it does not find at least one.',
-          },
-
-          search: 'find_product',
-
-          create: 'add_product',
-
-          update: 'update_product',
-
-          updateInputFromSearchOutput: {
-            product_id: 'id',
-          },
+        search: 'find_product',
+        create: 'add_product',
+        update: 'update_product',
+        searchUniqueInputToOutputConstraint: {
+          product_title: 'product_title',
         },
       },
     };
+    delete definition.searches.find_product.operation.sample;
 
     const results = schema.validateAppDefinition(definition);
     results.errors.should.have.length(0);
@@ -1245,39 +495,7 @@ describe('searchOrCreateKeys', () => {
 
   it('should only give type errors if searchOrCreate.updateInputFromSearchOutput and searchOrCreate.searchUniqueInputToOutputConstraint are not objects', () => {
     const definition = {
-      version: '1.0.0',
-      platformVersion: '1.0.0',
-      creates: {
-        add_product: {
-          key: 'add_product',
-          noun: 'Product',
-          display: {
-            label: 'Create Product',
-            description: 'Creates a new product.',
-          },
-          operation: { perform: '$func$2$f$' },
-        },
-        update_product: {
-          key: 'update_product',
-          noun: 'Product',
-          display: {
-            label: 'Update Product',
-            description: 'Updates an existing product.',
-          },
-          operation: { perform: '$func$2$f$' },
-        },
-      },
-      searches: {
-        find_product: {
-          key: 'find_product',
-          noun: 'Product',
-          display: {
-            label: 'Search Product',
-            description: 'Searches for an existing product.',
-          },
-          operation: { perform: '$func$2$f$' },
-        },
-      },
+      ...baseDefinition,
       searchOrCreates: {
         find_product: {
           key: 'find_product',
@@ -1305,5 +523,31 @@ describe('searchOrCreateKeys', () => {
     results.errors[1].stack.should.eql(
       'instance.searchOrCreates.find_product.searchUniqueInputToOutputConstraint is not of a type(s) object'
     );
+  });
+
+  it('should skip searchUniqueInputToOutputConstraint value check if it is nested', () => {
+    const definition = {
+      ...baseDefinition,
+      searchOrCreates: {
+        find_product: {
+          key: 'find_product',
+          display: {
+            label: 'Find, Create, or Update Product',
+            description: 'Finds, creates, or updates a product.',
+          },
+          search: 'find_product',
+          create: 'add_product',
+          update: 'update_product',
+          searchUniqueInputToOutputConstraint: {
+            product_title: {
+              value_from_need: 'lookup_value',
+            },
+          },
+        },
+      },
+    };
+
+    const results = schema.validateAppDefinition(definition);
+    results.errors.should.have.length(0);
   });
 });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

**EXPERIMENTAL: This feature is still in internal testing and is subject to change. Don't use it yet unless you're a Zapier employee.**

Before this PR, `searchUniqueInputToOutputConstraint` only allows string-to-string mapping. Now with this change, it can be nested to support dynamic fields. For example:

```js
const App = {
  creates: {
    add_row: { /* ... */ },
    update_row: { /* ... */ },
  },
  searches: {
    find_row: {
      // ...
      operation: {
        inputFields: [
          { key: 'lookup_key' },
          { key: 'lookup_value' },
          // ...
          getCustomFields,  // a function to get custom fields
        ]
      }
    },
  },
  searchOrCreates: {
    find_row: {
      key: 'find_row',
      display: {
        label: 'Find, Create, or Update Row',
        description: 'Finds, creates, or updates a row.',
      },
      search: 'find_row',
      create: 'add_row',
      update: 'update_row',
      searchUniqueInputToOutputConstraint: {
        lookup_key: {
          value_from_need: 'lookup_value',
        },
      },
    },
  },
};
```

Both `lookup_key` and `lookup_value` are static input fields of the `find_row` search. `value_from_need` is a keyword that Zapier recognizes and will do additional lookups to properly map dynamic fields.

For more context, see Jira epic [PDE-3679](https://zapierorg.atlassian.net/browse/PDE-3679).

I also fixed and refactored some test code while I was there.

[PDE-3679]: https://zapierorg.atlassian.net/browse/PDE-3679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ