### PR TITLE
fix(cli): Fix convert missing key in .zapierapprc file

### DIFF
--- a/packages/cli/src/tests/utils/convert.js
+++ b/packages/cli/src/tests/utils/convert.js
@@ -296,6 +296,7 @@ describe('convert', () => {
 
       const rcFile = JSON.parse(readTempFile('.zapierapprc'));
       should(rcFile.id).eql(visualApp.id);
+      should(rcFile.key).eql(visualApp.key);
       should(rcFile.includeInBuild).be.undefined();
 
       const envFile = readTempFile('.env');

--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -468,6 +468,9 @@ const writeZapierAppRc = async (appInfo, appDefinition, newAppDir) => {
   if (appInfo.id) {
     json.id = appInfo.id;
   }
+  if (appInfo.key) {
+    json.key = appInfo.key;
+  }
   if (appDefinition.legacy) {
     json.includeInBuild = ['scripting.js'];
   }


### PR DESCRIPTION
When you run `zapier convert`, the `.zapierapprc` file that it generates is missing the `key` property.

This PR fixes that, and includes a test to prevent regressions.