### PR TITLE
PDE-4140 feat(cli): Integration title length must be at least 2 characters

### DIFF
--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -57,6 +57,7 @@ const IS_TESTING =
   argvStr.includes('jest') ||
   (process.env.NODE_ENV || '').toLowerCase().startsWith('test');
 
+const MIN_TITLE_LENGTH = 2;
 const MAX_DESCRIPTION_LENGTH = 140;
 
 const EXAMPLE_CHANGELOG = `
@@ -101,6 +102,7 @@ module.exports = {
   ISSUES_URL,
   LAMBDA_VERSION,
   LEGACY_RUNNER_PACKAGE,
+  MIN_TITLE_LENGTH,
   MAX_DESCRIPTION_LENGTH,
   NODE_VERSION,
   NODE_VERSION_CLI_REQUIRES,

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -167,6 +167,10 @@ class ZapierBaseCommand extends Command {
           input.length > charLimit
             ? `Please provide a value ${charLimit} characters or less.`
             : true,
+        charMinimum: (input, charMinimum) =>
+          input.length < charMinimum
+            ? `Please provide a value ${charMinimum} characters or more.`
+            : true,
       };
       let aggregateResult = true;
 

--- a/packages/cli/src/oclif/commands/register.js
+++ b/packages/cli/src/oclif/commands/register.js
@@ -33,7 +33,10 @@ class RegisterCommand extends ZapierBaseCommand {
       );
     }
 
-    if ('title' in this.args && this.args.title.length < MIN_TITLE_LENGTH) {
+    if (
+      this.args.title !== undefined &&
+      this.args.title.length < MIN_TITLE_LENGTH
+    ) {
       throw new Error(
         `Please provide a title that is ${MIN_TITLE_LENGTH} characters or more.`
       );

--- a/packages/cli/src/oclif/commands/register.js
+++ b/packages/cli/src/oclif/commands/register.js
@@ -2,7 +2,11 @@ const colors = require('colors/safe');
 const { flags } = require('@oclif/command');
 
 const ZapierBaseCommand = require('../ZapierBaseCommand');
-const { CURRENT_APP_FILE, MAX_DESCRIPTION_LENGTH } = require('../../constants');
+const {
+  CURRENT_APP_FILE,
+  MAX_DESCRIPTION_LENGTH,
+  MIN_TITLE_LENGTH,
+} = require('../../constants');
 const { buildFlags } = require('../buildFlags');
 const {
   callAPI,
@@ -18,6 +22,12 @@ class RegisterCommand extends ZapierBaseCommand {
    */
   async perform() {
     // Flag validation
+    if ('title' in this.args && this.args.title.length < MIN_TITLE_LENGTH) {
+      throw new Error(
+        `Please provide a title that is ${MIN_TITLE_LENGTH} characters or more.`
+      );
+    }
+
     this._validateEnumFlags();
     if (
       'desc' in this.flags &&
@@ -145,9 +155,10 @@ class RegisterCommand extends ZapierBaseCommand {
     appMeta.title = this.args.title?.trim();
     if (!appMeta.title) {
       appMeta.title = await this.prompt(
-        'What is the title of your integration?',
+        `What is the title of your integration? It must be ${MIN_TITLE_LENGTH} characters at minimum.`,
         {
           required: true,
+          charMinimum: MIN_TITLE_LENGTH,
           default: this.app?.title,
         }
       );
@@ -241,7 +252,7 @@ RegisterCommand.args = [
   {
     name: 'title',
     description:
-      "Your integrations's public title. Asked interactively if not present.",
+      "Your integration's public title. Asked interactively if not present.",
   },
 ];
 

--- a/packages/cli/src/oclif/commands/register.js
+++ b/packages/cli/src/oclif/commands/register.js
@@ -22,19 +22,20 @@ class RegisterCommand extends ZapierBaseCommand {
    */
   async perform() {
     // Flag validation
-    if ('title' in this.args && this.args.title.length < MIN_TITLE_LENGTH) {
-      throw new Error(
-        `Please provide a title that is ${MIN_TITLE_LENGTH} characters or more.`
-      );
-    }
-
     this._validateEnumFlags();
+
     if (
       'desc' in this.flags &&
       this.flags.desc.length > MAX_DESCRIPTION_LENGTH
     ) {
       throw new Error(
         `Please provide a description that is ${MAX_DESCRIPTION_LENGTH} characters or less.`
+      );
+    }
+
+    if ('title' in this.args && this.args.title.length < MIN_TITLE_LENGTH) {
+      throw new Error(
+        `Please provide a title that is ${MIN_TITLE_LENGTH} characters or more.`
       );
     }
 

--- a/packages/cli/src/tests/register.test.js
+++ b/packages/cli/src/tests/register.test.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const oclif = require('@oclif/test');
-const { BASE_ENDPOINT, MAX_DESCRIPTION_LENGTH } = require('../constants');
+const {
+  BASE_ENDPOINT,
+  MIN_TITLE_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+} = require('../constants');
 const registerFieldChoices = require('./fixtures/registerFieldChoices');
 const { privateApp, publicApp } = require('./fixtures/createApp');
 
@@ -24,6 +28,19 @@ describe('RegisterCommand', () => {
         .reply(200, registerFieldChoices)
     );
   }
+
+  describe('zapier register should enforce character minimum on title', function () {
+    getTestObj()
+      .command(['register', 't'])
+      .catch((ctx) => {
+        oclif
+          .expect(ctx.message)
+          .to.contain(
+            `Please provide a title that is ${MIN_TITLE_LENGTH} characters or more.`
+          );
+      })
+      .it('zapier register should enforce character minimum on title flag');
+  });
 
   describe('zapier register should enforce character limits on flags', function () {
     getTestObj()


### PR DESCRIPTION
This PR adds a minimum length constraint for an integration title when adding via zapier register.