### PR TITLE
fix(core): Handle null response_content before passing to findSensitiveValues

### DIFF
--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -123,7 +123,7 @@ const toStdout = (event, msg, data) => {
 const attemptFindSecretsInStr = (s, isGettingNewSecret) => {
   let parsedRespContent;
   try {
-    parsedRespContent = JSON.parse(s);
+    parsedRespContent = JSON.parse(s) || {};
   } catch {
     return [];
   }

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -335,6 +335,39 @@ describe('logger', () => {
     ]);
   });
 
+  it('should leave response content of null uncensored', async () => {
+    const event = {
+      method: 'authentication.sessionConfig.perform',
+    };
+    const logger = createlogger(event, options);
+
+    const { message, data } = prepareTestRequest({
+      resBody: JSON.stringify(null),
+    });
+
+    await logger(message, data);
+    const response = await logger.end(1000);
+    response.status.should.eql(200);
+
+    response.content.logs.should.deepEqual([
+      {
+        message: '200 POST http://example.com',
+        data: {
+          log_type: 'http',
+          request_type: 'devplatform-outbound',
+          request_url: 'http://example.com',
+          request_method: 'POST',
+          request_headers: 'accept: application/json',
+          request_data: '{}',
+          request_via_client: true,
+          response_status_code: 200,
+          response_headers: 'content-type: application/json',
+          response_content: 'null',
+        },
+      },
+    ]);
+  });
+
   it('should handle missing bits of the request/response', async () => {
     // this test should, as closely as possible, match what we actually log after an http request from z.request
     const bundle = {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
