### PR TITLE
PDE-3951 test(cli): fix failing tests in dependabot's PRs

### DIFF
--- a/packages/cli/src/oclif/hooks/getAppRegistrationFieldChoices.js
+++ b/packages/cli/src/oclif/hooks/getAppRegistrationFieldChoices.js
@@ -10,7 +10,7 @@ module.exports = async function (options) {
   let formFields;
 
   try {
-    formFields = await callAPI('/apps/fields-choices');
+    formFields = await callAPI('/apps/fields-choices', { skipDeployKey: true });
   } catch (e) {
     this.error(
       `Unable to connect to Zapier API. Please check your connection and try again. ${e}`

--- a/packages/cli/src/smoke-tests/smoke-tests.js
+++ b/packages/cli/src/smoke-tests/smoke-tests.js
@@ -19,10 +19,10 @@ const setupZapierRC = () => {
   const rcPath = path.join(os.homedir(), '.zapierrc');
   if (fs.existsSync(rcPath)) {
     hasRC = true;
-  } else if (process.env.DEPLOY_KEY) {
+  } else if (process.env.ZAPIER_DEPLOY_KEY) {
     fs.writeFileSync(
       rcPath,
-      JSON.stringify({ deployKey: process.env.DEPLOY_KEY })
+      JSON.stringify({ deployKey: process.env.ZAPIER_DEPLOY_KEY })
     );
     hasRC = true;
   }
@@ -195,6 +195,7 @@ describe('smoke tests - setup will take some time', function () {
   it('zapier integrations', function () {
     if (!context.hasRC) {
       this.skip();
+      return;
     }
     const stdout = runCommand(context.cliBin, [
       'integrations',

--- a/packages/cli/src/tests/register.test.js
+++ b/packages/cli/src/tests/register.test.js
@@ -10,6 +10,7 @@ const { privateApp, publicApp } = require('./fixtures/createApp');
 
 describe('RegisterCommand', () => {
   const APP_RC_FILE = './.zapierapprc';
+  const ORIG_DEPLOY_KEY = process.env.ZAPIER_DEPLOY_KEY;
 
   const deleteRcFile = () => {
     if (fs.existsSync(APP_RC_FILE)) {
@@ -17,9 +18,23 @@ describe('RegisterCommand', () => {
     }
   };
 
+  const mockDeployKey = () => {
+    process.env.ZAPIER_DEPLOY_KEY = 'fake';
+  };
+
+  const restoreDeployKey = () => {
+    process.env.ZAPIER_DEPLOY_KEY = ORIG_DEPLOY_KEY;
+  };
+
   // Delete generated .zapierapprc file before and after tests
-  before(deleteRcFile);
-  after(deleteRcFile);
+  before(() => {
+    deleteRcFile();
+    mockDeployKey();
+  });
+  after(() => {
+    deleteRcFile();
+    restoreDeployKey();
+  });
 
   function getTestObj() {
     return oclif.test.nock(BASE_ENDPOINT, (mockApi) =>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

**Mock `ZAPIER_DEPLOY_KEY` for RegisterCommand tests**
commit ac29aa2ea832e3a379b4d3b74a4c10a0b511a20b

GitHub's dependabot [doesn't have access to secrets][1]. This is why dependabot's PRs have been failing. The tests in RegisterCommand don't really need the deploy key because they use nock to mock HTTP requests. But our `callAPI()` function always checks crendentials with `readCredentials()`; it isn't aware that the request may be "nocked" and won't require a deploy key.

This commit bypasses the checks in `readCredentials()` by setting a fake `ZAPIER_DEPLOY_KEY` before running the tests. Since the requests are "nocked", the fake deploy key won't be sent to Zapier anyway.

[1]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets

----

**Replace `DEPLOY_KEY` with `ZAPIER_DEPLOY_KEY` in CLI smoke tests**
commit 18b7ebcbaacc2b3c0ba820f5fd41b01cb96e7171
    
It turns out our CI isn't running the smoke test for the `zapier integrations` command because `DEPLOY_KEY` has been always empty. The correct environment variable to use is `ZAPIER_DEPLOY_KEY`.

----

**`/api/platform/cli/apps/fields-choices` doesn't need deploy key**
commit d60711ac1d31236cadca512c35c2fa2f01c3095d
    
The `fields-choices` endpoint doesn't need a deploy key, so we can enable `skipDeployKey` in the request options.