### PR TITLE
docs(cli): Fix 'integraiton' typo in CLI docs

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -380,7 +380,7 @@ a code {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Convert a Visual Builder integration to a CLI integration.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
+</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>The resulting CLI integration will be identical to its Visual Builder version and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>integrationId</code> | To get the integration/app ID, go to &quot;<a href="https://developer.zapier.com&quot;">https://developer.zapier.com&quot;</a>, click on an integration, and copy the number directly after &quot;/app/&quot; in the URL.</li>
 <li>(required) <code>path</code> | Relative to your current path - IE: <code>.</code> for current directory.</li>
 </ul><p><strong>Flags</strong></p><ul>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -59,7 +59,7 @@ This command is typically followed by `zapier upload`.
 
 **Usage**: `zapier convert INTEGRATIONID PATH`
 
-The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!
+The resulting CLI integration will be identical to its Visual Builder version and ready to push and use immediately!
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -380,7 +380,7 @@ a code {
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Convert a Visual Builder integration to a CLI integration.</p>
-</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
+</blockquote><p><strong>Usage</strong>: <code>zapier convert INTEGRATIONID PATH</code></p><p>The resulting CLI integration will be identical to its Visual Builder version and ready to push and use immediately!</p><p>If you re-run this command on an existing directory it will leave existing files alone and not clobber them.</p><p>You&apos;ll need to do a <code>zapier push</code> before the new version is visible in the editor, but otherwise you&apos;re good to go.</p><p><strong>Arguments</strong></p><ul>
 <li>(required) <code>integrationId</code> | To get the integration/app ID, go to &quot;<a href="https://developer.zapier.com&quot;">https://developer.zapier.com&quot;</a>, click on an integration, and copy the number directly after &quot;/app/&quot; in the URL.</li>
 <li>(required) <code>path</code> | Relative to your current path - IE: <code>.</code> for current directory.</li>
 </ul><p><strong>Flags</strong></p><ul>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -59,7 +59,7 @@ This command is typically followed by `zapier upload`.
 
 **Usage**: `zapier convert INTEGRATIONID PATH`
 
-The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!
+The resulting CLI integration will be identical to its Visual Builder version and ready to push and use immediately!
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 

--- a/packages/cli/src/oclif/commands/convert.js
+++ b/packages/cli/src/oclif/commands/convert.js
@@ -86,7 +86,7 @@ ConvertCommand.flags = buildFlags({
 });
 ConvertCommand.description = `Convert a Visual Builder integration to a CLI integration.
 
-The resulting CLI integraiton will be identical to its Visual Builder version and ready to push and use immediately!
+The resulting CLI integration will be identical to its Visual Builder version and ready to push and use immediately!
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 


### PR DESCRIPTION
Spotted by @standielpls over at https://github.com/zapier/visual-builder/pull/401#discussion_r1087123753