### PR TITLE
 [PDE-4445] docs(CLI): Update zapier logs documentation to mention default user target

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4428,7 +4428,7 @@ z.console.log(url);
 <li><code>http</code>: logged automatically by Zapier on HTTP requests</li>
 <li><code>bundle</code>: logged automatically on every method execution</li>
 <li><code>console</code>: manual logs via <code>z.console.log()</code> statements (<a href="#console-logging">see below for details</a>)</li>
-</ul><p>Note that by default, this command with fetch logs associated to your user.</p><p>For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:</p>
+</ul><p>Note that by default, this command will only fetch logs associated to your user.</p><p>For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">zapier <span class="hljs-built_in">help</span> logs

--- a/docs/index.html
+++ b/docs/index.html
@@ -4428,7 +4428,7 @@ z.console.log(url);
 <li><code>http</code>: logged automatically by Zapier on HTTP requests</li>
 <li><code>bundle</code>: logged automatically on every method execution</li>
 <li><code>console</code>: manual logs via <code>z.console.log()</code> statements (<a href="#console-logging">see below for details</a>)</li>
-</ul><p>For advanced logging options, including only displaying the logs for a certain user or app version, look at the help for the logs command:</p>
+</ul><p>Note that by default, this command with fetch logs associated to your user.</p><p>For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">zapier <span class="hljs-built_in">help</span> logs

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1514,7 +1514,9 @@ There are three types of logs for a Zapier app:
 * `bundle`: logged automatically on every method execution
 * `console`: manual logs via `z.console.log()` statements ([see below for details](#console-logging))
 
-For advanced logging options, including only displaying the logs for a certain user or app version, look at the help for the logs command:
+Note that by default, this command with fetch logs associated to your user.
+
+For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:
 
 ```bash
 zapier help logs

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1514,7 +1514,7 @@ There are three types of logs for a Zapier app:
 * `bundle`: logged automatically on every method execution
 * `console`: manual logs via `z.console.log()` statements ([see below for details](#console-logging))
 
-Note that by default, this command with fetch logs associated to your user.
+Note that by default, this command will only fetch logs associated to your user.
 
 For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2763,7 +2763,7 @@ There are three types of logs for a Zapier app:
 * `bundle`: logged automatically on every method execution
 * `console`: manual logs via `z.console.log()` statements ([see below for details](#console-logging))
 
-Note that by default, this command with fetch logs associated to your user.
+Note that by default, this command will only fetch logs associated to your user.
 
 For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2763,7 +2763,9 @@ There are three types of logs for a Zapier app:
 * `bundle`: logged automatically on every method execution
 * `console`: manual logs via `z.console.log()` statements ([see below for details](#console-logging))
 
-For advanced logging options, including only displaying the logs for a certain user or app version, look at the help for the logs command:
+Note that by default, this command with fetch logs associated to your user.
+
+For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:
 
 ```bash
 zapier help logs

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -4428,7 +4428,7 @@ z.console.log(url);
 <li><code>http</code>: logged automatically by Zapier on HTTP requests</li>
 <li><code>bundle</code>: logged automatically on every method execution</li>
 <li><code>console</code>: manual logs via <code>z.console.log()</code> statements (<a href="#console-logging">see below for details</a>)</li>
-</ul><p>Note that by default, this command with fetch logs associated to your user.</p><p>For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:</p>
+</ul><p>Note that by default, this command will only fetch logs associated to your user.</p><p>For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">zapier <span class="hljs-built_in">help</span> logs

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -4428,7 +4428,7 @@ z.console.log(url);
 <li><code>http</code>: logged automatically by Zapier on HTTP requests</li>
 <li><code>bundle</code>: logged automatically on every method execution</li>
 <li><code>console</code>: manual logs via <code>z.console.log()</code> statements (<a href="#console-logging">see below for details</a>)</li>
-</ul><p>For advanced logging options, including only displaying the logs for a certain user or app version, look at the help for the logs command:</p>
+</ul><p>Note that by default, this command with fetch logs associated to your user.</p><p>For advanced logging options, including the option to fetch logs for other users or specific app versions, look at the help for the logs command:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-bash">zapier <span class="hljs-built_in">help</span> logs


### PR DESCRIPTION
Update the documentation on the `zapier logs` command to make clearer the fact that it defaults to the command runner's account.