### PR TITLE
[SUPPORTENG-907] Update "Output Fields" section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2725,10 +2725,15 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the <code>outputFields</code>. Output Fields are what your users would see when they select a field provided by your trigger, search or create to map it to another.</p><p>Output Fields are optional, but can be used to:</p><ul>
+      <p>On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the <code>outputFields</code>. Output Fields are what users see when they select a field provided by your trigger, search or create to map it to another.</p><p>Output Fields are optional, but can be used to:</p><ul>
 <li>Define friendly labels for the returned fields. By default, we will <em>humanize</em> for example <code>my_key</code> as <em>My Key</em>.</li>
 <li>Make sure that custom fields that may not be found in every live sample and - since they&apos;re custom to the connected account - cannot be defined in the static sample, can still be mapped.</li>
-</ul><p>The <a href="https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema">schema</a> for <code>outputFields</code> is shared with <code>inputFields</code> but only the <code>key</code> and <code>required</code> properties are relevant.</p><p>Custom/Dynamic Output Fields are defined in the same way as <a href="#customdynamic-fields">Custom/Dynamic Input Fields</a>.</p>
+</ul><p>The <a href="https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema">schema</a> for <code>outputFields</code> is shared with <code>inputFields</code> but only the <code>key</code>, <code>label</code>, <code>type</code>, and <code>required</code> properties are relevant:</p><ul>
+<li><code>key</code> - includes the field when not present in the live sample. When no <code>label</code> property is provided, <code>key</code> will be <em>humanized</em> and displayed as the field name.</li>
+<li><code>label</code> - defines the field name displayed to users.</li>
+<li><code>type</code> - defines the type for static sample data. A <a href="https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition">validation warning</a> will be displayed if the static sample does not match the specified type.</li>
+<li><code>required</code> - defines whether the field is required in static sample data. A <a href="https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition">validation warning</a> will be displayed if the value is true and the static sample does not contain the field.</li>
+</ul><p>Custom/Dynamic Output Fields are defined in the same way as <a href="#customdynamic-fields">Custom/Dynamic Input Fields</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -770,14 +770,20 @@ When your action needs to accept an array of items, you can include an input fie
 
 ## Output Fields
 
-On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the `outputFields`. Output Fields are what your users would see when they select a field provided by your trigger, search or create to map it to another.
+On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the `outputFields`. Output Fields are what users see when they select a field provided by your trigger, search or create to map it to another.
 
 Output Fields are optional, but can be used to:
+
 
 - Define friendly labels for the returned fields. By default, we will *humanize* for example `my_key` as *My Key*.
 - Make sure that custom fields that may not be found in every live sample and - since they're custom to the connected account - cannot be defined in the static sample, can still be mapped.
 
-The [schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) for `outputFields` is shared with `inputFields` but only the `key` and `required` properties are relevant.
+The [schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) for `outputFields` is shared with `inputFields` but only the `key`, `label`, `type`, and `required` properties are relevant:
+
+- `key` - includes the field when not present in the live sample. When no `label` property is provided, `key` will be *humanized* and displayed as the field name.
+- `label` - defines the field name displayed to users.
+- `type` - defines the type for static sample data. A [validation warning](https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition) will be displayed if the static sample does not match the specified type.
+- `required` - defines whether the field is required in static sample data. A [validation warning](https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition) will be displayed if the value is true and the static sample does not contain the field.
 
 Custom/Dynamic Output Fields are defined in the same way as [Custom/Dynamic Input Fields](#customdynamic-fields).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1660,14 +1660,20 @@ const App = {
 
 ## Output Fields
 
-On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the `outputFields`. Output Fields are what your users would see when they select a field provided by your trigger, search or create to map it to another.
+On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the `outputFields`. Output Fields are what users see when they select a field provided by your trigger, search or create to map it to another.
 
 Output Fields are optional, but can be used to:
+
 
 - Define friendly labels for the returned fields. By default, we will *humanize* for example `my_key` as *My Key*.
 - Make sure that custom fields that may not be found in every live sample and - since they're custom to the connected account - cannot be defined in the static sample, can still be mapped.
 
-The [schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) for `outputFields` is shared with `inputFields` but only the `key` and `required` properties are relevant.
+The [schema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema) for `outputFields` is shared with `inputFields` but only the `key`, `label`, `type`, and `required` properties are relevant:
+
+- `key` - includes the field when not present in the live sample. When no `label` property is provided, `key` will be *humanized* and displayed as the field name.
+- `label` - defines the field name displayed to users.
+- `type` - defines the type for static sample data. A [validation warning](https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition) will be displayed if the static sample does not match the specified type.
+- `required` - defines whether the field is required in static sample data. A [validation warning](https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition) will be displayed if the value is true and the static sample does not contain the field.
 
 Custom/Dynamic Output Fields are defined in the same way as [Custom/Dynamic Input Fields](#customdynamic-fields).
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2725,10 +2725,15 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the <code>outputFields</code>. Output Fields are what your users would see when they select a field provided by your trigger, search or create to map it to another.</p><p>Output Fields are optional, but can be used to:</p><ul>
+      <p>On each trigger, search, or create in the operation directive - you can provide an array of objects as fields under the <code>outputFields</code>. Output Fields are what users see when they select a field provided by your trigger, search or create to map it to another.</p><p>Output Fields are optional, but can be used to:</p><ul>
 <li>Define friendly labels for the returned fields. By default, we will <em>humanize</em> for example <code>my_key</code> as <em>My Key</em>.</li>
 <li>Make sure that custom fields that may not be found in every live sample and - since they&apos;re custom to the connected account - cannot be defined in the static sample, can still be mapped.</li>
-</ul><p>The <a href="https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema">schema</a> for <code>outputFields</code> is shared with <code>inputFields</code> but only the <code>key</code> and <code>required</code> properties are relevant.</p><p>Custom/Dynamic Output Fields are defined in the same way as <a href="#customdynamic-fields">Custom/Dynamic Input Fields</a>.</p>
+</ul><p>The <a href="https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#fieldschema">schema</a> for <code>outputFields</code> is shared with <code>inputFields</code> but only the <code>key</code>, <code>label</code>, <code>type</code>, and <code>required</code> properties are relevant:</p><ul>
+<li><code>key</code> - includes the field when not present in the live sample. When no <code>label</code> property is provided, <code>key</code> will be <em>humanized</em> and displayed as the field name.</li>
+<li><code>label</code> - defines the field name displayed to users.</li>
+<li><code>type</code> - defines the type for static sample data. A <a href="https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition">validation warning</a> will be displayed if the static sample does not match the specified type.</li>
+<li><code>required</code> - defines whether the field is required in static sample data. A <a href="https://platform.zapier.com/docs/integration-checks-reference#d024---static-sample-respects-output-field-definition">validation warning</a> will be displayed if the value is true and the static sample does not contain the field.</li>
+</ul><p>Custom/Dynamic Output Fields are defined in the same way as <a href="#customdynamic-fields">Custom/Dynamic Input Fields</a>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
Modify copy to more clearly explain schema property relevance and usage for [output fields](https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#output-fields): https://zapierorg.atlassian.net/browse/SUPPORTENG-907

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
