### PR TITLE
SUPPORTENG-929_Adding detail on encoding default

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3068,6 +3068,7 @@ Use [</code>skipEncodingChars`](<a href="https://github.com/zapier/zapier-platfo
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> perform = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-comment">// something like this url:</span>
   <span class="hljs-comment">// https://zapier.com/hooks/callback/123/abcdef01-2345-6789-abcd-ef0123456789/abcdef0123456789abcdef0123456789abcdef01/</span>
+  <span class="hljs-comment">// consider checking bundle.meta.isLoadingSample to determine if this is a test run or real run!</span>
   <span class="hljs-keyword">const</span> callbackUrl = z.generateCallbackUrl();
   <span class="hljs-keyword">await</span> z.request({
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com/api/slow-job&apos;</span>,
@@ -3099,7 +3100,9 @@ Use [</code>skipEncodingChars`](<a href="https://github.com/zapier/zapier-platfo
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>And finally, in a <code>performResume</code> to handle the final step which will receive three bundle properties:</p><ul>
+      <blockquote>
+<p>We recommend using <code>bundle.meta.isLoadingSample</code> to determine if the execution is happening in the foreground (IE: during Zap setup) as using <code>z.generateCallbackUrl()</code> can be inappropriate given the disconnect. Instead, wait for the long running request without generating a callback, or if you must, return stubbed data.</p>
+</blockquote><p>And finally, in a <code>performResume</code> to handle the final step which will receive three bundle properties:</p><ul>
 <li><code>bundle.outputData</code> is <code>{&quot;hello&quot;: &quot;world&quot;}</code>, the data returned from the initial <code>perform</code></li>
 <li><code>bundle.cleanedRequest</code> is <code>{&quot;foo&quot;: &quot;bar&quot;}</code>, the payload from the callback URL</li>
 <li><code>bundle.rawRequest</code> is the full request object corresponding to <code>bundle.cleanedRequest</code></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2890,7 +2890,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><code>z.request([url], options)</code> is a promise based HTTP client with some Zapier-specific goodies. See <a href="#making-http-requests">Making HTTP Requests</a>.</p>
+      <p><code>z.request([url], options)</code> is a promise based HTTP client with some Zapier-specific goodies. See <a href="#making-http-requests">Making HTTP Requests</a>. <code>z.request()</code> will percent-encode non-ascii characters and these reserved characters: :$/?#[]@$&amp;+,;=^@<code>\. 
+Use [</code>skipEncodingChars`](<a href="https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#requestschema">https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#requestschema</a>) to modify this behaviour. </p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -815,7 +815,8 @@ We provide several methods off of the `z` object, which is provided as the first
 
 ### `z.request([url], options)`
 
-`z.request([url], options)` is a promise based HTTP client with some Zapier-specific goodies. See [Making HTTP Requests](#making-http-requests).
+`z.request([url], options)` is a promise based HTTP client with some Zapier-specific goodies. See [Making HTTP Requests](#making-http-requests). `z.request()` will percent-encode non-ascii characters and these reserved characters: :$/?#[]@$&+,;=^@`\. 
+Use [`skipEncodingChars`](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#requestschema) to modify this behaviour. 
 
 ### `z.console`
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -875,6 +875,7 @@ For example, in your `perform` you might do:
 const perform = async (z, bundle) => {
   // something like this url:
   // https://zapier.com/hooks/callback/123/abcdef01-2345-6789-abcd-ef0123456789/abcdef0123456789abcdef0123456789abcdef01/
+  // consider checking bundle.meta.isLoadingSample to determine if this is a test run or real run!
   const callbackUrl = z.generateCallbackUrl();
   await z.request({
     url: 'https://example.com/api/slow-job',
@@ -897,6 +898,7 @@ Content-Type: application/json
 
 {"foo":"bar"}
 ```
+> We recommend using `bundle.meta.isLoadingSample` to determine if the execution is happening in the foreground (IE: during Zap setup) as using `z.generateCallbackUrl()` can be inappropriate given the disconnect. Instead, wait for the long running request without generating a callback, or if you must, return stubbed data.
 
 And finally, in a `performResume` to handle the final step which will receive three bundle properties:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1788,7 +1788,8 @@ We provide several methods off of the `z` object, which is provided as the first
 
 ### `z.request([url], options)`
 
-`z.request([url], options)` is a promise based HTTP client with some Zapier-specific goodies. See [Making HTTP Requests](#making-http-requests).
+`z.request([url], options)` is a promise based HTTP client with some Zapier-specific goodies. See [Making HTTP Requests](#making-http-requests). `z.request()` will percent-encode non-ascii characters and these reserved characters: :$/?#[]@$&+,;=^@`\. 
+Use [`skipEncodingChars`](https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#requestschema) to modify this behaviour. 
 
 ### `z.console`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1848,6 +1848,7 @@ For example, in your `perform` you might do:
 const perform = async (z, bundle) => {
   // something like this url:
   // https://zapier.com/hooks/callback/123/abcdef01-2345-6789-abcd-ef0123456789/abcdef0123456789abcdef0123456789abcdef01/
+  // consider checking bundle.meta.isLoadingSample to determine if this is a test run or real run!
   const callbackUrl = z.generateCallbackUrl();
   await z.request({
     url: 'https://example.com/api/slow-job',
@@ -1870,6 +1871,7 @@ Content-Type: application/json
 
 {"foo":"bar"}
 ```
+> We recommend using `bundle.meta.isLoadingSample` to determine if the execution is happening in the foreground (IE: during Zap setup) as using `z.generateCallbackUrl()` can be inappropriate given the disconnect. Instead, wait for the long running request without generating a callback, or if you must, return stubbed data.
 
 And finally, in a `performResume` to handle the final step which will receive three bundle properties:
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3068,6 +3068,7 @@ Use [</code>skipEncodingChars`](<a href="https://github.com/zapier/zapier-platfo
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> perform = <span class="hljs-keyword">async</span> (z, bundle) =&gt; {
   <span class="hljs-comment">// something like this url:</span>
   <span class="hljs-comment">// https://zapier.com/hooks/callback/123/abcdef01-2345-6789-abcd-ef0123456789/abcdef0123456789abcdef0123456789abcdef01/</span>
+  <span class="hljs-comment">// consider checking bundle.meta.isLoadingSample to determine if this is a test run or real run!</span>
   <span class="hljs-keyword">const</span> callbackUrl = z.generateCallbackUrl();
   <span class="hljs-keyword">await</span> z.request({
     <span class="hljs-attr">url</span>: <span class="hljs-string">&apos;https://example.com/api/slow-job&apos;</span>,
@@ -3099,7 +3100,9 @@ Use [</code>skipEncodingChars`](<a href="https://github.com/zapier/zapier-platfo
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>And finally, in a <code>performResume</code> to handle the final step which will receive three bundle properties:</p><ul>
+      <blockquote>
+<p>We recommend using <code>bundle.meta.isLoadingSample</code> to determine if the execution is happening in the foreground (IE: during Zap setup) as using <code>z.generateCallbackUrl()</code> can be inappropriate given the disconnect. Instead, wait for the long running request without generating a callback, or if you must, return stubbed data.</p>
+</blockquote><p>And finally, in a <code>performResume</code> to handle the final step which will receive three bundle properties:</p><ul>
 <li><code>bundle.outputData</code> is <code>{&quot;hello&quot;: &quot;world&quot;}</code>, the data returned from the initial <code>perform</code></li>
 <li><code>bundle.cleanedRequest</code> is <code>{&quot;foo&quot;: &quot;bar&quot;}</code>, the payload from the callback URL</li>
 <li><code>bundle.rawRequest</code> is the full request object corresponding to <code>bundle.cleanedRequest</code></li>

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2890,7 +2890,8 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><code>z.request([url], options)</code> is a promise based HTTP client with some Zapier-specific goodies. See <a href="#making-http-requests">Making HTTP Requests</a>.</p>
+      <p><code>z.request([url], options)</code> is a promise based HTTP client with some Zapier-specific goodies. See <a href="#making-http-requests">Making HTTP Requests</a>. <code>z.request()</code> will percent-encode non-ascii characters and these reserved characters: :$/?#[]@$&amp;+,;=^@<code>\. 
+Use [</code>skipEncodingChars`](<a href="https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#requestschema">https://github.com/zapier/zapier-platform/blob/main/packages/schema/docs/build/schema.md#requestschema</a>) to modify this behaviour. </p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
as suggested here https://zapier.slack.com/archives/C04P5J5R8E4/p1689900123007759 

also added detail for callback testing, per https://zapier.slack.com/archives/C5Z9BP4U9/p1691168493239769?thread_ts=1691167523.978609&cid=C5Z9BP4U9 