### PR TITLE
PDE-3242 - feat(schema) Add enablePkce to OAuth2Config

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -257,6 +257,7 @@ Key | Required | Type | Description
 `codeParam` | no | `string` | Define a non-standard code param Zapier should scrape instead.
 `scope` | no | `string` | What scope should Zapier request?
 `autoRefresh` | no | `boolean` | Should Zapier invoke `refreshAccessToken` when we receive an error for a 401 response?
+`enablePkce` | no | `boolean` | Should Zapier use PKCE for OAuth2?
 
 #### Examples
 
@@ -273,7 +274,8 @@ Key | Required | Type | Description
     refreshAccessToken: { require: 'some/path/to/file3.js' },
     codeParam: 'unique_code',
     scope: 'read/write',
-    autoRefresh: true
+    autoRefresh: true,
+    enablePkce: true
   }
   ```
 

--- a/packages/schema/examples/definition.json
+++ b/packages/schema/examples/definition.json
@@ -31,7 +31,8 @@
         "method": "POST"
       },
       "scope": "tags,users,contacts",
-      "autoRefresh": false
+      "autoRefresh": false,
+      "enablePkce": false
     },
     "connectionLabel": "{{inputData.email}}"
   },

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -550,6 +550,10 @@
         "autoRefresh": {
           "description": "Should Zapier invoke `refreshAccessToken` when we receive an error for a 401 response?",
           "type": "boolean"
+        },
+        "enablePkce": {
+          "description": "Should Zapier use PKCE for OAuth2?",
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/packages/schema/lib/schemas/AuthenticationOAuth2ConfigSchema.js
+++ b/packages/schema/lib/schemas/AuthenticationOAuth2ConfigSchema.js
@@ -44,6 +44,10 @@ module.exports = makeSchema(
           'Should Zapier invoke `refreshAccessToken` when we receive an error for a 401 response?',
         type: 'boolean',
       },
+      enablePkce: {
+        description: 'Should Zapier use PKCE for OAuth2?',
+        type: 'boolean',
+      },
     },
     additionalProperties: false,
     examples: [
@@ -58,6 +62,7 @@ module.exports = makeSchema(
         codeParam: 'unique_code',
         scope: 'read/write',
         autoRefresh: true,
+        enablePkce: true,
       },
     ],
     antiExamples: [


### PR DESCRIPTION
Adds a new option to the OAuth2Config: `enablePkce`. 
This option will be read by the Zapier Platform backend to use PKCE for the authorization/access token exchange request flow. If this option is not provided, it will default to use the existing OAuth2 flow. 