### PR TITLE
feat(core) - Add support for locking

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -125,6 +125,14 @@ type DehydrateFunc = <T>(
   inputData: T
 ) => string;
 
+type LockFunc = <T>(
+  key: [string],
+  value: string,
+  maxLockSec: number,
+  callbackFn: () => Promise<T>,
+  scope: string
+) => Promise<T>;
+
 export interface ZObject {
   request: {
     // most specific overloads go first
@@ -200,4 +208,5 @@ export interface ZObject {
     set: (key: string, value: any, ttl?: number) => Promise<boolean>;
     delete: (key: string) => Promise<boolean>;
   };
+  lock: LockFunc;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,8 @@
     "aws-sdk": "^2.1397.0",
     "dicer": "^0.3.1",
     "fs-extra": "^11.1.1",
-    "mock-fs": "^5.2.0"
+    "mock-fs": "^5.2.0",
+    "timekeeper": "^2.2.0"
   },
   "optionalDependencies": {
     "@types/node": "^20.3.1"

--- a/packages/core/src/app-middlewares/before/z-object.js
+++ b/packages/core/src/app-middlewares/before/z-object.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 
 const createAppRequestClient = require('../../tools/create-app-request-client');
 const createCache = require('../../tools/create-cache');
+const createLock = require('../../tools/create-lock');
 const createDehydrator = require('../../tools/create-dehydrator');
 const createFileStasher = require('../../tools/create-file-stasher');
 const createJSONtool = require('../../tools/create-json-tool');
@@ -19,8 +20,9 @@ const hashing = require('../../tools/hashing');
 */
 const injectZObject = (input) => {
   const bundle = _.get(input, '_zapier.event.bundle', {});
+  const cache = createCache(input);
   const zRoot = {
-    cache: createCache(input),
+    cache,
     console: createLoggerConsole(input),
     cursor: createStoreKeyTool(input),
     dehydrate: createDehydrator(input, 'method'),
@@ -29,6 +31,7 @@ const injectZObject = (input) => {
     generateCallbackUrl: createCallbackHigherOrderFunction(input),
     hash: hashing.hashify,
     JSON: createJSONtool(),
+    lock: createLock(input, cache),
     require: (moduleName) => require(moduleName),
     stashFile: createFileStasher(input),
   };

--- a/packages/core/src/tools/create-cache.js
+++ b/packages/core/src/tools/create-cache.js
@@ -24,21 +24,39 @@ const createCache = (input) => {
   };
 
   return {
-    get: async (key) => {
+    get: async (key, namespaceMode = null, namespaceScope = null) => {
       runValidationChecks(rpc, key);
 
-      const result = await rpc('zcache_get', key);
+      const result = await rpc(
+        'zcache_get',
+        key,
+        namespaceMode,
+        namespaceScope
+      );
       return result ? JSON.parse(result) : null;
     },
-    set: async (key, value, ttl = null) => {
+    set: async (
+      key,
+      value,
+      ttl = null,
+      namespaceMode = null,
+      namespaceScope = null
+    ) => {
       runValidationChecks(rpc, key, value, ttl);
 
-      return await rpc('zcache_set', key, JSON.stringify(value), ttl);
+      return await rpc(
+        'zcache_set',
+        key,
+        JSON.stringify(value),
+        ttl,
+        namespaceMode,
+        namespaceScope
+      );
     },
-    delete: async (key) => {
+    delete: async (key, namespaceMode = null, namespaceScope = null) => {
       runValidationChecks(rpc, key);
 
-      return await rpc('zcache_delete', key);
+      return await rpc('zcache_delete', key, namespaceMode, namespaceScope);
     },
   };
 };

--- a/packages/core/src/tools/create-lock.js
+++ b/packages/core/src/tools/create-lock.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const _ = require('lodash');
+const { ThrottledError } = require('../errors');
+
+const createLock = (input, cache) => {
+  const _unlock = async (key, scope) => {
+    await cache.delete(key, 'locking', scope);
+  };
+
+  const validateInput = (key, callbackFn, maxLockSec, scope) => {
+    if (!Array.isArray(key)) {
+      throw new TypeError('key must be an array');
+    }
+
+    if (!_.isFunction(callbackFn)) {
+      throw new TypeError('callbackFn must be a function');
+    }
+
+    if (!_.isInteger(maxLockSec)) {
+      throw new TypeError('maxLockSec must be an integer');
+    } else if (maxLockSec <= 0) {
+      throw new TypeError('maxLockSec must be greater than 0');
+    }
+
+    if (scope && scope !== 'user' && scope !== 'global' && scope !== 'auth') {
+      throw new TypeError(
+        `scope '${scope}' is invalid. It must be one of user, global, or auth`
+      );
+    }
+  };
+  const _lock = async (key, callbackFn, maxLockSec, scope) => {
+    validateInput(key, callbackFn, maxLockSec, scope);
+
+    const lockKey = key.join('-');
+
+    // Set the lock expiry as the value
+    const expirationTimeMs = Date.now() + maxLockSec * 10000;
+
+    const response = await cache.set(
+      lockKey,
+      expirationTimeMs,
+      maxLockSec,
+      'locking',
+      scope
+    );
+
+    // Did not acquire lock, try again later. The response value is the lock expiry
+    // time, so we can calculate the remaining time to wait.
+    if (typeof response === 'string') {
+      const remainingTimeSec = (Number(response) - Date.now()) / 10000;
+      throw new ThrottledError(
+        'Unable to acquire lock, trying again in ' +
+          remainingTimeSec +
+          ' seconds',
+        remainingTimeSec
+      );
+    }
+
+    // Lock acquired, will invoke callbackFn and return
+    let callbackResponse;
+    if (response) {
+      try {
+        callbackResponse = await callbackFn();
+      } finally {
+        await _unlock(lockKey, scope);
+      }
+      return callbackResponse;
+    }
+
+    throw new Error('Unable to acquire lock due to server issues.');
+  };
+  return (key, callbackFn, maxLockSec, scope = 'user') =>
+    _lock(key, callbackFn, maxLockSec, scope);
+};
+
+module.exports = createLock;

--- a/packages/core/test/tools/create-lock.js
+++ b/packages/core/test/tools/create-lock.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const should = require('should');
+const { makeRpc, mockRpcCall } = require('./mocky');
+const createCache = require('../../src/tools/create-cache');
+const createLock = require('../../src/tools/create-lock');
+const { ThrottledError } = require('../../src/errors');
+const timekeeper = require('timekeeper');
+
+describe('lock', () => {
+  const rpc = makeRpc();
+  const input = { _zapier: { rpc } };
+  const cache = createCache(input);
+  const lock = createLock(input, cache);
+
+  afterEach(() => {
+    timekeeper.reset();
+  });
+
+  it('should acquire lock successfully', async () => {
+    // Acquire the lock
+    mockRpcCall(true);
+    // Release the lock
+    mockRpcCall(true);
+
+    const expensiveCall = async () =>
+      new Promise((resolve) => {
+        resolve('success');
+      });
+
+    const result = await lock(['test'], expensiveCall, 10);
+    should(result).eql('success');
+  });
+
+  it('should throw ThrottledError if trying to acquire a held lock', async () => {
+    const someTimeAgo = new Date('2020-01-01T00:00:00Z'); // Using ISO format
+    timekeeper.freeze(someTimeAgo);
+    const expiry = someTimeAgo.getTime() + 30 * 10000; // set to 30 seconds from 'someTimeAgo'
+
+    const now = new Date(someTimeAgo.getTime() + 10 * 10000); // 10 seconds from 'someTimeAgo'
+    const expectedDelay = (expiry - now.getTime()) / 10000; // 20 seconds
+    timekeeper.freeze(now);
+
+    const expensiveCall = async () =>
+      new Promise((resolve) => resolve('success'));
+
+    try {
+      mockRpcCall(String(expiry));
+      await lock(['test'], expensiveCall, 30);
+    } catch (err) {
+      should(err).instanceOf(ThrottledError);
+      err.name.should.eql('ThrottledError');
+
+      const response = JSON.parse(err.message);
+      response.delay.should.eql(expectedDelay);
+    }
+  });
+
+  it('should throw TypeError if input fields are not valid', async () => {
+    // Invalid key array
+    await lock('test', () => {}, 10).should.be.rejectedWith(TypeError);
+    // Invalid callbackFn
+    await lock(['test'], '12', 10).should.be.rejectedWith(TypeError);
+    // Invalid maxLockSec
+    await lock('test', () => {}, -3).should.be.rejectedWith(TypeError);
+    // Invalid scope
+    await lock('test', () => {}, 30, 'fake-scope').should.be.rejectedWith(
+      TypeError
+    );
+  });
+
+  it('should default to using the user namespace scope', async () => {
+    const setNamespace = {
+      mode: '',
+      scope: '',
+    };
+    const deleteNamespace = {
+      mode: '',
+      scope: '',
+    };
+    const cache = {
+      set: (key, value, maxLockSec, namespaceMode, namespaceScope) => {
+        setNamespace.mode = namespaceMode;
+        setNamespace.scope = namespaceScope;
+        return true;
+      },
+      delete: (key, namespaceMode, namespaceScope) => {
+        deleteNamespace.mode = namespaceMode;
+        deleteNamespace.scope = namespaceScope;
+        return true;
+      },
+    };
+    const lock = createLock(input, cache);
+    const expensiveCall = async () => {
+      return 'success';
+    };
+    await lock(['test'], expensiveCall, 10);
+    setNamespace.mode.should.eql('locking');
+    setNamespace.scope.should.eql('user');
+    deleteNamespace.mode.should.eql('locking');
+    deleteNamespace.scope.should.eql('user');
+  });
+
+  it('should use the same namespace parameters to lock and unlock', async () => {
+    const setNamespace = {
+      mode: '',
+      scope: '',
+    };
+    const deleteNamespace = {
+      mode: '',
+      scope: '',
+    };
+    const cache = {
+      set: (key, value, maxLockSec, namespaceMode, namespaceScope) => {
+        setNamespace.mode = namespaceMode;
+        setNamespace.scope = namespaceScope;
+        return true;
+      },
+      delete: (key, namespaceMode, namespaceScope) => {
+        deleteNamespace.mode = namespaceMode;
+        deleteNamespace.scope = namespaceScope;
+        return true;
+      },
+    };
+    const lock = createLock(input, cache);
+    const expensiveCall = async () => {
+      return 'success';
+    };
+    await lock(['test'], expensiveCall, 10, 'global');
+    setNamespace.mode.should.eql('locking');
+    setNamespace.scope.should.eql('global');
+    deleteNamespace.mode.should.eql('locking');
+    deleteNamespace.scope.should.eql('global');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -11095,6 +11095,11 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+timekeeper@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.2.0.tgz#9645731fce9e3280a18614a57a9d1b72af3ca368"
+  integrity sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==
+
 timers-browserify@^1.0.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"


### PR DESCRIPTION
Add support for locking.
To help review the code, the locking usage would look like this:

this is the interface for devs
```js
lock(key: [string], value: string, callbackFn: Function, maxLockSec: number, scope: 'global' | 'user' | 'auth')
```

```js
const expensiveCall = () => z.request(requestOptions)
const response = await z.lock(['lyrics', params.songId], 10, expensiveCall, 'global')
```
if lock acquired - return results from `expensiveCall`, calls unlock
if lock is held by another process - throw ThrottledError
if lock failed for other reasons - throw generic Error


