### PR TITLE
docs(cli): update z.cursor docs for how to handle reaching the end of the result set

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5513,8 +5513,8 @@ zapier push
   );
 
   <span class="hljs-comment">// after fetching a page, set the returned cursor for the next page,</span>
-  <span class="hljs-comment">// or empty/null if this was the last one.</span>
-  <span class="hljs-keyword">await</span> z.cursor.set(response.nextPage);
+  <span class="hljs-comment">// or an empty string if the cursor is null</span>
+  <span class="hljs-keyword">await</span> z.cursor.set(response.nextPage ?? <span class="hljs-string">&apos;&apos;</span>);
 
   <span class="hljs-keyword">return</span> response.items;
 };

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3467,8 +3467,8 @@ const perform = async (z, bundle) => {
   );
 
   // after fetching a page, set the returned cursor for the next page,
-  // or empty/null if this was the last one.
-  await z.cursor.set(response.nextPage);
+  // or an empty string if the cursor is null
+  await z.cursor.set(response.nextPage ?? '');
 
   return response.items;
 };

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -5513,8 +5513,8 @@ zapier push
   );
 
   <span class="hljs-comment">// after fetching a page, set the returned cursor for the next page,</span>
-  <span class="hljs-comment">// or empty/null if this was the last one.</span>
-  <span class="hljs-keyword">await</span> z.cursor.set(response.nextPage);
+  <span class="hljs-comment">// or an empty string if the cursor is null</span>
+  <span class="hljs-keyword">await</span> z.cursor.set(response.nextPage ?? <span class="hljs-string">&apos;&apos;</span>);
 
   <span class="hljs-keyword">return</span> response.items;
 };

--- a/packages/cli/snippets/paging-cursor.js
+++ b/packages/cli/snippets/paging-cursor.js
@@ -23,8 +23,8 @@ const perform = async (z, bundle) => {
   );
 
   // after fetching a page, set the returned cursor for the next page,
-  // or empty/null if this was the last one.
-  await z.cursor.set(response.nextPage);
+  // or an empty string if the cursor is null
+  await z.cursor.set(response.nextPage ?? '');
 
   return response.items;
 };


### PR DESCRIPTION
Small syntax improvement in the docs example - the previous example would throw an error if `response.nextPage` was `null` which would commonly be the case.
