### PR TITLE
PDE-4678 fix(cli): `zapier build` fails with npm workspaces

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint src snippets",
     "lint:fix": "eslint --fix src snippets",
     "test": "cross-env NODE_ENV=test mocha -t 50s --recursive src/tests --exit",
+    "test-debug": "cross-env NODE_ENV=test node inspect ../../node_modules/.bin/mocha -t 50s --recursive src/tests --exit",
     "smoke-test": "cross-env NODE_ENV=test mocha -t 2m --recursive src/smoke-tests --exit",
     "validate-templates": "./scripts/validate-app-templates.js",
     "set-template-versions": "./scripts/set-app-template-versions.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
     "lodash": "4.17.21",
     "marked": "4.2.12",
     "marked-terminal": "5.2.0",
+    "minimatch": "9.0.3",
     "node-fetch": "2.6.7",
     "ora": "5.4.0",
     "parse-gitignore": "0.5.1",

--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -321,14 +321,15 @@ describe('build in workspaces', function () {
     // Set up a monorepo project structure with two integrations as npm
     // workspaces:
     //
-    // packages/
+    // (project root)
     // ├─ package.json
-    // ├─ app-1/
-    // │  ├─ index.js
-    // │  └─ package.json
-    // └─ app-2/
-    // 	  ├─ index.js
-    // 	  └─ package.json
+    // └── packages/
+    //    ├─ app-1/
+    //    │  ├─ index.js
+    //    │  └─ package.json
+    //    └─ app-2/
+    // 	     ├─ index.js
+    // 	     └─ package.json
 
     // Create root package.json
     fs.outputFileSync(

--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -446,6 +446,15 @@ describe('build in workspaces', function () {
       )
     );
     uuidPackageJson.version.should.equal('8.3.2');
+
+    // Make sure node_modules/app-1 and node_modules/app-2 are not included
+    // in the build
+    fs.existsSync(
+      path.join(unzipPath, 'node_modules', 'app-1')
+    ).should.be.false();
+    fs.existsSync(
+      path.join(unzipPath, 'node_modules', 'app-2')
+    ).should.be.false();
   });
 
   it('should build in app-2', async () => {
@@ -495,5 +504,14 @@ describe('build in workspaces', function () {
       )
     );
     uuidPackageJson.version.should.equal('9.0.1');
+
+    // Make sure node_modules/app-1 and node_modules/app-2 are not included
+    // in the build
+    fs.existsSync(
+      path.join(unzipPath, 'node_modules', 'app-1')
+    ).should.be.false();
+    fs.existsSync(
+      path.join(unzipPath, 'node_modules', 'app-2')
+    ).should.be.false();
   });
 });

--- a/packages/cli/src/tests/utils/files.js
+++ b/packages/cli/src/tests/utils/files.js
@@ -1,8 +1,7 @@
-require('should');
-const files = require('../../utils/files');
-
-const path = require('path');
 const os = require('os');
