### PR TITLE
fix(cli): Fix convert duplicating auth fields

### DIFF
--- a/packages/cli/src/tests/utils/convert.js
+++ b/packages/cli/src/tests/utils/convert.js
@@ -100,6 +100,23 @@ const visualAppDefinition = {
       params: {},
       method: 'GET',
     },
+    fields: [
+      {
+        key: 'access_token',
+        type: 'string',
+        required: true,
+      },
+      {
+        key: 'refresh_token',
+        type: 'string',
+        required: true,
+      },
+      {
+        key: 'custom_auth_field',
+        type: 'string',
+        required: false,
+      },
+    ],
     oauth2Config: {
       authorizeUrl: {
         url: 'https://app.wistia.com/oauth/authorize?client_id=03e84930b97011c7bd674f6d02c04ec9c1a430325a73a0501eb443ef07b6b99c&redirect_uri=https%3A%2F%2Fzapier.com%2Fdashboard%2Fauth%2Foauth%2Freturn%2FApp17741CLIAPI%2F&response_type=code',
@@ -298,9 +315,16 @@ describe('convert', () => {
       should(rcFile.id).eql(visualApp.id);
       should(rcFile.includeInBuild).be.undefined();
 
+      const countOccurrences = (str, search) => {
+        const regex = new RegExp(search, 'g');
+        return (str.match(regex) || []).length;
+      };
+
       const envFile = readTempFile('.env');
-      should(envFile.includes('ACCESS_TOKEN')).be.true();
-      should(envFile.includes('REFRESH_TOKEN')).be.true();
+      // prevent regression of duplicates when authentication.fields contains default fields
+      should(countOccurrences(envFile, 'ACCESS_TOKEN=')).be.equals(1);
+      should(countOccurrences(envFile, 'REFRESH_TOKEN=')).be.equals(1);
+      should(envFile.includes('CUSTOM_AUTH_FIELD')).be.true();
 
       const idxFile = readTempFile('index.js');
 

--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -72,30 +72,30 @@ const renderTemplate = async (
 
 const getAuthFieldKeys = (appDefinition) => {
   const authFields = _.get(appDefinition, 'authentication.fields') || [];
-  const fieldKeys = authFields.map((f) => f.key);
+  const fieldKeys = new Set(authFields.map((f) => f.key));
 
   const authType = _.get(appDefinition, 'authentication.type');
   switch (authType) {
     case 'basic': {
-      fieldKeys.push('username', 'password');
+      fieldKeys.add('username');
+      fieldKeys.add('password');
       break;
     }
     case 'oauth1':
-      fieldKeys.push('oauth_access_token');
+      fieldKeys.add('oauth_access_token');
       break;
     case 'oauth2':
-      fieldKeys.push('access_token', 'refresh_token');
+      fieldKeys.add('access_token');
+      fieldKeys.add('refresh_token');
       break;
     default:
-      fieldKeys.push(
-        'oauth_consumer_key',
-        'oauth_consumer_secret',
-        'oauth_token',
-        'oauth_token_secret'
-      );
+      fieldKeys.add('oauth_consumer_key');
+      fieldKeys.add('oauth_consumer_secret');
+      fieldKeys.add('oauth_token');
+      fieldKeys.add('oauth_token_secret');
       break;
   }
-  return fieldKeys;
+  return Array.from(fieldKeys);
 };
 
 const renderPackageJson = async (appInfo, appDefinition) => {


### PR DESCRIPTION
In `packages/cli/src/utils/convert.js` for `zapier convert` the function `getAuthFieldKeys` does not check if the default keys already exist in the user-defined `authentication.fields`, and therefor generates duplicates in e.g. `.env`.

This PR fixes that and updates a test against regressions.