### PR TITLE
[SUPPORTENG-916] Updating a few links to match platform docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -737,7 +737,7 @@ zapier login
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer account here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
+<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://developer.zapier.com/partner-settings/deploy-keys/">your Zapier developer account here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
 </blockquote><p>Your Zapier CLI should be installed and ready to go at this point. Next up, we&apos;ll create our first app!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -800,7 +800,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For a full tutorial, head over to our <a href="https://zapier.com/developer/start">Tutorial</a> for a comprehensive walkthrough for creating your first app. If this isn&apos;t your first rodeo, read on!</p>
+      <p>For a full tutorial, head over to our <a href="https://platform.zapier.com/cli_tutorials/getting-started">Tutorial</a> for a comprehensive walkthrough for creating your first app. If this isn&apos;t your first rodeo, read on!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1539,7 +1539,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 <li>Zapier makes a backend call to your API to exchange the <code>code</code> for an <code>access_token</code>.</li>
 <li>Zapier stores the <code>access_token</code> and uses it to make calls on behalf of the user.</li>
 <li>(Optionally) Zapier can refresh the token if it expires.</li>
-</ol><p>You are required to define:</p><ul>
+</ol><blockquote>
+<p>Note: When <a href="https://platform.zapier.com/private_integrations/private-vs-public-integrations">building a public integration</a>,  the <code>redirect_uri</code> will change once the app is approved for publishing, to be more consistent with your app&#x2019;s branding. Depending on your API, you may need to add this new <code>redirect_uri</code> to an allow list in order for users to continue connecting to your app on Zapier. To access the new <code>redirect_uri</code>, run <code>zapier describe</code> again once the app is published.</p>
+</blockquote><p>You are required to define:</p><ul>
 <li><code>authorizeUrl</code>: The authorization URL</li>
 <li><code>getAccessToken</code>: The API call to fetch the access token</li>
 </ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh (<code>refreshAccessToken</code>). You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -92,7 +92,7 @@ npm install -g zapier-platform-cli
 # setup auth to Zapier's platform with a deploy key
 zapier login
 ```
-> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
+> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://developer.zapier.com/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
 
 Your Zapier CLI should be installed and ready to go at this point. Next up, we'll create our first app!
 
@@ -129,7 +129,7 @@ zapier push
 
 ### Tutorial
 
-For a full tutorial, head over to our [Tutorial](https://zapier.com/developer/start) for a comprehensive walkthrough for creating your first app. If this isn't your first rodeo, read on!
+For a full tutorial, head over to our [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a comprehensive walkthrough for creating your first app. If this isn't your first rodeo, read on!
 
 ## Creating a Local App
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -210,7 +210,7 @@ npm install -g zapier-platform-cli
 # setup auth to Zapier's platform with a deploy key
 zapier login
 ```
-> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://zapier.com/developer/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
+> Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that's the case, you'll need to generate a deploy key, go to [your Zapier developer account here](https://developer.zapier.com/partner-settings/deploy-keys/) and create/copy a key, then run ```zapier login``` command with the --sso flag.
 
 Your Zapier CLI should be installed and ready to go at this point. Next up, we'll create our first app!
 
@@ -247,7 +247,7 @@ zapier push
 
 ### Tutorial
 
-For a full tutorial, head over to our [Tutorial](https://zapier.com/developer/start) for a comprehensive walkthrough for creating your first app. If this isn't your first rodeo, read on!
+For a full tutorial, head over to our [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a comprehensive walkthrough for creating your first app. If this isn't your first rodeo, read on!
 
 ## Creating a Local App
 
@@ -770,6 +770,8 @@ The OAuth2 flow looks like this:
   3. Zapier makes a backend call to your API to exchange the `code` for an `access_token`.
   4. Zapier stores the `access_token` and uses it to make calls on behalf of the user.
   5. (Optionally) Zapier can refresh the token if it expires.
+
+> Note: When [building a public integration](https://platform.zapier.com/private_integrations/private-vs-public-integrations),  the `redirect_uri` will change once the app is approved for publishing, to be more consistent with your app’s branding. Depending on your API, you may need to add this new `redirect_uri` to an allow list in order for users to continue connecting to your app on Zapier. To access the new `redirect_uri`, run `zapier describe` again once the app is published.
 
 You are required to define:
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -737,7 +737,7 @@ zapier login
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://zapier.com/developer/partner-settings/deploy-keys/">your Zapier developer account here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
+<p>Note: If you log into Zapier via the single sign-on (Google, Facebook, or Microsoft), you may not have a Zapier password. If that&apos;s the case, you&apos;ll need to generate a deploy key, go to <a href="https://developer.zapier.com/partner-settings/deploy-keys/">your Zapier developer account here</a> and create/copy a key, then run <code>zapier login</code> command with the --sso flag.</p>
 </blockquote><p>Your Zapier CLI should be installed and ready to go at this point. Next up, we&apos;ll create our first app!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -800,7 +800,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>For a full tutorial, head over to our <a href="https://zapier.com/developer/start">Tutorial</a> for a comprehensive walkthrough for creating your first app. If this isn&apos;t your first rodeo, read on!</p>
+      <p>For a full tutorial, head over to our <a href="https://platform.zapier.com/cli_tutorials/getting-started">Tutorial</a> for a comprehensive walkthrough for creating your first app. If this isn&apos;t your first rodeo, read on!</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       
@@ -1539,7 +1539,9 @@ $ CLIENT_ID=1234 CLIENT_SECRET=abcd zapier <span class="hljs-built_in">test</spa
 <li>Zapier makes a backend call to your API to exchange the <code>code</code> for an <code>access_token</code>.</li>
 <li>Zapier stores the <code>access_token</code> and uses it to make calls on behalf of the user.</li>
 <li>(Optionally) Zapier can refresh the token if it expires.</li>
-</ol><p>You are required to define:</p><ul>
+</ol><blockquote>
+<p>Note: When <a href="https://platform.zapier.com/private_integrations/private-vs-public-integrations">building a public integration</a>,  the <code>redirect_uri</code> will change once the app is approved for publishing, to be more consistent with your app&#x2019;s branding. Depending on your API, you may need to add this new <code>redirect_uri</code> to an allow list in order for users to continue connecting to your app on Zapier. To access the new <code>redirect_uri</code>, run <code>zapier describe</code> again once the app is published.</p>
+</blockquote><p>You are required to define:</p><ul>
 <li><code>authorizeUrl</code>: The authorization URL</li>
 <li><code>getAccessToken</code>: The API call to fetch the access token</li>
 </ul><p>If the access token has a limited life and you want to refresh the token when it expires, you&apos;ll also need to define the API call to perform that refresh (<code>refreshAccessToken</code>). You can choose to set <code>autoRefresh: true</code>, as in the example app, if you want Zapier to automatically make a call to refresh the token after receiving a 401. See <a href="#stale-authentication-credentials">Stale Authentication Credentials</a> for more details on handling auth refresh.</p><p>You&apos;ll also likely want to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables:</p>


### PR DESCRIPTION
This PR updates a few broken links to match them with the equivalents already in the platform's CLI docs (https://platform.zapier.com/cli_docs/docs).

It also includes a new note, which was already in `README-source.md` but wasn't pushed to other files in someone else's earlier commit.

Note, I had some trouble with the pre-commit hook, so I ran `yarn docs` and then staged/committed individual files. Please let me know if anything here looks incorrect and I'll fix re-submit.

![image](https://github.com/zapier/zapier-platform/assets/57920178/9a6909b6-7c6c-4241-a110-48386e044e2b)
