### PR TITLE
docs(cli): Update docs on throttle config object

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3655,16 +3655,24 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Added in v15.4.0.</em></p><p>When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action&apos;s operation object, the root-level default is overwritten for that action only.</p><p>To throttle an action, you need to set a <code>throttle</code> object with the following variables:</p><ol>
+      <p><em>Added in v15.4.0.</em></p><p><em>Updated in v15.6.0</em></p><p>When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action&apos;s operation object, the root-level default is overwritten for that action only. Note that the throttle limit is not shared across actions unless for those with the same key, window, limit, and scope when &quot;action&quot; is not in the scope.</p><p>To throttle an action, you need to set a <code>throttle</code> object with the following variables:</p><ol>
 <li><code>window [integer]</code>: The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.</li>
 <li><code>limit [integer]</code>: The maximum number of invocations for an action, allowed within the timeframe window.</li>
+<li><code>key [string]</code>: The key to throttle with in combination with the scope. User data provided for the input fields can be used in the key with the use of the curly braces referencing. For example, to access the user data provided for the input field &quot;test_field&quot;, use <code>{{bundle.inputData.test_field}}</code>. Note that a required input field should be referenced to get user data always.</li>
 <li><code>scope [array]</code>: The granularity to throttle by. You can set the scope to one or more of the following options;<ul>
 <li>&apos;user&apos; - Throttles based on user ids.</li>
 <li>&apos;auth&apos; - Throttles based on auth ids.</li>
 <li>&apos;account&apos; - Throttles based on account ids for all users under a single account.</li>
+<li>&apos;action&apos; - Throttles the action it is set on separately from other actions.</li>
 </ul>
 </li>
-</ol><p>Except for the scope, all throttle variables are required. By default, throttling is scoped to the account.</p><p>Here is a typical usage of the throttle configuration:</p>
+<li><code>overrides [array[object]]</code>: &apos;EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.&apos;;<ul>
+<li><code>window [integer]</code>: Same description as above.</li>
+<li><code>limit [integer]</code>: Same description as above.</li>
+<li><code>filter [string]</code>: Account-based attribute to override the throttle by. You can set to one of the following: &quot;free&quot;, &quot;trial&quot;, &quot;paid&quot;. Therefore, the throttle scope would be automatically set to &quot;account&quot; and ONLY the accounts based on the specified filter will have their requests throttled based on the throttle overrides while the rest are throttled based on the original configuration.</li>
+</ul>
+</li>
+</ol><p>Both <code>window</code> and <code>limit</code> are required and others are optional. By default, throttling is scoped to the action and account.</p><p>Here is a typical usage of the throttle configuration:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {
@@ -3687,12 +3695,30 @@ zapier env:get 1.0.0
       },
       <span class="hljs-attr">operation</span>: {
         <span class="hljs-attr">perform</span>: <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {},
-        <span class="hljs-attr">inputFields</span>: [],
+        <span class="hljs-attr">inputFields</span>: [{<span class="hljs-attr">key</span>: <span class="hljs-string">&apos;name&apos;</span>, <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>}],
         <span class="hljs-comment">// overwrites the default, for this action</span>
         <span class="hljs-attr">throttle</span>: {
           <span class="hljs-attr">window</span>: <span class="hljs-number">600</span>,
           <span class="hljs-attr">limit</span>: <span class="hljs-number">5</span>,
+          <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;test-key-{{bundle.inputData.name}}&apos;</span>,
           <span class="hljs-attr">scope</span>: [<span class="hljs-string">&apos;account&apos;</span>],
+          <span class="hljs-attr">overrides</span>: [
+            {
+              <span class="hljs-attr">window</span>: <span class="hljs-number">600</span>,
+              <span class="hljs-attr">limit</span>: <span class="hljs-number">10</span>,
+              <span class="hljs-attr">filter</span>: <span class="hljs-string">&apos;free&apos;</span>,
+            },
+            {
+              <span class="hljs-attr">window</span>: <span class="hljs-number">600</span>,
+              <span class="hljs-attr">limit</span>: <span class="hljs-number">100</span>,
+              <span class="hljs-attr">filter</span>: <span class="hljs-string">&apos;trial&apos;</span>,
+            },
+            {
+              <span class="hljs-attr">window</span>: <span class="hljs-number">0</span>,
+              <span class="hljs-attr">limit</span>: <span class="hljs-number">0</span>,
+              <span class="hljs-attr">filter</span>: <span class="hljs-string">&apos;paid&apos;</span>,
+            },
+          ],
         },
       },
     },

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1158,17 +1158,25 @@ For example, you can access the `process.env` in your perform functions and in t
 
 *Added in v15.4.0.*
 
-When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action's operation object, the root-level default is overwritten for that action only.
+*Updated in v15.6.0*
+
+When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action's operation object, the root-level default is overwritten for that action only. Note that the throttle limit is not shared across actions unless for those with the same key, window, limit, and scope when "action" is not in the scope.
 
 To throttle an action, you need to set a `throttle` object with the following variables:
   1. `window [integer]`: The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.
   2. `limit [integer]`: The maximum number of invocations for an action, allowed within the timeframe window.
