### PR TITLE
PDE-3731 feat(cli): Add getAppRegistrationFieldChoices hook

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,7 +99,8 @@
         "./src/oclif/hooks/deprecated",
         "./src/oclif/hooks/updateNotifier",
         "./src/oclif/hooks/checkValidNodeVersion",
-        "./src/oclif/hooks/renderMarkdownHelp"
+        "./src/oclif/hooks/renderMarkdownHelp",
+        "./src/oclif/hooks/getAppRegistrationFieldChoices"
       ]
     },
     "topics": {

--- a/packages/cli/src/oclif/hooks/getAppRegistrationFieldChoices.js
+++ b/packages/cli/src/oclif/hooks/getAppRegistrationFieldChoices.js
@@ -1,0 +1,17 @@
+const { callAPI } = require('../../utils/api');
+
+module.exports = async function (options) {
+  // We only need to run this for the register command
+  if (!options || !options.id || options.id !== 'register') {
+    return null;
+  }
+
+  const enumFieldChoices = {};
+  const formFields = await callAPI('/apps/fields-choices');
+
+  for (const fieldName of ['intention', 'role', 'app_category']) {
+    enumFieldChoices[fieldName] = formFields[fieldName];
+  }
+
+  this.config.enumFieldChoices = enumFieldChoices;
+};


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This PR introduces a new hook `getAppRegistrationFieldChoices` that triggers during oclif's `init` hook (see [docs](https://oclif.io/docs/hooks)). The goal of this hook is to get enum field choices from `/api/platform/cli/apps/fields-choices` and provide them to `RegisterCommand` for use with forthcoming flags/prompts. It should not run on other commands.

This PR has no noticeable effect on current functionality.