### PR TITLE
[SUPPORTENG-905] Update "OAuth2 with PKCE" section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1652,9 +1652,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 <li><code>getAccessToken.body</code> to include <code>code_verifier: &quot;{{bundle.inputData.code_verifier}}&quot;</code></li>
 </ol><p>The OAuth2 PKCE flow uses the same flow as OAuth2 but adds a few extra parameters:</p><ol>
 <li>Zapier computes a <code>code_verifier</code> and <code>code_challenge</code> internally and stores the <code>code_verifier</code> in the Zapier bundle.</li>
-<li>Zapier sends the user to the authorization URL defined by your app, passing along the computed <code>code_challenge</code>.</li>
+<li>Zapier sends the user to the authorization URL defined by your app. We automatically include the computed <code>code_challenge</code> and <code>code_challenge_method</code> in the authorization request.</li>
 <li>Once authorized, your website sends the user to the <code>redirect_uri</code> Zapier provided.</li>
-<li>Zapier makes a call to your API to exchange the <code>code</code> and the computed <code>code_verifier</code> for an <code>access_token</code>.</li>
+<li>Zapier makes a call to your API to exchange the code but you must include the computed <code>code_verifier</code> in the request for an <code>access_token</code>.</li>
 <li>Zapier stores the <code>access_token</code> and uses it to make calls on behalf of the user.</li>
 </ol><p>Your auth definition would look something like this:</p>
     </div>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -457,9 +457,9 @@ To use PKCE in your OAuth2 flow, you'll need to set the following variables:
 The OAuth2 PKCE flow uses the same flow as OAuth2 but adds a few extra parameters:
 
   1. Zapier computes a `code_verifier` and `code_challenge` internally and stores the `code_verifier` in the Zapier bundle.
-  2. Zapier sends the user to the authorization URL defined by your app, passing along the computed `code_challenge`.
+  2. Zapier sends the user to the authorization URL defined by your app. We automatically include the computed `code_challenge` and `code_challenge_method` in the authorization request.
   3. Once authorized, your website sends the user to the `redirect_uri` Zapier provided.
-  4. Zapier makes a call to your API to exchange the `code` and the computed `code_verifier` for an `access_token`.
+  4. Zapier makes a call to your API to exchange the code but you must include the computed `code_verifier` in the request for an `access_token`.
   5. Zapier stores the `access_token` and uses it to make calls on behalf of the user.
 
 Your auth definition would look something like this:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -877,9 +877,9 @@ To use PKCE in your OAuth2 flow, you'll need to set the following variables:
 The OAuth2 PKCE flow uses the same flow as OAuth2 but adds a few extra parameters:
 
   1. Zapier computes a `code_verifier` and `code_challenge` internally and stores the `code_verifier` in the Zapier bundle.
-  2. Zapier sends the user to the authorization URL defined by your app, passing along the computed `code_challenge`.
+  2. Zapier sends the user to the authorization URL defined by your app. We automatically include the computed `code_challenge` and `code_challenge_method` in the authorization request.
   3. Once authorized, your website sends the user to the `redirect_uri` Zapier provided.
-  4. Zapier makes a call to your API to exchange the `code` and the computed `code_verifier` for an `access_token`.
+  4. Zapier makes a call to your API to exchange the code but you must include the computed `code_verifier` in the request for an `access_token`.
   5. Zapier stores the `access_token` and uses it to make calls on behalf of the user.
 
 Your auth definition would look something like this:

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -1652,9 +1652,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 <li><code>getAccessToken.body</code> to include <code>code_verifier: &quot;{{bundle.inputData.code_verifier}}&quot;</code></li>
 </ol><p>The OAuth2 PKCE flow uses the same flow as OAuth2 but adds a few extra parameters:</p><ol>
 <li>Zapier computes a <code>code_verifier</code> and <code>code_challenge</code> internally and stores the <code>code_verifier</code> in the Zapier bundle.</li>
-<li>Zapier sends the user to the authorization URL defined by your app, passing along the computed <code>code_challenge</code>.</li>
+<li>Zapier sends the user to the authorization URL defined by your app. We automatically include the computed <code>code_challenge</code> and <code>code_challenge_method</code> in the authorization request.</li>
 <li>Once authorized, your website sends the user to the <code>redirect_uri</code> Zapier provided.</li>
-<li>Zapier makes a call to your API to exchange the <code>code</code> and the computed <code>code_verifier</code> for an <code>access_token</code>.</li>
+<li>Zapier makes a call to your API to exchange the code but you must include the computed <code>code_verifier</code> in the request for an <code>access_token</code>.</li>
 <li>Zapier stores the <code>access_token</code> and uses it to make calls on behalf of the user.</li>
 </ol><p>Your auth definition would look something like this:</p>
     </div>


### PR DESCRIPTION
Modify copy to make platform behavior and implementation steps clearer: https://zapierorg.atlassian.net/browse/SUPPORTENG-905

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
