### PR TITLE
SUPPORTENG-919_hyperlinks_update

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -617,7 +617,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://zapier.com/developer/start">Tutorial</a> for a more thorough introduction.</p>
+<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://platform.zapier.com/cli_tutorials/getting-started">Tutorial</a> for a more thorough introduction.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -684,7 +684,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The Zapier Platform includes two ways to build integrations: a CLI (to build integrations in your local development environment and deploy them from the command line), and a Visual Builder (to create integrations with a visual builder from your browser). Both use the same underlying platform, so pick the one that fits your team&apos;s needs best. The main difference is how you make changes to your code.</p><p>Zapier Platform CLI is designed to be used by development teams who collaborate with version control and CI, and can be used to build more advanced integrations with custom coding for every part of your API calls and response parsing.</p><p><a href="https://zapier.com/app/developer/">Zapier Platform UI</a> is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It&apos;s the quickest way to start using the Zapier platform&#x2014;and you can manage your CLI apps&apos; core details from its online UI as well. You can also <a href="https://platform.zapier.com/docs/export">export</a> Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.</p><blockquote>
+      <p>The Zapier Platform includes two ways to build integrations: a CLI (to build integrations in your local development environment and deploy them from the command line), and a Visual Builder (to create integrations with a visual builder from your browser). Both use the same underlying platform, so pick the one that fits your team&apos;s needs best. The main difference is how you make changes to your code.</p><p>Zapier Platform CLI is designed to be used by development teams who collaborate with version control and CI, and can be used to build more advanced integrations with custom coding for every part of your API calls and response parsing.</p><p><a href="https://developer.zapier.com/">Zapier Platform UI</a> is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It&apos;s the quickest way to start using the Zapier platform&#x2014;and you can manage your CLI apps&apos; core details from its online UI as well. You can also <a href="https://platform.zapier.com/docs/export">export</a> Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.</p><blockquote>
 <p>Learn more in our <a href="https://platform.zapier.com/docs/vs">Zapier Platform UI vs CLI</a> post.</p>
 </blockquote>
     </div>
@@ -755,6 +755,18 @@ npm install
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Depending on the authentication method for your app, you&apos;ll also likely need to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables. These are the consumer key and secret in OAuth1 terminology.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_ID=1234
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_SECRET=abcd
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Note: When you run <code>zapier init</code>, you&apos;ll be presented with a list of templates to start with. Pick the one that matches a feature you&apos;ll need (such as &quot;dynamic-dropdown&quot; for an integration with <a href="#dynamic-dropdowns">dynamic dropdown fields</a>), or select &quot;minimal&quot; for an integration with only the essentials. <a href="https://github.com/zapier/zapier-platform/tree/main/example-apps">View more example apps here</a>.</p>
 </blockquote><p>You should now have a working local app. You can run several local commands to try it out.</p>
@@ -781,7 +793,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Go check out our <a href="https://zapier.github.io/zapier-platform/cli">full CLI reference documentation</a> to see all the other commands!</p>
+<p>Go check out our <a href="https://github.com/zapier/zapier-platform/blob/main/packages/cli/docs/cli.md#zapier-cli-reference">full CLI reference documentation</a> to see all the other commands!</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -819,7 +831,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Tip: Check the <a href="#quick-setup-guide">Quick Setup</a> if this is your first time using the platform!</p>
+<p>Tip: Check the <a href="https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#quick-setup-guide">Quick Setup</a> if this is your first time using the platform!</p>
 </blockquote><p>Creating an App can be done entirely locally and they are fairly simple Node.js apps using the standard Node environment and should be completely testable. However, a local app stays local until you <code>zapier register</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1114,7 +1126,7 @@ zapier deprecate 1.0.0 2020-06-01
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>If you have an existing Zapier <a href="https://zapier.com/developer/builder/">legacy Web Builder app</a>, you can use it as a template to kickstart your local application.</p>
+      <p>If you have an existing Zapier <a href="https://platform.zapier.com/conversion/maintaining">legacy Web Builder app</a>, you can use it as a template to kickstart your local application.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># Convert an existing Web Builder app to a CLI app in the my-app directory</span>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -34,7 +34,7 @@ This doc describes the latest CLI version (**PACKAGE_VERSION**), as of this writ
 
 ## Getting Started
 
-> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://zapier.com/developer/start) for a more thorough introduction.
+> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a more thorough introduction.
 
 ### What is an App?
 
@@ -64,7 +64,7 @@ The Zapier Platform includes two ways to build integrations: a CLI (to build int
 
 Zapier Platform CLI is designed to be used by development teams who collaborate with version control and CI, and can be used to build more advanced integrations with custom coding for every part of your API calls and response parsing.
 
-[Zapier Platform UI](https://zapier.com/app/developer/) is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It's the quickest way to start using the Zapier platform—and you can manage your CLI apps' core details from its online UI as well. You can also [export](https://platform.zapier.com/docs/export) Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.
+[Zapier Platform UI](https://developer.zapier.com/) is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It's the quickest way to start using the Zapier platform—and you can manage your CLI apps' core details from its online UI as well. You can also [export](https://platform.zapier.com/docs/export) Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.
 
 > Learn more in our [Zapier Platform UI vs CLI](https://platform.zapier.com/docs/vs) post.
 
@@ -106,7 +106,13 @@ cd example-app
 # install all the libraries needed for your app
 npm install
 ```
+Depending on the authentication method for your app, you'll also likely need to set your `CLIENT_ID` and `CLIENT_SECRET` as environment variables. These are the consumer key and secret in OAuth1 terminology.
 
+```bash
+# setting the environment variables on Zapier.com
+$ zapier env:set 1.0.0 CLIENT_ID=1234
+$ zapier env:set 1.0.0 CLIENT_SECRET=abcd
+```
 > Note: When you run `zapier init`, you'll be presented with a list of templates to start with. Pick the one that matches a feature you'll need (such as "dynamic-dropdown" for an integration with [dynamic dropdown fields](#dynamic-dropdowns)), or select "minimal" for an integration with only the essentials. [View more example apps here](https://github.com/zapier/zapier-platform/tree/main/example-apps).
 
 You should now have a working local app. You can run several local commands to try it out.
@@ -124,7 +130,7 @@ Next, you'll probably want to upload app to Zapier itself so you can start testi
 zapier push
 ```
 
-> Go check out our [full CLI reference documentation](https://zapier.github.io/zapier-platform/cli) to see all the other commands!
+> Go check out our [full CLI reference documentation](https://github.com/zapier/zapier-platform/blob/main/packages/cli/docs/cli.md#zapier-cli-reference) to see all the other commands!
 
 
 ### Tutorial
@@ -133,7 +139,7 @@ For a full tutorial, head over to our [Tutorial](https://platform.zapier.com/cli
 
 ## Creating a Local App
 
-> Tip: Check the [Quick Setup](#quick-setup-guide) if this is your first time using the platform!
+> Tip: Check the [Quick Setup](https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#quick-setup-guide) if this is your first time using the platform!
 
 Creating an App can be done entirely locally and they are fairly simple Node.js apps using the standard Node environment and should be completely testable. However, a local app stays local until you `zapier register`.
 
@@ -280,7 +286,7 @@ zapier deprecate 1.0.0 2020-06-01
 
 ## Converting an Existing App
 
-If you have an existing Zapier [legacy Web Builder app](https://zapier.com/developer/builder/), you can use it as a template to kickstart your local application.
+If you have an existing Zapier [legacy Web Builder app](https://platform.zapier.com/conversion/maintaining), you can use it as a template to kickstart your local application.
 
 ```bash
 # Convert an existing Web Builder app to a CLI app in the my-app directory

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -152,7 +152,7 @@ This doc describes the latest CLI version (**14.1.1**), as of this writing. If y
 
 ## Getting Started
 
-> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://zapier.com/developer/start) for a more thorough introduction.
+> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a more thorough introduction.
 
 ### What is an App?
 
@@ -182,7 +182,7 @@ The Zapier Platform includes two ways to build integrations: a CLI (to build int
 
 Zapier Platform CLI is designed to be used by development teams who collaborate with version control and CI, and can be used to build more advanced integrations with custom coding for every part of your API calls and response parsing.
 
-[Zapier Platform UI](https://zapier.com/app/developer/) is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It's the quickest way to start using the Zapier platform—and you can manage your CLI apps' core details from its online UI as well. You can also [export](https://platform.zapier.com/docs/export) Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.
+[Zapier Platform UI](https://developer.zapier.com/) is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It's the quickest way to start using the Zapier platform—and you can manage your CLI apps' core details from its online UI as well. You can also [export](https://platform.zapier.com/docs/export) Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.
 
 > Learn more in our [Zapier Platform UI vs CLI](https://platform.zapier.com/docs/vs) post.
 
@@ -224,7 +224,13 @@ cd example-app
 # install all the libraries needed for your app
 npm install
 ```
+Depending on the authentication method for your app, you'll also likely need to set your `CLIENT_ID` and `CLIENT_SECRET` as environment variables. These are the consumer key and secret in OAuth1 terminology.
 
+```bash
+# setting the environment variables on Zapier.com
+$ zapier env:set 1.0.0 CLIENT_ID=1234
+$ zapier env:set 1.0.0 CLIENT_SECRET=abcd
+```
 > Note: When you run `zapier init`, you'll be presented with a list of templates to start with. Pick the one that matches a feature you'll need (such as "dynamic-dropdown" for an integration with [dynamic dropdown fields](#dynamic-dropdowns)), or select "minimal" for an integration with only the essentials. [View more example apps here](https://github.com/zapier/zapier-platform/tree/main/example-apps).
 
 You should now have a working local app. You can run several local commands to try it out.
@@ -242,7 +248,7 @@ Next, you'll probably want to upload app to Zapier itself so you can start testi
 zapier push
 ```
 
-> Go check out our [full CLI reference documentation](https://zapier.github.io/zapier-platform/cli) to see all the other commands!
+> Go check out our [full CLI reference documentation](https://github.com/zapier/zapier-platform/blob/main/packages/cli/docs/cli.md#zapier-cli-reference) to see all the other commands!
 
 
 ### Tutorial
@@ -251,7 +257,7 @@ For a full tutorial, head over to our [Tutorial](https://platform.zapier.com/cli
 
 ## Creating a Local App
 
-> Tip: Check the [Quick Setup](#quick-setup-guide) if this is your first time using the platform!
+> Tip: Check the [Quick Setup](https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#quick-setup-guide) if this is your first time using the platform!
 
 Creating an App can be done entirely locally and they are fairly simple Node.js apps using the standard Node environment and should be completely testable. However, a local app stays local until you `zapier register`.
 
@@ -424,7 +430,7 @@ zapier deprecate 1.0.0 2020-06-01
 
 ## Converting an Existing App
 
-If you have an existing Zapier [legacy Web Builder app](https://zapier.com/developer/builder/), you can use it as a template to kickstart your local application.
+If you have an existing Zapier [legacy Web Builder app](https://platform.zapier.com/conversion/maintaining), you can use it as a template to kickstart your local application.
 
 ```bash
 # Convert an existing Web Builder app to a CLI app in the my-app directory

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -617,7 +617,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://zapier.com/developer/start">Tutorial</a> for a more thorough introduction.</p>
+<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://platform.zapier.com/cli_tutorials/getting-started">Tutorial</a> for a more thorough introduction.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -684,7 +684,7 @@ for. This is used during the &quot;Connect Accounts&quot; section of the Zap Edi
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The Zapier Platform includes two ways to build integrations: a CLI (to build integrations in your local development environment and deploy them from the command line), and a Visual Builder (to create integrations with a visual builder from your browser). Both use the same underlying platform, so pick the one that fits your team&apos;s needs best. The main difference is how you make changes to your code.</p><p>Zapier Platform CLI is designed to be used by development teams who collaborate with version control and CI, and can be used to build more advanced integrations with custom coding for every part of your API calls and response parsing.</p><p><a href="https://zapier.com/app/developer/">Zapier Platform UI</a> is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It&apos;s the quickest way to start using the Zapier platform&#x2014;and you can manage your CLI apps&apos; core details from its online UI as well. You can also <a href="https://platform.zapier.com/docs/export">export</a> Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.</p><blockquote>
+      <p>The Zapier Platform includes two ways to build integrations: a CLI (to build integrations in your local development environment and deploy them from the command line), and a Visual Builder (to create integrations with a visual builder from your browser). Both use the same underlying platform, so pick the one that fits your team&apos;s needs best. The main difference is how you make changes to your code.</p><p>Zapier Platform CLI is designed to be used by development teams who collaborate with version control and CI, and can be used to build more advanced integrations with custom coding for every part of your API calls and response parsing.</p><p><a href="https://developer.zapier.com/">Zapier Platform UI</a> is designed to quickly spin up new integrations, and collaborate on them with teams that include non-developers. It&apos;s the quickest way to start using the Zapier platform&#x2014;and you can manage your CLI apps&apos; core details from its online UI as well. You can also <a href="https://platform.zapier.com/docs/export">export</a> Zapier Platform UI integrations to CLI to start development in your browser, then finish out the core features in your local development environment.</p><blockquote>
 <p>Learn more in our <a href="https://platform.zapier.com/docs/vs">Zapier Platform UI vs CLI</a> post.</p>
 </blockquote>
     </div>
@@ -755,6 +755,18 @@ npm install
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Depending on the authentication method for your app, you&apos;ll also likely need to set your <code>CLIENT_ID</code> and <code>CLIENT_SECRET</code> as environment variables. These are the consumer key and secret in OAuth1 terminology.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height  docs-code">
+      <pre><code class="lang-bash"><span class="hljs-comment"># setting the environment variables on Zapier.com</span>
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_ID=1234
+$ zapier env:<span class="hljs-built_in">set</span> 1.0.0 CLIENT_SECRET=abcd
+</code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
 <p>Note: When you run <code>zapier init</code>, you&apos;ll be presented with a list of templates to start with. Pick the one that matches a feature you&apos;ll need (such as &quot;dynamic-dropdown&quot; for an integration with <a href="#dynamic-dropdowns">dynamic dropdown fields</a>), or select &quot;minimal&quot; for an integration with only the essentials. <a href="https://github.com/zapier/zapier-platform/tree/main/example-apps">View more example apps here</a>.</p>
 </blockquote><p>You should now have a working local app. You can run several local commands to try it out.</p>
@@ -781,7 +793,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Go check out our <a href="https://zapier.github.io/zapier-platform/cli">full CLI reference documentation</a> to see all the other commands!</p>
+<p>Go check out our <a href="https://github.com/zapier/zapier-platform/blob/main/packages/cli/docs/cli.md#zapier-cli-reference">full CLI reference documentation</a> to see all the other commands!</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
@@ -819,7 +831,7 @@ zapier push
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>Tip: Check the <a href="#quick-setup-guide">Quick Setup</a> if this is your first time using the platform!</p>
+<p>Tip: Check the <a href="https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#quick-setup-guide">Quick Setup</a> if this is your first time using the platform!</p>
 </blockquote><p>Creating an App can be done entirely locally and they are fairly simple Node.js apps using the standard Node environment and should be completely testable. However, a local app stays local until you <code>zapier register</code>.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
@@ -1114,7 +1126,7 @@ zapier deprecate 1.0.0 2020-06-01
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>If you have an existing Zapier <a href="https://zapier.com/developer/builder/">legacy Web Builder app</a>, you can use it as a template to kickstart your local application.</p>
+      <p>If you have an existing Zapier <a href="https://platform.zapier.com/conversion/maintaining">legacy Web Builder app</a>, you can use it as a template to kickstart your local application.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash"><span class="hljs-comment"># Convert an existing Web Builder app to a CLI app in the my-app directory</span>


### PR DESCRIPTION
When following the quick setup guide, the lack of mention of environment variables could result in user confusion. If a required client id doesn't generate, the error we see, will be the API error when the authorizeUrl is wrong, so might not be clear that you need to set a client_id and client_secret to a user that has pushed a barebones CLI app. 

Also some outdated hyperlink updates. 