### PR TITLE
fix(legacy-scripting-runner): Remove error traceback from ErrorException

### DIFF
--- a/packages/legacy-scripting-runner/exceptions.js
+++ b/packages/legacy-scripting-runner/exceptions.js
@@ -13,7 +13,7 @@ class AppError extends Error {
       })
     );
     this.name = 'AppError';
-    this.contextify = false;
+    this.doNotContextify = true;
   }
 }
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
The addition of error traceback makes the error message an invalid JSON and the backend expects a valid JSON. So this change aligns with the current behavior in the core [here](https://github.com/zapier/zapier-platform/blob/main/packages/core/src/errors.js#L16).