### PR TITLE
PDE-4678 fix(cli): add comments and fix a path issue in `utils/build.js`

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -319,6 +319,8 @@ const maybeRunBuildScript = async (options = {}) => {
   }
 };
 
+// Get `workspaces` from root package.json and convert them to absolute paths.
+// Returns an empty array if package.json can't be found.
 const listWorkspaces = (workspaceRoot) => {
   const packageJsonPath = path.join(workspaceRoot, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
@@ -333,7 +335,7 @@ const listWorkspaces = (workspaceRoot) => {
   }
 
   return (packageJson.workspaces || []).map((relpath) =>
-    path.join(workspaceRoot, relpath)
+    path.resolve(workspaceRoot, relpath)
   );
 };
 
@@ -395,6 +397,8 @@ const _buildFunc = async ({
               fse.readlinkSync(src)
             );
             for (const workspace of workspaces) {
+              // Use minimatch to do glob pattern match. If match, it means the
+              // symlink points to a workspace package, so we don't copy it.
               if (minimatch(realPath, workspace)) {
                 return false;
               }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Following up with this [comment](https://github.com/zapier/zapier-platform/pull/738#discussion_r1475061941), this PR adds some comments in the workspace handling code in `utils/build.js`.

Also replaces `path.join(workspaceRoot, relpath)` with `path.resolve(workspaceRoot, relpath)` just in case someone uses an absolute path in `<package_json>.workspaces` and `relpath` is an absolute path.