### PR TITLE
PDE-4677 fix(core): RawHttpResponse method types

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -115,9 +115,10 @@ export interface HttpResponse extends BaseHttpResponse {
 }
 
 export interface RawHttpResponse extends BaseHttpResponse {
-  content: Buffer;
-  json: Promise<object | undefined>;
   body: NodeJS.ReadableStream;
+	buffer(): Promise<Buffer>;
+	json(): Promise<object>;
+	text(): Promise<string>;
 }
 
 type DehydrateFunc = <T>(


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes #734, where the response of `z.request({ raw: true })` doesn't have correct method typings for TypeScript.

## Example TypeScript Code

```typescript
import { Bundle, ZObject } from 'zapier-platform-core';

const getJson = async (z: ZObject): Promise<object> => {
  const response = await z.request({
    url: 'https://httpbin.zapier-tooling.com/get',
    raw: true,
  });
  return response.json();
};

const getBuffer = async (z: ZObject): Promise<Buffer> => {
  const response = await z.request({
    url: 'https://httpbin.zapier-tooling.com/image/png',
    raw: true,
  });
  return response.buffer();
};

const getText = async (z: ZObject): Promise<string> => {
  const response = await z.request({
    url: 'https://httpbin.zapier-tooling.com/status/418',
    raw: true,
    skipThrowForStatus: true,
  });
  return response.text();
};

const getContent = async (z: ZObject): Promise<Buffer> => {
  const response = await z.request({
    url: 'https://httpbin.zapier-tooling.com/robots.txt',
    raw: true,
  });
  return response.content;
};
```

## Current Behavior

When running the `tsc` transpiler, `response.buffer()`, `response.json()`, and `response.text()` report errors. `response.content`, on the other hand, _should_ report an error, but passes instead.

![](https://cdn.zappy.app/4bda641637f225c024790391812bb328.png)

## Expected Behavior

![](https://cdn.zappy.app/a0a1c08c2b45febbe2cbad0d911b2161.png)