### PR TITLE
feat(schema): Add steadyState property on FieldSchema

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -963,6 +963,7 @@ Key | Required | Type | Description
 `dict` | no | `boolean` | Is this field a key/value input?
 `computed` | no | `boolean` | Is this field automatically populated (and hidden from the user)? Note: Only OAuth and Session Auth support fields with this key.
 `altersDynamicFields` | no | `boolean` | Does the value of this field affect the definitions of other fields in the set?
+`steadyState` | no | `boolean` | Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. Can be used to, e.g., not trigger on a new contact until the contact has completed typing their name.
 `inputFormat` | no | `string` | Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user's input (IE: "https://{{input}}.yourdomain.com").
 
 #### Examples

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -963,7 +963,7 @@ Key | Required | Type | Description
 `dict` | no | `boolean` | Is this field a key/value input?
 `computed` | no | `boolean` | Is this field automatically populated (and hidden from the user)? Note: Only OAuth and Session Auth support fields with this key.
 `altersDynamicFields` | no | `boolean` | Does the value of this field affect the definitions of other fields in the set?
-`steadyState` | no | `boolean` | Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. Can be used to, e.g., not trigger on a new contact until the contact has completed typing their name.
+`steadyState` | no | `boolean` | Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. It can be used to, e.g., not trigger on a new contact until the contact has completed typing their name. NOTE that this only applies to the `outputFields` of polling triggers.
 `inputFormat` | no | `string` | Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user's input (IE: "https://{{input}}.yourdomain.com").
 
 #### Examples

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -238,7 +238,7 @@
           "type": "boolean"
         },
         "steadyState": {
-          "description": "Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. Can be used to, e.g., not trigger on a new contact until the contact has completed typing their name.",
+          "description": "Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. It can be used to, e.g., not trigger on a new contact until the contact has completed typing their name. NOTE that this only applies to the `outputFields` of polling triggers.",
           "type": "boolean"
         },
         "inputFormat": {

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -237,6 +237,10 @@
           "description": "Does the value of this field affect the definitions of other fields in the set?",
           "type": "boolean"
         },
+        "steadyState": {
+          "description": "Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. Can be used to, e.g., not trigger on a new contact until the contact has completed typing their name.",
+          "type": "boolean"
+        },
         "inputFormat": {
           "description": "Useful when you expect the input to be part of a longer string. Put \"{{input}}\" in place of the user's input (IE: \"https://{{input}}.yourdomain.com\").",
           "type": "string",

--- a/packages/schema/lib/schemas/FieldSchema.js
+++ b/packages/schema/lib/schemas/FieldSchema.js
@@ -121,7 +121,7 @@ module.exports = makeSchema(
         type: 'boolean',
       },
       steadyState: {
-        description: 'Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. Can be used to, e.g., not trigger on a new contact until the contact has completed typing their name.',
+        description: 'Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. It can be used to, e.g., not trigger on a new contact until the contact has completed typing their name. NOTE that this only applies to the `outputFields` of polling triggers.',
         type: 'boolean',
       },
       inputFormat: {

--- a/packages/schema/lib/schemas/FieldSchema.js
+++ b/packages/schema/lib/schemas/FieldSchema.js
@@ -120,6 +120,10 @@ module.exports = makeSchema(
           'Does the value of this field affect the definitions of other fields in the set?',
         type: 'boolean',
       },
+      steadyState: {
+        description: 'Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. Can be used to, e.g., not trigger on a new contact until the contact has completed typing their name.',
+        type: 'boolean',
+      },
       inputFormat: {
         description:
           'Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user\'s input (IE: "https://{{input}}.yourdomain.com").',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Adds an optional property `steadyState` on the `FieldSchema` to be used with outputFields of polling triggers.

Ticket: https://zapierorg.atlassian.net/browse/PDE-4362