### PR TITLE
PDE-3664 feat(cli): Use uniform field names in check-missing-app-info util

### DIFF
--- a/packages/cli/src/tests/utils/check-missing-app-info.js
+++ b/packages/cli/src/tests/utils/check-missing-app-info.js
@@ -11,11 +11,10 @@ describe('check missing required app info', () => {
       title: 'Test App',
       description: 'Sample description',
       key: 'App123',
-      app_category: 'crm',
     };
     should(() => checkMissingAppInfo(app)).throw(
       new Error(
-        `Your integration is missing required info (intention, role). Please, run "zapier register" to add it.`
+        `Your integration is missing required info (category, audience, role). Please, run "zapier register" to add it.`
       )
     );
   });

--- a/packages/cli/src/utils/check-missing-app-info.js
+++ b/packages/cli/src/utils/check-missing-app-info.js
@@ -5,20 +5,20 @@ module.exports = (app) => {
     return false;
   }
   const requiredFields = [
-    'title',
-    'description',
-    'app_category',
-    'intention',
-    'role',
+    { apiName: 'title' },
+    { apiName: 'description' },
+    { apiName: 'app_category', cliName: 'category' },
+    { apiName: 'intention', cliName: 'audience' },
+    { apiName: 'role' },
   ];
   const missingRequiredFields = requiredFields.filter(
-    (field) => app[field] == null
+    (field) => app[field.apiName] == null
   );
   if (missingRequiredFields.length) {
     throw new Error(
-      `Your integration is missing required info (${missingRequiredFields.join(
-        ', '
-      )}). Please, run "zapier register" to add it.`
+      `Your integration is missing required info (${missingRequiredFields
+        .map((field) => field.cliName ?? field.apiName)
+        .join(', ')}). Please, run "zapier register" to add it.`
     );
   }
 


### PR DESCRIPTION
Since the BE field names that the API is expecting do not match the names of the flags we're using in the CLI, we need to make sure we're using the proper name in the proper context. This commit ensures that we're using proper names in the CLI error message when check-missing-app-info fails.