### PR TITLE
BREAKING CHANGE(cli) - Upgrade to use Node 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           cache: yarn
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -65,7 +65,7 @@ jobs:
           - ubuntu-latest
           # TODO: Fix tests on Windows
           # - windows-latest
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
           - ubuntu-latest
           # TODO: Fix tests on Windows
           # - windows-latest
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/boilerplate/scripts/build.sh
+++ b/boilerplate/scripts/build.sh
@@ -160,7 +160,7 @@ pushd $BOILERPLATE_DIR > /dev/null
 
 # Build the zip!
 # the node-X segment in the next line should match the latest major version
-zip -R $TARGET_FILE '*.js' '*.cjs' '*.json' '*/linux-x64-node-12/*.node' '*/linux-x64-node-14/*.node' '*/linux-x64-node-16/*.node'
+zip -R $TARGET_FILE '*.js' '*.cjs' '*.json' '*/linux-x64-node-14/*.node' '*/linux-x64-node-16/*.node' '*/linux-x64-node-18/*.node'
 
 # Remove generated files
 rm -f zapierwrapper.js definition.json core-*.tgz legacy-*.tgz

--- a/docs/index.html
+++ b/docs/index.html
@@ -704,7 +704,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>All Zapier CLI apps are run using Node.js <code>v16</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v16</code>. If you&apos;re using features not yet available in <code>v16</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v16</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/main/example-apps/trigger/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v16</code>, or do <code>nvm exec v16 zapier test</code> so you can run tests without having to switch versions while developing.</p>
+      <p>All Zapier CLI apps are run using Node.js <code>v18</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v18</code>. If you&apos;re using features not yet available in <code>v18</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v18</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/main/example-apps/trigger/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v18</code>, or do <code>nvm exec v18 zapier test</code> so you can run tests without having to switch versions while developing.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1539,7 +1539,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 <li>Zapier makes a backend call to your API to exchange the <code>code</code> for an <code>access_token</code>.</li>
 <li>Zapier stores the <code>access_token</code> and uses it to make calls on behalf of the user.</li>
 <li>(Optionally) Zapier can refresh the token if it expires.</li>
-</ol><p>You are required to define:</p><ul>
+</ol><blockquote>
+<p>Note: When <a href="https://platform.zapier.com/private_integrations/private-vs-public-integrations">building a public integration</a>,  the <code>redirect_uri</code> will change once the app is approved for publishing, to be more consistent with your app&#x2019;s branding. Depending on your API, you may need to add this new <code>redirect_uri</code> to an allow list in order for users to continue connecting to your app on Zapier. To access the new <code>redirect_uri</code>, run <code>zapier describe</code> again once the app is published.</p>
+</blockquote><p>You are required to define:</p><ul>
 <li><code>authorizeUrl</code>: The authorization URL</li>
 <li><code>getAccessToken</code>: The API call to fetch the access token</li>
 </ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh (<code>refreshAccessToken</code>). You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>
@@ -4924,7 +4926,7 @@ zapier <span class="hljs-built_in">test</span>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-yaml"><span class="hljs-attr">language:</span> <span class="hljs-string">node_js</span>
 <span class="hljs-attr">node_js:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v16&quot;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v18&quot;</span>
 <span class="hljs-attr">before_script:</span> <span class="hljs-string">npm</span> <span class="hljs-string">install</span> <span class="hljs-string">-g</span> <span class="hljs-string">zapier-platform-cli</span>
 <span class="hljs-attr">script:</span> <span class="hljs-string">CLIENT_ID=1234</span> <span class="hljs-string">CLIENT_SECRET=abcd</span> <span class="hljs-string">zapier</span> <span class="hljs-string">test</span>
 </code></pre>
@@ -5598,7 +5600,7 @@ zapier push
       <p>... then you need to update your <code>zapier-platform-core</code> dependency to a non-deprecated version that uses a newer version of Node.js. Complete the following instructions as soon as possible:</p><ol>
 <li>Edit <code>package.json</code> to depend on a later major version of <code>zapier-platform-core</code>. There&apos;s a list of all breaking changes (marked with a :exclamation:) in the <a href="https://github.com/zapier/zapier-platform/blob/main/CHANGELOG.md">changelog</a>.</li>
 <li>Increment the <code>version</code> property in <code>package.json</code></li>
-<li>Ensure you&apos;re using version <code>v16</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
+<li>Ensure you&apos;re using version <code>v18</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
 <li>Run <code>rm -rf node_modules &amp;&amp; npm i</code> to get a fresh copy of everything</li>
 <li>Run <code>zapier test</code> to ensure your tests still pass</li>
 <li>Run <code>zapier push</code></li>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -188,15 +188,15 @@ Zapier Platform CLI is designed to be used by development teams who collaborate 
 
 ### Requirements
 
