### PR TITLE
PDE-4193 docs(cli): fix broken link in README-source.md

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -619,7 +619,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://platform.zapier.com/cli_tutorials/getting-started">Tutorial</a> for a more thorough introduction.</p>
+<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://platform.zapier.com/quickstart/cli-tutorial">Tutorial</a> for a more thorough introduction.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -34,7 +34,7 @@ This doc describes the latest CLI version (**PACKAGE_VERSION**), as of this writ
 
 ## Getting Started
 
-> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://platform.zapier.com/cli_tutorials/getting-started) for a more thorough introduction.
+> If you're new to Zapier Platform CLI, we strongly recommend you to walk through the [Tutorial](https://platform.zapier.com/quickstart/cli-tutorial) for a more thorough introduction.
 
 ### What is an App?
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -619,7 +619,7 @@ a code {
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
       <blockquote>
-<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://platform.zapier.com/cli_tutorials/getting-started">Tutorial</a> for a more thorough introduction.</p>
+<p>If you&apos;re new to Zapier Platform CLI, we strongly recommend you to walk through the <a href="https://platform.zapier.com/quickstart/cli-tutorial">Tutorial</a> for a more thorough introduction.</p>
 </blockquote>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Copies the change in #713 back to README-source.md.