### PR TITLE
fix(core): Convert authentication config source functions to actual functions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
     "string-length": "4.0.2",
     "through2": "4.0.2",
     "tmp": "0.2.1",
+    "traverse": "0.6.7",
     "update-notifier": "5.1.0",
     "yeoman-environment": "3.3.0",
     "yeoman-generator": "5.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10635,6 +10635,11 @@ tr46@~0.0.1, tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+traverse@0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.7.tgz#46961cd2d57dd8706c36664acde06a248f1173fe"
+  integrity sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg==
+
 treeify@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"


### PR DESCRIPTION
`IP-127` [Zapier Convert: Convert auth config source to functions](https://zapierorg.atlassian.net/browse/IP-127)

Inline functions under auth config objects are not converted to functions by `zapier convert`, while the test function is:

```js
const testAuth = async (z, bundle) => {
  z.request({
    url: "https://api.wistia.com/v1/account.json",
    method: "GET",
    headers: {
      Authorization: "Bearer {{bundle.authData.access_token}}",
    },
    body: {},
  }).then((response) => response.data);
};

module.exports = {
  type: 'oauth2',
  test: testAuth,
  fields: [],
  oauth2Config: {
    getAccessToken: {
      source:
        "const options = {\n  url: 'https://api.wistia.com/oauth/token',\n  method: 'POST',\n  headers: {\n    'content-type': 'application/x-www-form-urlencoded',\n    accept: 'application/json',\n  },\n  body: {\n    grant_type: 'refresh_token',\n    refresh_token: '{{bundle.authData.refresh_token}}',\n  }\n}\n\nreturn z.request(options)\n  .then((response) => {\n    const results = response.data;\n\n    // You can do any parsing you need for results here before returning them\n\n    return results;\n  });",
    },
  },
};
```

This PR fixes that my traversing to look for any `source:` and adds missing test coverage.