### PR TITLE
fix(cli) - Broken link to deploy keys for zapier login sso

### DIFF
--- a/packages/cli/src/oclif/commands/login.js
+++ b/packages/cli/src/oclif/commands/login.js
@@ -19,7 +19,13 @@ const { writeFile } = require('../../utils/files');
 const { prettyJSONstringify } = require('../../utils/display');
 const { isSamlEmail } = require('../../utils/credentials');
 
-const DEPLOY_KEY_DASH_URL = `${BASE_ENDPOINT}/developer/partner-settings/deploy-keys/`;
+const getDeployKeyUrl = () => {
+  const url = new URL(BASE_ENDPOINT);
+  url.hostname = `developer.${url.hostname}`;
+  url.pathname = 'partner-settings/deploy-keys/';
+  return url.href;
+};
+const DEPLOY_KEY_DASH_URL = getDeployKeyUrl();
 
 const isValidTotpCode = (i) => {
   const num = parseInt(i, 10);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
