### PR TITLE
fix(cli) Don't break when converting triggers whose key start with a number

### DIFF
--- a/packages/cli/scaffold/test.template.js
+++ b/packages/cli/scaffold/test.template.js
@@ -12,7 +12,7 @@ describe('<%= ACTION_PLURAL %>.<%= KEY %>', () => {
   it('should run', async () => {
     const bundle = { inputData: {} };
 
-    const results = await appTester(App.<%= ACTION_PLURAL %>.<%= KEY %>.<%= MAYBE_RESOURCE %>operation.perform, bundle);
+    const results = await appTester(App.<%= ACTION_PLURAL %>['<%= KEY %>'].<%= MAYBE_RESOURCE %>operation.perform, bundle);
     expect(results).toBeDefined();
     // TODO: add more assertions
   });

--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -343,7 +343,12 @@ const renderIndex = async (appDefinition) => {
     },
     (importNameSuffix, stepType) => {
       _.each(appDefinition[stepType], (definition, key) => {
-        const importName = _.camelCase(key) + importNameSuffix;
+        let importName = _.camelCase(key) + importNameSuffix;
+
+        if (importName[0].match(/[0-9]/)) {
+          importName = `cannotStartWithNumber${importName}`;
+        }
+
         const filepath = `./${stepType}/${_.snakeCase(key)}.js`;
 
         importBlock.push(`const ${importName} = require('${filepath}');`);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

This fixes `zapier convert` failing (and thus rolling back) on:

```
 ›   Error: Identifier directly after number. (1:15)
 ›   > 1 | const 20151109PollTrigger = require('./triggers/20151109_poll.js');
 ›       |               ^
 ›     2 | const hookTrigger = require('./triggers/hook.js');
 ›     3 | const hookRawTrigger = require('./triggers/hook_raw.js');
 ›     4 | const hookV2Trigger = require('./triggers/hook_v_2.js');
```

and:

```
 ›   Error: Identifier directly after number. (13:59)
 ›     11 |     const bundle = { inputData: {} };
 ›     12 |
 ›   > 13 |     const results = await appTester(App.triggers.20151109_poll.operation.perform, bundle);
 ›        |                                                           ^
 ›     14 |     expect(results).toBeDefined();
 ›     15 |     // TODO: add more assertions
 ›     16 |   });
```

We'll still need to rename the key later to not run into:

```
┌─────────────┬────────────────────────────────────────────────────────────────────────┐
│ Property    │ App.triggers                                                           │
│ Message     │ additionalProperty "20151109_poll" exists in instance when not allowed │
│ Links       │ https://platform.zapier.com/cli_docs/schema#triggersschema@15.5.1      │
└─────────────┴────────────────────────────────────────────────────────────────────────┘
```

But we can't rename that key in Platform UI, so we're stuck.

Jira: https://zapierorg.atlassian.net/browse/IP-243