-  3. `scope [array]`: The granularity to throttle by. You can set the scope to one or more of the following options;
+  3. `key [string]`: The key to throttle with in combination with the scope. User data provided for the input fields can be used in the key with the use of the curly braces referencing. For example, to access the user data provided for the input field "test_field", use `{{bundle.inputData.test_field}}`. Note that a required input field should be referenced to get user data always.
+  4. `scope [array]`: The granularity to throttle by. You can set the scope to one or more of the following options;
         - 'user' - Throttles based on user ids.
         - 'auth' - Throttles based on auth ids.
         - 'account' - Throttles based on account ids for all users under a single account.
+        - 'action' - Throttles the action it is set on separately from other actions.
+  5. `overrides [array[object]]`: 'EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.';
+        - `window [integer]`: Same description as above.
+        - `limit [integer]`: Same description as above.
+        - `filter [string]`: Account-based attribute to override the throttle by. You can set to one of the following: "free", "trial", "paid". Therefore, the throttle scope would be automatically set to "account" and ONLY the accounts based on the specified filter will have their requests throttled based on the throttle overrides while the rest are throttled based on the original configuration.
 
-Except for the scope, all throttle variables are required. By default, throttling is scoped to the account.
+Both `window` and `limit` are required and others are optional. By default, throttling is scoped to the action and account.
 
 Here is a typical usage of the throttle configuration:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2160,17 +2160,25 @@ const App = {
 
 *Added in v15.4.0.*
 
-When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action's operation object, the root-level default is overwritten for that action only.
+*Updated in v15.6.0*
+
+When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action's operation object, the root-level default is overwritten for that action only. Note that the throttle limit is not shared across actions unless for those with the same key, window, limit, and scope when "action" is not in the scope.
 
 To throttle an action, you need to set a `throttle` object with the following variables:
   1. `window [integer]`: The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.
   2. `limit [integer]`: The maximum number of invocations for an action, allowed within the timeframe window.
-  3. `scope [array]`: The granularity to throttle by. You can set the scope to one or more of the following options;
+  3. `key [string]`: The key to throttle with in combination with the scope. User data provided for the input fields can be used in the key with the use of the curly braces referencing. For example, to access the user data provided for the input field "test_field", use `{{bundle.inputData.test_field}}`. Note that a required input field should be referenced to get user data always.
+  4. `scope [array]`: The granularity to throttle by. You can set the scope to one or more of the following options;
         - 'user' - Throttles based on user ids.
         - 'auth' - Throttles based on auth ids.
         - 'account' - Throttles based on account ids for all users under a single account.
+        - 'action' - Throttles the action it is set on separately from other actions.
+  5. `overrides [array[object]]`: 'EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.';
+        - `window [integer]`: Same description as above.
+        - `limit [integer]`: Same description as above.
+        - `filter [string]`: Account-based attribute to override the throttle by. You can set to one of the following: "free", "trial", "paid". Therefore, the throttle scope would be automatically set to "account" and ONLY the accounts based on the specified filter will have their requests throttled based on the throttle overrides while the rest are throttled based on the original configuration.
 
-Except for the scope, all throttle variables are required. By default, throttling is scoped to the account.
+Both `window` and `limit` are required and others are optional. By default, throttling is scoped to the action and account.
 
 Here is a typical usage of the throttle configuration:
 
@@ -2195,12 +2203,30 @@ const App = {
       },
       operation: {
         perform: () => {},
-        inputFields: [],
+        inputFields: [{key: 'name', required: true, type: 'string'}],
         // overwrites the default, for this action
         throttle: {
           window: 600,
           limit: 5,
+          key: 'test-key-{{bundle.inputData.name}}',
           scope: ['account'],
+          overrides: [
+            {
+              window: 600,
+              limit: 10,
+              filter: 'free',
+            },
+            {
+              window: 600,
+              limit: 100,
+              filter: 'trial',
+            },
+            {
+              window: 0,
+              limit: 0,
+              filter: 'paid',
+            },
+          ],
         },
       },
     },

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3655,16 +3655,24 @@ zapier env:get 1.0.0
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Added in v15.4.0.</em></p><p>When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action&apos;s operation object, the root-level default is overwritten for that action only.</p><p>To throttle an action, you need to set a <code>throttle</code> object with the following variables:</p><ol>
+      <p><em>Added in v15.4.0.</em></p><p><em>Updated in v15.6.0</em></p><p>When a throttle configuration is set for an action, Zapier uses it to apply throttling when the limit for the timeframe window is exceeded. It can be set at the root level and/or on an action. When set at the root level, it is the default throttle configuration used on each action of the integration. And when set in an action&apos;s operation object, the root-level default is overwritten for that action only. Note that the throttle limit is not shared across actions unless for those with the same key, window, limit, and scope when &quot;action&quot; is not in the scope.</p><p>To throttle an action, you need to set a <code>throttle</code> object with the following variables:</p><ol>
 <li><code>window [integer]</code>: The timeframe, in seconds, within which the system tracks the number of invocations for an action. The number of invocations begins at zero at the start of each window.</li>
 <li><code>limit [integer]</code>: The maximum number of invocations for an action, allowed within the timeframe window.</li>
