### PR TITLE
fix(cli): Remove logic converting empty array to undefined in changelog metadata

### DIFF
--- a/packages/cli/src/tests/utils/changelog.js
+++ b/packages/cli/src/tests/utils/changelog.js
@@ -23,6 +23,9 @@ describe('changelog utils', () => {
           '5. New action! create/add_contact\n' +
           'However, we also addressed fixed open issues!\n' +
           '- Fix #123 and an issue with create/send_message\n\n' +
+          '## 2.0.1\n\n' +
+          '1. Action fix only\n' +
+          '2. Another action fix\n\n' +
           '## new and improved version! (v2.0.0)\n\n' +
           '* Fix some bugs.\n' +
           '* Major docs fixes.\n\n' +
@@ -42,8 +45,8 @@ describe('changelog utils', () => {
     it('should be forgiving on the markdown format', async () => {
       const { appMetadata, issueMetadata, changelog } =
         await changelogUtil.getVersionChangelog('0.0.1', appDir);
-      should(appMetadata).equal(undefined);
-      should(issueMetadata).equal(undefined);
+      should(appMetadata.length).equal(0);
+      should(issueMetadata.length).equal(0);
       changelog.should.equal('initial release\n\njust for internal testing');
     });
 
@@ -74,8 +77,8 @@ describe('changelog utils', () => {
     it('should not return metadata if it is not found', async () => {
       const { appMetadata, issueMetadata, changelog } =
         await changelogUtil.getVersionChangelog('1.0.0', appDir);
-      should(appMetadata).equal(undefined);
-      should(issueMetadata).equal(undefined);
+      should(appMetadata.length).equal(0);
+      should(issueMetadata.length).equal(0);
       changelog.should.equal('* Removing beta "label".\n* Minor docs fixes.');
     });
 

--- a/packages/cli/src/utils/changelog.js
+++ b/packages/cli/src/utils/changelog.js
@@ -8,9 +8,6 @@ const isAppMetadata = (obj) =>
 
 const isIssueMetadata = (obj) => obj?.app_change_type && obj?.issue_id;
 
-// Turns an empty array into undefined so it will not be present in the body when sent
-const absentIfEmpty = (arr) => (arr.length === 0 ? undefined : arr);
-
 const getChangelogFromMarkdown = (version, markdown) => {
   const lines = markdown
     .replace(/\r\n/g, '\n')
@@ -56,8 +53,8 @@ const getChangelogFromMarkdown = (version, markdown) => {
 
   return {
     changelog: changelog.join('\n').trim(),
-    appMetadata: absentIfEmpty(appMetadata),
-    issueMetadata: absentIfEmpty(issueMetadata),
+    appMetadata,
+    issueMetadata,
   };
 };
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Currently, if either an App type update or an Issue type update is present, the promotion process expects **both** to be present. If only one is present, the other is converted to `undefined` instead of an empty array. However, there is a `join` attempt on both values -- so if one is undefined, the code returns something like `TypeError: issueFeatureUpdates is not iterable`.

This blocks the developer from promoting and doesn't clearly state what they need to do to fix it, which is not ideal.

It looks like this logic was originally added to keep empty fields from being included in the changelog -- however, I was not able to find instances where that would actually happen. Either way, empty fields would be preferable to blocking developers from promoting if they only include one of an issue type update and an app type update.