### PR TITLE
[PDE-4304] fix(core): z.cursor.set() returns TypeError with non-string arguments

### DIFF
--- a/packages/core/src/tools/create-storekey-tool.js
+++ b/packages/core/src/tools/create-storekey-tool.js
@@ -14,9 +14,16 @@ const createStoreKeyTool = (input) => {
 
       return rpc('get_cursor');
     },
+
     set: (cursor) => {
       if (!rpc) {
         return ZapierPromise.reject(new Error('rpc is not available'));
+      }
+
+      if (!_.isString(cursor)) {
+        return ZapierPromise.reject(
+          new TypeError('cursor value must be a string')
+        );
       }
 
       return rpc('set_cursor', cursor);

--- a/packages/core/test/tools/create-storekey-tools.js
+++ b/packages/core/test/tools/create-storekey-tools.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const should = require('should');
+
+const { makeRpc, mockRpcCall } = require('./mocky');
+const createStoreKeyTool = require('../../src/tools/create-storekey-tool');
+
+describe('storekey (cursor): get, set', () => {
+  const rpc = makeRpc();
+  const cursor = createStoreKeyTool({ _zapier: { rpc } });
+
+  it('storekey (cursor) get: should return the cursor value given a key', async () => {
+    const expected = 64;
+    mockRpcCall(expected);
+
+    const result = await cursor.get('existing-key');
+    should(result).eql(expected);
+  });
+
+  it('storekey (cursor) set: should raise TypeError on non-string value', async () => {
+    await should(cursor.set(64)).rejectedWith(TypeError, {
+      message: 'cursor value must be a string',
+    });
+
+    await should(cursor.set(null)).rejectedWith(TypeError, {
+      message: 'cursor value must be a string',
+    });
+
+    await should(cursor.set(undefined)).rejectedWith(TypeError, {
+      message: 'cursor value must be a string',
+    });
+  });
+
+  it('storekey (cursor) set: should set a cursor entry', async () => {
+    const expected = 'ok';
+    mockRpcCall(expected);
+
+    const result1 = await cursor.set('test-key');
+    should(result1).eql(expected);
+  });
+});


### PR DESCRIPTION
* Added a `TypeError` check for non-string cursors in `z.cursor.set()`.

Note regarding backwards compatibility: Using `z.cursor.set` with `Number`, `undefined` or `null` values results in the Zapier monolith throwing an exception. Therefore, this change is just moving the check closer to where the error is (improving the developer experience). But technically, it does break backwards compatibility 🤔 

See Jira ticket for more details and links to context: https://zapierorg.atlassian.net/browse/PDE-4304