### PR TITLE
PDE-3266: Fix logo in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -394,11 +394,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h1 align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png">
-    <img alt="Zapier Logo" src="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png" width="300px">
-  </picture>
+  <img alt="Zapier Logo" src="https://cdn.zappy.app/1cd66b15407db2d9a01fbe8d600772fe.svg" width="300px">
   <br>
   Platform CLI
   <br>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1,9 +1,5 @@
 <h1 align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.zappy.app/11069978ee4a9b1eeeeb62b11f541b7c.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png">
-    <img alt="Zapier Logo" src="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png" width="300px">
-  </picture>
+  <img alt="Zapier Logo" src="https://cdn.zappy.app/1cd66b15407db2d9a01fbe8d600772fe.svg" width="300px">
   <br>
   Platform CLI
   <br>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,11 +1,7 @@
 <!-- GENERATED! ONLY EDIT `README-source.md` -->
 
 <h1 align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.zappy.app/11069978ee4a9b1eeeeb62b11f541b7c.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png">
-    <img alt="Zapier Logo" src="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png" width="300px">
-  </picture>
+  <img alt="Zapier Logo" src="https://cdn.zappy.app/1cd66b15407db2d9a01fbe8d600772fe.svg" width="300px">
   <br>
   Platform CLI
   <br>

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -394,11 +394,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <h1 align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png">
-    <source media="(prefers-color-scheme: light)" srcset="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png">
-    <img alt="Zapier Logo" src="https://cdn.zappy.app/2602734341239f1b82ef0ff4ca160430.png" width="300px">
-  </picture>
+  <img alt="Zapier Logo" src="https://cdn.zappy.app/1cd66b15407db2d9a01fbe8d600772fe.svg" width="300px">
   <br>
   Platform CLI
   <br>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

GitHub's [light-dark color mode image](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) seems to stop working. Let's just use an opaque SVG logo so it looks good on both light and dark modes.

Before (broken image):
![](https://cdn.zappy.app/40662afe68efde175aad26a8d118f160.png)

After:
![](https://cdn.zappy.app/8461a633f7509b38efc335c34e7be436.png)
![](https://cdn.zappy.app/aaaedec0fa564b3bcbb7a518f0624796.png)