+const path = require('path');
+const should = require('should');
+const files = require('../../utils/files');
 
 describe('files', () => {
   let tmpDir;
@@ -38,27 +37,137 @@ describe('files', () => {
       .catch(done);
   });
 
-  // TODO: this is broken in travis - works locally though
-  it.skip('should copy a directory', (done) => {
-    const srcDir = os.tmpdir();
-    const srcFileName = path.resolve(srcDir, 'read-write-test.txt');
-    const dstDir = path.resolve(srcDir, 'zapier-platform-cli-test-dest-dir');
-    const dstFileName = path.resolve(dstDir, 'read-write-test.txt');
-    const data = '123';
+  describe('copyDir', () => {
+    let tmpDir, srcDir, dstDir;
 
-    files
-      .writeFile(srcFileName, data)
-      .then(files.copyDir(srcDir, dstDir))
-      .then(() =>
-        files.readFile(dstFileName).then((buf) => {
-          buf.toString().should.equal(data);
-          done();
-        })
-      )
-      .catch((err) => {
-        console.log('error', err);
-        done(err);
+    beforeEach(async () => {
+      tmpDir = path.join(os.tmpdir(), 'zapier-platform-cli-copyDir-test');
+      srcDir = path.join(tmpDir, 'src');
+      dstDir = path.join(tmpDir, 'dst');
+
+      await files.removeDir(srcDir);
+      await files.ensureDir(srcDir);
+      await files.writeFile(path.join(srcDir, '01.txt'), 'chapter 1');
+      await files.writeFile(path.join(srcDir, '02.txt'), 'chapter 2');
+      await files.ensureDir(path.join(srcDir, '03'));
+      await files.writeFile(path.join(srcDir, '03', '03.txt'), 'chapter 3');
+      await files.writeFile(path.join(srcDir, '03', 'cover.jpg'), 'image data');
+      await files.writeFile(path.join(srcDir, '03', 'photo.jpg'), 'photo data');
+
+      await files.removeDir(dstDir);
+      await files.ensureDir(dstDir);
+      await files.writeFile(path.join(dstDir, '01.txt'), 'ch 1');
+      await files.writeFile(path.join(dstDir, '02.txt'), 'ch 2');
+      await files.ensureDir(path.join(dstDir, '03'));
+      await files.writeFile(path.join(dstDir, '03', '03.txt'), 'ch 3');
+      await files.writeFile(path.join(dstDir, '03', 'cover.jpg'), 'old data');
+      await files.writeFile(path.join(dstDir, '03', 'fig.png'), 'png data');
+    });
+
+    afterEach(async () => {
+      await files.removeDir(tmpDir);
+    });
+
+    it('should copy a directory without clobber', async () => {
+      // clobber defaults to false
+      await files.copyDir(srcDir, dstDir);
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '01.txt')),
+        'ch 1'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', '03.txt')),
+        'ch 3'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'fig.png')),
+        'png data'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'photo.jpg')),
+        'photo data'
+      );
+    });
+
+    it('should copy a directory with clobber', async () => {
+      await files.copyDir(srcDir, dstDir, { clobber: true });
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '02.txt')),
+        'chapter 2'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', '03.txt')),
+        'chapter 3'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'cover.jpg')),
+        'image data'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'fig.png')),
+        'png data'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'photo.jpg')),
+        'photo data'
+      );
+    });
+
+    it('should copy a directory with onDirExists returning false', async () => {
+      await files.copyDir(srcDir, dstDir, {
+        clobber: true,
+        onDirExists: () => false,
       });
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '02.txt')),
+        'chapter 2'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', '03.txt')),
+        'ch 3'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'cover.jpg')),
+        'old data'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'fig.png')),
+        'png data'
+      );
+      files
+        .fileExistsSync(path.join(dstDir, '03', 'photo.jpg'))
+        .should.be.false();
+    });
+
+    it('should copy a directory with onDirExists deleting dir', async () => {
+      await files.copyDir(srcDir, dstDir, {
+        clobber: true,
+        onDirExists: (dir) => {
+          // Delete existing directory => completely overwrite the directory
+          files.removeDirSync(dir);
+          return true;
+        },
+      });
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '01.txt')),
+        'chapter 1'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', '03.txt')),
+        'chapter 3'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'cover.jpg')),
+        'image data'
+      );
+      should.equal(
+        await files.readFileStr(path.join(dstDir, '03', 'photo.jpg')),
+        'photo data'
+      );
+      files
+        .fileExistsSync(path.join(dstDir, '03', 'fig.png'))
+        .should.be.false();
+    });
   });
 
   describe('validateFileExists', () => {

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -415,6 +415,11 @@ const _buildFunc = async ({
     zapierWrapperBuf.toString()
   );
 
+  if (printProgress) {
+    endSpinner();
+    startSpinner('Building app definition.json');
+  }
+
   const rawDefinition = (
     await _appCommandZapierWrapper(tmpDir, {
       command: 'definition',

--- a/packages/cli/src/utils/files.js
+++ b/packages/cli/src/utils/files.js
@@ -86,21 +86,21 @@ const copyFile = (src, dest, mode) => {
 /*
   Returns a promise that copies a directory recursively.
 
-	Options:
-		
-	- clobber: Overwrite existing files? Default is false.
-	- filter:
-			A function that returns true if the file should be copied. By default, it
-			ignores node_modules and .zip files.
-	- onCopy:
-			A function called when a file is copied. Takes the destination path as an
-			argument.
-	- onSkip:
-			A function called when a file is skipped. Takes the destination path as an
-			argument.
-	- onDirExists:
-			A function called when a directory exists. Takes the destination path as
-			an argument. Returns true to carry on copying. Returns false to skip.
+  Options:
+
+  - clobber: Overwrite existing files? Default is false.
+  - filter:
+      A function that returns true if the file should be copied. By default, it
+      ignores node_modules and .zip files.
+  - onCopy:
+      A function called when a file is copied. Takes the destination path as an
+      argument.
+  - onSkip:
+      A function called when a file is skipped. Takes the destination path as an
+      argument.
+  - onDirExists:
+      A function called when a directory exists. Takes the destination path as
+      an argument. Returns true to carry on copying. Returns false to skip.
 */
 const copyDir = async (src, dst, options) => {
   const defaultFilter = (srcPath) => {

--- a/packages/cli/src/utils/files.js
+++ b/packages/cli/src/utils/files.js
@@ -83,7 +83,25 @@ const copyFile = (src, dest, mode) => {
   });
 };
 
-// Returns a promise that copies a directory.
+/*
+  Returns a promise that copies a directory recursively.
+
+	Options:
+		
+	- clobber: Overwrite existing files? Default is false.
+	- filter:
+			A function that returns true if the file should be copied. By default, it
+			ignores node_modules and .zip files.
+	- onCopy:
+			A function called when a file is copied. Takes the destination path as an
+			argument.
+	- onSkip:
+			A function called when a file is skipped. Takes the destination path as an
+			argument.
+	- onDirExists:
+			A function called when a directory exists. Takes the destination path as
+			an argument. Returns true to carry on copying. Returns false to skip.
+*/
 const copyDir = async (src, dst, options) => {
   const defaultFilter = (srcPath) => {
     const isntPackage = !srcPath.includes('node_modules');
@@ -91,13 +109,18 @@ const copyDir = async (src, dst, options) => {
     return isntPackage && isntBuild;
   };
 
-  options = _.defaults(options || {}, {
+  options = {
     clobber: false,
     filter: defaultFilter,
     onCopy: () => {},
     onSkip: () => {},
     onDirExists: () => true,
-  });
+    ...options,
+  };
+
+  if (!options.filter) {
+    options.filter = defaultFilter;
+  }
 
   await ensureDir(dst);
   const files = await fse.readdirSync(src);
@@ -140,6 +163,7 @@ const copyDir = async (src, dst, options) => {
 
 // Delete a directory.
 const removeDir = (dir) => fse.remove(dir);
+const removeDirSync = (dir) => fse.removeSync(dir);
 
 // Returns true if directory is empty, else false.
 // Rejects if directory does not exist.
@@ -167,6 +191,7 @@ module.exports = {
   readFile,
   readFileStr,
   removeDir,
+  removeDirSync,
   validateFileExists,
   writeFile,
   copyFile,

--- a/packages/cli/src/utils/local.js
+++ b/packages/cli/src/utils/local.js
@@ -16,7 +16,7 @@ const getLocalAppHandler = ({ reload = false, baseEvent = {} } = {}) => {
   let appRaw, zapier;
   try {
     appRaw = require(entryPath);
-    zapier = require(`${rootPath}/node_modules/${PLATFORM_PACKAGE}`);
+    zapier = require(PLATFORM_PACKAGE);
   } catch (err) {
     // this err.stack doesn't give a nice traceback at all :-(
     // maybe we could do require('syntax-error') in the future

--- a/yarn.lock
+++ b/yarn.lock
@@ -8129,6 +8129,13 @@ minimatch@5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^5.0.1:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Fixes #648.

Some developers may choose to structure their project using [npm workpaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) or [yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/). An example project structure might look like:

```
(project root)
├─ package.json
└── packages/
    ├─ app-1/
    │  ├─ index.js
    │  └─ package.json
    └─ app-2/
        ├─ index.js
        └─ package.json
```

If you run `npm install` in the above example, `app-1` and `app-2` will share their dependencies in the project root's `node_modules`. Only the dependencies with version discrepancies will be placed into `app-1/node_modules` or `app-2/node_modules`.

The current implementation of `zapier build` doesn't support workspaces. It always assume it can always find `zapier-platform-core` in the working directory's `node_modules`.

This PR fixes that by finding `zapier-platform-core` in the working directory _and_ all the parent directories.