-All Zapier CLI apps are run using Node.js `v16`.
+All Zapier CLI apps are run using Node.js `v18`.
 
-You can develop using any version of Node you'd like, but your eventual code must be compatible with `v16`. If you're using features not yet available in `v16`, you can transpile your code to a compatible format with [Babel](https://babeljs.io/) (or similar).
+You can develop using any version of Node you'd like, but your eventual code must be compatible with `v18`. If you're using features not yet available in `v18`, you can transpile your code to a compatible format with [Babel](https://babeljs.io/) (or similar).
 
-To ensure stability for our users, we strongly encourage you run tests on `v16` sometime before your code reaches users. This can be done multiple ways.
+To ensure stability for our users, we strongly encourage you run tests on `v18` sometime before your code reaches users. This can be done multiple ways.
 
 Firstly, by using a CI tool (like [Travis CI](https://travis-ci.org/) or [Circle CI](https://circleci.com/), which are free for open source projects). We provide a sample [.travis.yml](https://github.com/zapier/zapier-platform/blob/main/example-apps/trigger/.travis.yml) file in our template apps to get you started.
 
-Alternatively, you can change your local node version with tools such as [nvm](https://github.com/nvm-sh/nvm#installation-and-update). Then you can either swap to that version with `nvm use v16`, or do `nvm exec v16 zapier test` so you can run tests without having to switch versions while developing.
+Alternatively, you can change your local node version with tools such as [nvm](https://github.com/nvm-sh/nvm#installation-and-update). Then you can either swap to that version with `nvm use v18`, or do `nvm exec v18 zapier test` so you can run tests without having to switch versions while developing.
 
 
 ### Quick Setup Guide
@@ -770,6 +770,8 @@ The OAuth2 flow looks like this:
   3. Zapier makes a backend call to your API to exchange the `code` for an `access_token`.
   4. Zapier stores the `access_token` and uses it to make calls on behalf of the user.
   5. (Optionally) Zapier can refresh the token if it expires.
+
+> Note: When [building a public integration](https://platform.zapier.com/private_integrations/private-vs-public-integrations),  the `redirect_uri` will change once the app is approved for publishing, to be more consistent with your app’s branding. Depending on your API, you may need to add this new `redirect_uri` to an allow list in order for users to continue connecting to your app on Zapier. To access the new `redirect_uri`, run `zapier describe` again once the app is published.
 
 You are required to define:
 
@@ -3047,7 +3049,7 @@ This makes it straightforward to integrate into your testing interface. For exam
 ```yaml
 language: node_js
 node_js:
-  - "v16"
+  - "v18"
 before_script: npm install -g zapier-platform-cli
 script: CLIENT_ID=1234 CLIENT_SECRET=abcd zapier test
 ```
@@ -3519,7 +3521,7 @@ InvalidParameterValueException An error occurred (InvalidParameterValueException
 
 1. Edit `package.json` to depend on a later major version of `zapier-platform-core`. There's a list of all breaking changes (marked with a :exclamation:) in the [changelog](https://github.com/zapier/zapier-platform/blob/main/CHANGELOG.md).
 2. Increment the `version` property in `package.json`
-3. Ensure you're using version `v16` (or greater) of node locally (`node -v`). Use [nvm](https://github.com/nvm-sh/nvm) to use a different one if need be.
+3. Ensure you're using version `v18` (or greater) of node locally (`node -v`). Use [nvm](https://github.com/nvm-sh/nvm) to use a different one if need be.
 4. Run `rm -rf node_modules && npm i` to get a fresh copy of everything
 5. Run `zapier test` to ensure your tests still pass
 6. Run `zapier push`

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -704,7 +704,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>All Zapier CLI apps are run using Node.js <code>v16</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v16</code>. If you&apos;re using features not yet available in <code>v16</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v16</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/main/example-apps/trigger/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v16</code>, or do <code>nvm exec v16 zapier test</code> so you can run tests without having to switch versions while developing.</p>
+      <p>All Zapier CLI apps are run using Node.js <code>v18</code>.</p><p>You can develop using any version of Node you&apos;d like, but your eventual code must be compatible with <code>v18</code>. If you&apos;re using features not yet available in <code>v18</code>, you can transpile your code to a compatible format with <a href="https://babeljs.io/">Babel</a> (or similar).</p><p>To ensure stability for our users, we strongly encourage you run tests on <code>v18</code> sometime before your code reaches users. This can be done multiple ways.</p><p>Firstly, by using a CI tool (like <a href="https://travis-ci.org/">Travis CI</a> or <a href="https://circleci.com/">Circle CI</a>, which are free for open source projects). We provide a sample <a href="https://github.com/zapier/zapier-platform/blob/main/example-apps/trigger/.travis.yml">.travis.yml</a> file in our template apps to get you started.</p><p>Alternatively, you can change your local node version with tools such as <a href="https://github.com/nvm-sh/nvm#installation-and-update">nvm</a>. Then you can either swap to that version with <code>nvm use v18</code>, or do <code>nvm exec v18 zapier test</code> so you can run tests without having to switch versions while developing.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1539,7 +1539,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 <li>Zapier makes a backend call to your API to exchange the <code>code</code> for an <code>access_token</code>.</li>
 <li>Zapier stores the <code>access_token</code> and uses it to make calls on behalf of the user.</li>
 <li>(Optionally) Zapier can refresh the token if it expires.</li>
-</ol><p>You are required to define:</p><ul>
+</ol><blockquote>
+<p>Note: When <a href="https://platform.zapier.com/private_integrations/private-vs-public-integrations">building a public integration</a>,  the <code>redirect_uri</code> will change once the app is approved for publishing, to be more consistent with your app&#x2019;s branding. Depending on your API, you may need to add this new <code>redirect_uri</code> to an allow list in order for users to continue connecting to your app on Zapier. To access the new <code>redirect_uri</code>, run <code>zapier describe</code> again once the app is published.</p>
+</blockquote><p>You are required to define:</p><ul>
 <li><code>authorizeUrl</code>: The authorization URL</li>
 <li><code>getAccessToken</code>: The API call to fetch the access token</li>
 </ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh (<code>refreshAccessToken</code>). You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>
@@ -4924,7 +4926,7 @@ zapier <span class="hljs-built_in">test</span>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-yaml"><span class="hljs-attr">language:</span> <span class="hljs-string">node_js</span>
 <span class="hljs-attr">node_js:</span>
-  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v16&quot;</span>
+  <span class="hljs-bullet">-</span> <span class="hljs-string">&quot;v18&quot;</span>
 <span class="hljs-attr">before_script:</span> <span class="hljs-string">npm</span> <span class="hljs-string">install</span> <span class="hljs-string">-g</span> <span class="hljs-string">zapier-platform-cli</span>
 <span class="hljs-attr">script:</span> <span class="hljs-string">CLIENT_ID=1234</span> <span class="hljs-string">CLIENT_SECRET=abcd</span> <span class="hljs-string">zapier</span> <span class="hljs-string">test</span>
 </code></pre>
@@ -5598,7 +5600,7 @@ zapier push
       <p>... then you need to update your <code>zapier-platform-core</code> dependency to a non-deprecated version that uses a newer version of Node.js. Complete the following instructions as soon as possible:</p><ol>
 <li>Edit <code>package.json</code> to depend on a later major version of <code>zapier-platform-core</code>. There&apos;s a list of all breaking changes (marked with a :exclamation:) in the <a href="https://github.com/zapier/zapier-platform/blob/main/CHANGELOG.md">changelog</a>.</li>
 <li>Increment the <code>version</code> property in <code>package.json</code></li>
-<li>Ensure you&apos;re using version <code>v16</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
+<li>Ensure you&apos;re using version <code>v18</code> (or greater) of node locally (<code>node -v</code>). Use <a href="https://github.com/nvm-sh/nvm">nvm</a> to use a different one if need be.</li>
 <li>Run <code>rm -rf node_modules &amp;&amp; npm i</code> to get a fresh copy of everything</li>
 <li>Run <code>zapier test</code> to ensure your tests still pass</li>
 <li>Run <code>zapier push</code></li>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "/oclif.manifest.json"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "scripts": {
     "docs": "ZAPIER_BASE_ENDPOINT='' node scripts/docs.js && cp -r docs ../..",

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -26,7 +26,7 @@ const BLACKLISTED_PATHS = [
 ];
 const NODE_VERSION = versionStore[versionStore.length - 1].nodeVersion;
 const LAMBDA_VERSION = `v${NODE_VERSION}`;
-const NODE_VERSION_CLI_REQUIRES = '>=14'; // should be the oldest non-ETL version
+const NODE_VERSION_CLI_REQUIRES = '>=16'; // should be the oldest non-ETL version
 const AUTH_KEY = 'deployKey';
 const ANALYTICS_KEY = 'analyticsMode';
 const ANALYTICS_MODES = {

--- a/packages/cli/src/version-store.js
+++ b/packages/cli/src/version-store.js
@@ -16,4 +16,5 @@ module.exports = [
   { nodeVersion: '14', npmVersion: '>=5.6.0' }, // 11.x
   { nodeVersion: '14', npmVersion: '>=5.6.0' }, // 12.x
   { nodeVersion: '16', npmVersion: '>=5.6.0' }, // 13.x
+  { nodeVersion: '18', npmVersion: '>=5.6.0' }, // 15.x
 ];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "validate": "yarn test && yarn smoke-test && yarn lint"
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=16",
     "npm": ">=5.6.0"
   },
   "engineStrict": true,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
