### PR TITLE
[PDE-4286] fix(boilerplate): clear build directory before building

### DIFF
--- a/boilerplate/scripts/build.sh
+++ b/boilerplate/scripts/build.sh
@@ -67,7 +67,11 @@ BOILERPLATE_DIR="$REPO_DIR/boilerplate"
 
 BUILD_DIR="$BOILERPLATE_DIR/build"
 
-mkdir -p $BUILD_DIR
+# Prevent leftover old builds from being included
+if [ -d $BUILD_DIR ]; then
+    --rm --rf $BUILD_DIR
+
+mkdir $BUILD_DIR
 
 # Copy files
 cp "$CORE_DIR/include/zapierwrapper.js" "$BOILERPLATE_DIR/"

--- a/boilerplate/scripts/build.sh
+++ b/boilerplate/scripts/build.sh
@@ -67,11 +67,13 @@ BOILERPLATE_DIR="$REPO_DIR/boilerplate"
 
 BUILD_DIR="$BOILERPLATE_DIR/build"
 
-# Prevent leftover old builds from being included
+# Prevent leftover old builds from being included in new build
 if [ -d $BUILD_DIR ]; then
-    --rm --rf $BUILD_DIR
+    echo "Removing existing boilerplate/build directory..."
+    rm -r "$BUILD_DIR"
+fi
 
-mkdir $BUILD_DIR
+mkdir -p $BUILD_DIR
 
 # Copy files
 cp "$CORE_DIR/include/zapierwrapper.js" "$BOILERPLATE_DIR/"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Currently, when building the boilerplate, if it is unclean (old build files persists from previous runs), then that increases the size of the new build, which can cause issues.

This PR updates the script to remove the old build directory and recreate it before running, to make sure nothing is lingering.