### PR TITLE
feat(schema) - Add support for throttle configuration override

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -2080,12 +2080,21 @@ Key | Required | Type | Description
 `window` | **yes** | `integer` | The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.
 `limit` | **yes** | `integer` | The maximum number of invocations for an action, allowed within the timeframe window.
 `scope` | no | `array`[`string` in (`'user'`, `'auth'`, `'account'`)] | The granularity to throttle by. You can set the scope to one or more of the following: 'user' - Throttles based on user ids.  'auth' - Throttles based on auth ids. 'account' - Throttles based on account ids for all users under a single account. By default, throttling is scoped to the account.
+`overrides` | no | `array`[`object`] | Overrides the original throttle configuration based on a Zapier account attribute.
 
 #### Examples
 
 * `{ window: 60, limit: 100 }`
 * `{ window: 600, limit: 100, scope: [ 'account', 'user' ] }`
 * `{ window: 3600, limit: 10, scope: [ 'auth' ] }`
+* ```
+  {
+    window: 3600,
+    limit: 10,
+    scope: [ 'auth' ],
+    overrides: [ { window: 3600, limit: 2, filter: 'free' } ]
+  }
+  ```
 
 #### Anti-Examples
 

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -2080,7 +2080,7 @@ Key | Required | Type | Description
 `window` | **yes** | `integer` | The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.
 `limit` | **yes** | `integer` | The maximum number of invocations for an action, allowed within the timeframe window.
 `scope` | no | `array`[`string` in (`'user'`, `'auth'`, `'account'`)] | The granularity to throttle by. You can set the scope to one or more of the following: 'user' - Throttles based on user ids.  'auth' - Throttles based on auth ids. 'account' - Throttles based on account ids for all users under a single account. By default, throttling is scoped to the account.
-`overrides` | no | `array`[`object`] | Overrides the original throttle configuration based on a Zapier account attribute.
+`overrides` | no | `array`[`object`] | EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.
 
 #### Examples
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -681,6 +681,27 @@
             "enum": ["user", "auth", "account"],
             "type": "string"
           }
+        },
+        "overrides": {
+          "description": "Overrides the original throttle configuration based on a Zapier account attribute.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "window": {
+                "description": "The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.",
+                "type": "integer"
+              },
+              "limit": {
+                "description": "The maximum number of invocations for an action, allowed within the timeframe window.",
+                "type": "integer"
+              },
+              "filter": {
+                "description": "Account-based attribute to override the throttle by. You can set to one of the following: \"free\", \"trial\", \"paid\". Therefore, the throttle scope would be automatically set to \"account\" and ONLY the accounts based on the specified filter will have their requests throttled based on the throttle overrides while the rest are throttled based on the original configuration.",
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -683,7 +683,7 @@
           }
         },
         "overrides": {
-          "description": "Overrides the original throttle configuration based on a Zapier account attribute.",
+          "description": "EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.",
           "type": "array",
           "items": {
             "type": "object",

--- a/packages/schema/lib/schemas/ThrottleObjectSchema.js
+++ b/packages/schema/lib/schemas/ThrottleObjectSchema.js
@@ -27,6 +27,29 @@ module.exports = makeSchema({
         type: 'string',
       },
     },
+    overrides: {
+      description: `Overrides the original throttle configuration based on a Zapier account attribute.`,
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          window: {
+            description:
+              'The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.',
+            type: 'integer',
+          },
+          limit: {
+            description:
+              'The maximum number of invocations for an action, allowed within the timeframe window.',
+            type: 'integer',
+          },
+          filter: {
+            description: `Account-based attribute to override the throttle by. You can set to one of the following: "free", "trial", "paid". Therefore, the throttle scope would be automatically set to "account" and ONLY the accounts based on the specified filter will have their requests throttled based on the throttle overrides while the rest are throttled based on the original configuration.`,
+            type: 'string',
+          },
+        }
+      },
+    },
   },
   examples: [
     {
@@ -42,6 +65,16 @@ module.exports = makeSchema({
       window: 3600,
       limit: 10,
       scope: ['auth'],
+    },
+    {
+      window: 3600,
+      limit: 10,
+      scope: ['auth'],
+      overrides: [{
+        window: 3600,
+        limit: 2,
+        filter: 'free',
+      }],
     },
   ],
   antiExamples: [

--- a/packages/schema/lib/schemas/ThrottleObjectSchema.js
+++ b/packages/schema/lib/schemas/ThrottleObjectSchema.js
@@ -28,7 +28,7 @@ module.exports = makeSchema({
       },
     },
     overrides: {
-      description: `Overrides the original throttle configuration based on a Zapier account attribute.`,
+      description: 'EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.',
       type: 'array',
       items: {
         type: 'object',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

feat(schema): Adds support for overriding the throttle configuration based on a Zapier account attribute "EXPERIMENTAL"