+<li><code>key [string]</code>: The key to throttle with in combination with the scope. User data provided for the input fields can be used in the key with the use of the curly braces referencing. For example, to access the user data provided for the input field &quot;test_field&quot;, use <code>{{bundle.inputData.test_field}}</code>. Note that a required input field should be referenced to get user data always.</li>
 <li><code>scope [array]</code>: The granularity to throttle by. You can set the scope to one or more of the following options;<ul>
 <li>&apos;user&apos; - Throttles based on user ids.</li>
 <li>&apos;auth&apos; - Throttles based on auth ids.</li>
 <li>&apos;account&apos; - Throttles based on account ids for all users under a single account.</li>
+<li>&apos;action&apos; - Throttles the action it is set on separately from other actions.</li>
 </ul>
 </li>
-</ol><p>Except for the scope, all throttle variables are required. By default, throttling is scoped to the account.</p><p>Here is a typical usage of the throttle configuration:</p>
+<li><code>overrides [array[object]]</code>: &apos;EXPERIMENTAL: Overrides the original throttle configuration based on a Zapier account attribute.&apos;;<ul>
+<li><code>window [integer]</code>: Same description as above.</li>
+<li><code>limit [integer]</code>: Same description as above.</li>
+<li><code>filter [string]</code>: Account-based attribute to override the throttle by. You can set to one of the following: &quot;free&quot;, &quot;trial&quot;, &quot;paid&quot;. Therefore, the throttle scope would be automatically set to &quot;account&quot; and ONLY the accounts based on the specified filter will have their requests throttled based on the throttle overrides while the rest are throttled based on the original configuration.</li>
+</ul>
+</li>
+</ol><p>Both <code>window</code> and <code>limit</code> are required and others are optional. By default, throttling is scoped to the action and account.</p><p>Here is a typical usage of the throttle configuration:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {
@@ -3687,12 +3695,30 @@ zapier env:get 1.0.0
       },
       <span class="hljs-attr">operation</span>: {
         <span class="hljs-attr">perform</span>: <span class="hljs-function"><span class="hljs-params">()</span> =&gt;</span> {},
-        <span class="hljs-attr">inputFields</span>: [],
+        <span class="hljs-attr">inputFields</span>: [{<span class="hljs-attr">key</span>: <span class="hljs-string">&apos;name&apos;</span>, <span class="hljs-attr">required</span>: <span class="hljs-literal">true</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">&apos;string&apos;</span>}],
         <span class="hljs-comment">// overwrites the default, for this action</span>
         <span class="hljs-attr">throttle</span>: {
           <span class="hljs-attr">window</span>: <span class="hljs-number">600</span>,
           <span class="hljs-attr">limit</span>: <span class="hljs-number">5</span>,
+          <span class="hljs-attr">key</span>: <span class="hljs-string">&apos;test-key-{{bundle.inputData.name}}&apos;</span>,
           <span class="hljs-attr">scope</span>: [<span class="hljs-string">&apos;account&apos;</span>],
+          <span class="hljs-attr">overrides</span>: [
+            {
+              <span class="hljs-attr">window</span>: <span class="hljs-number">600</span>,
+              <span class="hljs-attr">limit</span>: <span class="hljs-number">10</span>,
+              <span class="hljs-attr">filter</span>: <span class="hljs-string">&apos;free&apos;</span>,
+            },
+            {
+              <span class="hljs-attr">window</span>: <span class="hljs-number">600</span>,
+              <span class="hljs-attr">limit</span>: <span class="hljs-number">100</span>,
+              <span class="hljs-attr">filter</span>: <span class="hljs-string">&apos;trial&apos;</span>,
+            },
+            {
+              <span class="hljs-attr">window</span>: <span class="hljs-number">0</span>,
+              <span class="hljs-attr">limit</span>: <span class="hljs-number">0</span>,
+              <span class="hljs-attr">filter</span>: <span class="hljs-string">&apos;paid&apos;</span>,
+            },
+          ],
         },
       },
     },

--- a/packages/cli/snippets/throttle-configuration.js
+++ b/packages/cli/snippets/throttle-configuration.js
@@ -18,12 +18,30 @@ const App = {
       },
       operation: {
         perform: () => {},
-        inputFields: [],
+        inputFields: [{key: 'name', required: true, type: 'string'}],
         // overwrites the default, for this action
         throttle: {
           window: 600,
           limit: 5,
+          key: 'test-key-{{bundle.inputData.name}}',
           scope: ['account'],
+          overrides: [
+            {
+              window: 600,
+              limit: 10,
+              filter: 'free',
+            },
+            {
+              window: 600,
+              limit: 100,
+              filter: 'trial',
+            },
+            {
+              window: 0,
+              limit: 0,
+              filter: 'paid',
+            },
+          ],
         },
       },
     },


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
Documents changes in https://github.com/zapier/zapier-platform/pull/755 and https://github.com/zapier/zapier-platform/pull/757. Merge this only when both have been merged.