### PR TITLE
[PDE-5065] cli(fix): Add `shell: true` as a default option for Windows users when running spawn() command

### DIFF
--- a/packages/cli/src/utils/misc.js
+++ b/packages/cli/src/utils/misc.js
@@ -25,7 +25,9 @@ const isWindows = () => {
 
 // Run a bash command with a promise.
 const runCommand = (command, args, options) => {
-  if (isWindows()) {
+  const isRunningUnderWindows = isWindows();
+
+  if (isRunningUnderWindows) {
     command += '.cmd';
   }
 
@@ -34,6 +36,11 @@ const runCommand = (command, args, options) => {
   }
 
   options = options || {};
+
+  if (isRunningUnderWindows) {
+    // See CVE-2024-27980
+    options.shell = true;
+  }
 
   debug('\n');
   debug(

--- a/packages/cli/src/utils/misc.js
+++ b/packages/cli/src/utils/misc.js
@@ -25,19 +25,15 @@ const isWindows = () => {
 
 // Run a bash command with a promise.
 const runCommand = (command, args, options) => {
-  const isRunningUnderWindows = isWindows();
-
-  if (isRunningUnderWindows) {
-    command += '.cmd';
-  }
-
   if (_.get(global, ['argOpts', 'debug'])) {
     debug.enabled = true;
   }
 
   options = options || {};
 
-  if (isRunningUnderWindows) {
+  if (isWindows()) {
+    command += '.cmd';
+
     // See CVE-2024-27980
     options.shell = true;
   }


### PR DESCRIPTION
This is related to `CVE-2024-27980`. See Node.js report for the full details: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high

This fixes #784.