### PR TITLE
PDE-3822 feat(cli): Only require fields for private integrations via CLI

### DIFF
--- a/packages/cli/src/oclif/commands/register.js
+++ b/packages/cli/src/oclif/commands/register.js
@@ -132,6 +132,13 @@ class RegisterCommand extends ZapierBaseCommand {
       this.startSpinner('Retrieving details for your integration');
       this.app = await getWritableApp();
       this.stopSpinner();
+
+      // Block non-private apps from updating settings
+      if (this.app?.intention !== 'private') {
+        throw new Error(
+          "You can't edit settings for this integration. To edit your integration details on Zapier's public app directory, email partners@zapier.com."
+        );
+      }
     }
 
     appMeta.title = this.args.title?.trim();

--- a/packages/cli/src/oclif/commands/register.js
+++ b/packages/cli/src/oclif/commands/register.js
@@ -8,6 +8,7 @@ const {
   callAPI,
   getLinkedAppConfig,
   getWritableApp,
+  isPublished,
   writeLinkedAppConfig,
 } = require('../../utils/api');
 
@@ -133,8 +134,8 @@ class RegisterCommand extends ZapierBaseCommand {
       this.app = await getWritableApp();
       this.stopSpinner();
 
-      // Block non-private apps from updating settings
-      if (this.app?.intention !== 'private') {
+      // Block published apps from updating settings
+      if (this.app?.status && isPublished(this.app.status)) {
         throw new Error(
           "You can't edit settings for this integration. To edit your integration details on Zapier's public app directory, email partners@zapier.com."
         );

--- a/packages/cli/src/tests/fixtures/createApp.js
+++ b/packages/cli/src/tests/fixtures/createApp.js
@@ -1,4 +1,4 @@
-module.exports = {
+const privateApp = {
   id: 123456,
   public: false,
   pending: false,
@@ -20,4 +20,33 @@ module.exports = {
   slug: null,
   allowed_self_signup_domains: null,
   self_signup_allowed: true,
+};
+
+const publicApp = {
+  id: 123456,
+  public: false,
+  pending: false,
+  public_ish: false,
+  status: 'global',
+  date: '2023-02-14T16:35:44+00:00',
+  title: 'My Cool Integration',
+  description:
+    'My Cool Integration helps you integrate your apps with the apps that you need.',
+  image: null,
+  key: 'App123456',
+  invite_url:
+    'https://zapier.com/developer/public-invite/123456/770200a3a7bd09e405979c2ce54bb181/',
+  intention: 'private',
+  homepage_url: 'https://www.zapier.com',
+  app_category: 'marketing-automation',
+  app_category_other: '',
+  role: 'employee',
+  slug: null,
+  allowed_self_signup_domains: null,
+  self_signup_allowed: true,
+};
+
+module.exports = {
+  privateApp,
+  publicApp,
 };

--- a/packages/cli/src/tests/fixtures/createApp.js
+++ b/packages/cli/src/tests/fixtures/createApp.js
@@ -27,7 +27,7 @@ const publicApp = {
   public: false,
   pending: false,
   public_ish: false,
-  status: 'global',
+  status: 'public',
   date: '2023-02-14T16:35:44+00:00',
   title: 'My Cool Integration',
   description:

--- a/packages/cli/src/tests/register.test.js
+++ b/packages/cli/src/tests/register.test.js
@@ -123,6 +123,7 @@ describe('RegisterCommand', () => {
             role: 'contractor',
             app_category: 'productivity',
           })
+          .optionally()
           .reply(201, exportedApp)
       );
     }
@@ -153,6 +154,8 @@ describe('RegisterCommand', () => {
       .it('zapier register --yes should update an app without prompts');
 
     getTestObj(true)
+      .stdout()
+      .stderr()
       .command([
         'register',
         'Hello',
@@ -168,6 +171,13 @@ describe('RegisterCommand', () => {
         'productivity',
         '--yes',
       ])
+      .catch((ctx) => {
+        oclif
+          .expect(ctx.message)
+          .to.contain(
+            "You can't edit settings for this integration. To edit your integration details on Zapier's public app directory, email partners@zapier.com."
+          );
+      })
       .it(
         'zapier register should not allow a user to update a pre-existing public app'
       );

--- a/packages/cli/src/tests/utils/api.js
+++ b/packages/cli/src/tests/utils/api.js
@@ -117,4 +117,18 @@ describe('api', () => {
       nock.restore();
     });
   });
+
+  describe('isPublished', () => {
+    it('should return false for a private app', () => {
+      should(api.isPublished('private')).false();
+    });
+
+    it('should return true for a public app', () => {
+      should(api.isPublished('public')).true();
+    });
+
+    it('should return true for a beta app', () => {
+      should(api.isPublished('beta')).true();
+    });
+  });
 });

--- a/packages/cli/src/tests/utils/check-missing-app-info.js
+++ b/packages/cli/src/tests/utils/check-missing-app-info.js
@@ -5,6 +5,7 @@ describe('check missing required app info', () => {
   it('should raise an error when one or more required app info are missing', () => {
     const app = {
       id: 123,
+      status: 'private',
       public: false,
       pending: false,
       title: 'Test App',
@@ -32,10 +33,25 @@ describe('check missing required app info', () => {
     };
     checkMissingAppInfo(app).should.equal(false);
   });
-  it('should return false when an app is public (app.intention == `global`)', () => {
+  it('should return false when an app is public', () => {
     const app = {
       id: 123,
       public: false,
+      status: 'public',
+      pending: false,
+      title: 'Test App',
+      key: 'App123',
+      intention: 'global',
+      app_category: 'crm',
+      role: 'user',
+    };
+    checkMissingAppInfo(app).should.equal(false);
+  });
+  it('should return false when an app is beta', () => {
+    const app = {
+      id: 123,
+      public: false,
+      status: 'beta',
       pending: false,
       title: 'Test App',
       key: 'App123',

--- a/packages/cli/src/tests/utils/check-missing-app-info.js
+++ b/packages/cli/src/tests/utils/check-missing-app-info.js
@@ -12,7 +12,11 @@ describe('check missing required app info', () => {
       key: 'App123',
       app_category: 'crm',
     };
-    should(() => checkMissingAppInfo(app)).throw(new Error(`Your integration is missing required info (intention, role). Please, run "zapier register" to add it.`));
+    should(() => checkMissingAppInfo(app)).throw(
+      new Error(
+        `Your integration is missing required info (intention, role). Please, run "zapier register" to add it.`
+      )
+    );
   });
   it('should return false when all the required app info are set', () => {
     const app = {
@@ -23,6 +27,19 @@ describe('check missing required app info', () => {
       description: 'Sample description',
       key: 'App123',
       intention: 'private',
+      app_category: 'crm',
+      role: 'user',
+    };
+    checkMissingAppInfo(app).should.equal(false);
+  });
+  it('should return false when an app is public (app.intention == `global`)', () => {
+    const app = {
+      id: 123,
+      public: false,
+      pending: false,
+      title: 'Test App',
+      key: 'App123',
+      intention: 'global',
       app_category: 'crm',
       role: 'user',
     };

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -265,6 +265,12 @@ const getVersionInfo = () => {
   });
 };
 
+// Intended to match logic of https://gitlab.com/zapier/team-developer-platform/dev-platform/-/blob/9fa28d8bacd04ebdad5937bd039c71aede4ede47/web/frontend/assets/app/entities/CliApp/CliApp.ts#L96
+const isPublished = (appStatus) => {
+  const publishedStatuses = ['public', 'beta'];
+  return publishedStatuses.indexOf(appStatus) > -1;
+};
+
 const listApps = async () => {
   let linkedApp;
   try {
@@ -405,6 +411,7 @@ module.exports = {
   getLinkedAppConfig,
   getWritableApp,
   getVersionInfo,
+  isPublished,
   listApps,
   listEndpoint,
   listEndpointMulti,

--- a/packages/cli/src/utils/check-missing-app-info.js
+++ b/packages/cli/src/utils/check-missing-app-info.js
@@ -1,5 +1,7 @@
+const { isPublished } = require('../utils/api');
+
 module.exports = (app) => {
-  if (app.intention && app.intention !== 'private') {
+  if (app.status && isPublished(app.status)) {
     return false;
   }
   const requiredFields = [

--- a/packages/cli/src/utils/check-missing-app-info.js
+++ b/packages/cli/src/utils/check-missing-app-info.js
@@ -1,9 +1,22 @@
 module.exports = (app) => {
-  const requiredFields = ['title', 'description', 'app_category', 'intention', 'role'];
-  const missingRequiredFields = requiredFields.filter(field => app[field] == null);
+  if (app.intention && app.intention !== 'private') {
+    return false;
+  }
+  const requiredFields = [
+    'title',
+    'description',
+    'app_category',
+    'intention',
+    'role',
+  ];
+  const missingRequiredFields = requiredFields.filter(
+    (field) => app[field] == null
+  );
   if (missingRequiredFields.length) {
     throw new Error(
-      `Your integration is missing required info (${missingRequiredFields.join(', ')}). Please, run "zapier register" to add it.`
+      `Your integration is missing required info (${missingRequiredFields.join(
+        ', '
+      )}). Please, run "zapier register" to add it.`
     );
   }
 


### PR DESCRIPTION
Currently, app meta fields/settings are only editable for private apps in the visual builder. Now that the CLI allows users to update these settings via CLI, we need to ensure that they can only update these settings for **private** apps.

[Jira story](https://zapierorg.atlassian.net/browse/PDE-3822)