### PR TITLE
[PLATSUP-1022] Document `allowGetBody` option in `z.request()` options

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4060,6 +4060,7 @@ zapier env:get 1.0.0
 <li><code>headers</code>: request headers object, format <code>{&apos;header-key&apos;: &apos;header-value&apos;}</code>.</li>
 <li><code>params</code>: URL query params object, format <code>{&apos;query-key&apos;: &apos;query-value&apos;}</code>.</li>
 <li><code>body</code>: request body, can be a string, buffer, readable stream or plain object. When it is an object/array and the <code>Content-Type</code> header is <code>application/x-www-form-urlencoded</code> the body will be transformed to query string parameters, otherwise we&apos;ll set the header to <code>application/json; charset=utf-8</code> and JSON encode the body. Default is <code>null</code>.</li>
+<li><code>allowGetBody</code>: include <code>body</code> in <code>GET</code> requests. Set to <code>true</code> to enable. Default is <code>false</code>. Set only if required by the receiving API. See <a href="https://www.rfc-editor.org/rfc/rfc7231#section-4.3.1">section 4.3.1 in RFC 7231</a>.</li>
 <li><code>json</code>: shortcut object/array/etc. you want to JSON encode into body. Default is <code>null</code>.</li>
 <li><code>form</code>: shortcut object. you want to form encode into body. Default is <code>null</code>.</li>
 <li><code>raw</code>: set this to stream the response instead of consuming it immediately. Default is <code>false</code>.</li>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1324,6 +1324,7 @@ Ensure you're handling errors correctly for your platform version. The latest re
 * `headers`: request headers object, format `{'header-key': 'header-value'}`.
 * `params`: URL query params object, format `{'query-key': 'query-value'}`.
 * `body`: request body, can be a string, buffer, readable stream or plain object. When it is an object/array and the `Content-Type` header is `application/x-www-form-urlencoded` the body will be transformed to query string parameters, otherwise we'll set the header to `application/json; charset=utf-8` and JSON encode the body. Default is `null`.
+* `allowGetBody`: include `body` in `GET` requests. Set to `true` to enable. Default is `false`. Set only if required by the receiving API. See [section 4.3.1 in RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.1).
 * `json`: shortcut object/array/etc. you want to JSON encode into body. Default is `null`.
 * `form`: shortcut object. you want to form encode into body. Default is `null`.
 * `raw`: set this to stream the response instead of consuming it immediately. Default is `false`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2476,6 +2476,7 @@ Ensure you're handling errors correctly for your platform version. The latest re
 * `headers`: request headers object, format `{'header-key': 'header-value'}`.
 * `params`: URL query params object, format `{'query-key': 'query-value'}`.
 * `body`: request body, can be a string, buffer, readable stream or plain object. When it is an object/array and the `Content-Type` header is `application/x-www-form-urlencoded` the body will be transformed to query string parameters, otherwise we'll set the header to `application/json; charset=utf-8` and JSON encode the body. Default is `null`.
+* `allowGetBody`: include `body` in `GET` requests. Set to `true` to enable. Default is `false`. Set only if required by the receiving API. See [section 4.3.1 in RFC 7231](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.1).
 * `json`: shortcut object/array/etc. you want to JSON encode into body. Default is `null`.
 * `form`: shortcut object. you want to form encode into body. Default is `null`.
 * `raw`: set this to stream the response instead of consuming it immediately. Default is `false`.

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -4060,6 +4060,7 @@ zapier env:get 1.0.0
 <li><code>headers</code>: request headers object, format <code>{&apos;header-key&apos;: &apos;header-value&apos;}</code>.</li>
 <li><code>params</code>: URL query params object, format <code>{&apos;query-key&apos;: &apos;query-value&apos;}</code>.</li>
 <li><code>body</code>: request body, can be a string, buffer, readable stream or plain object. When it is an object/array and the <code>Content-Type</code> header is <code>application/x-www-form-urlencoded</code> the body will be transformed to query string parameters, otherwise we&apos;ll set the header to <code>application/json; charset=utf-8</code> and JSON encode the body. Default is <code>null</code>.</li>
+<li><code>allowGetBody</code>: include <code>body</code> in <code>GET</code> requests. Set to <code>true</code> to enable. Default is <code>false</code>. Set only if required by the receiving API. See <a href="https://www.rfc-editor.org/rfc/rfc7231#section-4.3.1">section 4.3.1 in RFC 7231</a>.</li>
 <li><code>json</code>: shortcut object/array/etc. you want to JSON encode into body. Default is <code>null</code>.</li>
 <li><code>form</code>: shortcut object. you want to form encode into body. Default is <code>null</code>.</li>
 <li><code>raw</code>: set this to stream the response instead of consuming it immediately. Default is <code>false</code>.</li>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Document `allowGetBody` option as discussed and confirmed in this Slack thread: 

[Hey team - any reasons why we shouldn’t document the allowGetBody option on z.request() that was originally implemented here and is mentioned in the CHANGELOG?](https://zapier.slack.com/archives/C04P5J5R8E4/p1709091636494479)
