### PR TITLE
fix(schema): Update createsSchema to disallow additional properties, improve tests [PDE-4948]

### DIFF
--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -1613,7 +1613,8 @@
           "description": "Any unique key can be used and its values will be validated against the CreateSchema.",
           "$ref": "/CreateSchema"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "SearchAndCreatesSchema": {
       "id": "/SearchAndCreatesSchema",

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -1494,7 +1494,8 @@
           "description": "Any unique key can be used and its values will be validated against the SearchOrCreateSchema.",
           "$ref": "/SearchOrCreateSchema"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "AuthenticationSchema": {
       "id": "/AuthenticationSchema",
@@ -1602,7 +1603,8 @@
           "description": "Any unique key can be used and its values will be validated against the SearchSchema.",
           "$ref": "/SearchSchema"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "CreatesSchema": {
       "id": "/CreatesSchema",
@@ -1625,7 +1627,8 @@
           "description": "Any unique key can be used and its values will be validated against the SearchOrCreateSchema.",
           "$ref": "/SearchOrCreateSchema"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "VersionSchema": {
       "id": "/VersionSchema",

--- a/packages/schema/lib/schemas/CreatesSchema.js
+++ b/packages/schema/lib/schemas/CreatesSchema.js
@@ -17,6 +17,7 @@ module.exports = makeSchema(
         $ref: CreateSchema.id,
       },
     },
+    additionalProperties: false,
     examples: [
       {
         createRecipe: {

--- a/packages/schema/lib/schemas/SearchOrCreatesSchema.js
+++ b/packages/schema/lib/schemas/SearchOrCreatesSchema.js
@@ -18,6 +18,7 @@ module.exports = makeSchema(
         $ref: SearchOrCreateSchema.id,
       },
     },
+    additionalProperties: false,
     examples: [
       {
         searchOrCreateWidgets: {

--- a/packages/schema/lib/schemas/SearchesSchema.js
+++ b/packages/schema/lib/schemas/SearchesSchema.js
@@ -17,6 +17,7 @@ module.exports = makeSchema(
         $ref: SearchSchema.id,
       },
     },
+    additionalProperties: false,
     examples: [
       {
         recipe: {

--- a/packages/schema/test/index.js
+++ b/packages/schema/test/index.js
@@ -28,12 +28,36 @@ describe('app', () => {
       results.errors.length.should.eql(4);
     });
 
-    it('should invalidate a bad named trigger', () => {
+    it('should invalidate a badly named trigger', () => {
       const appCopy = copy(appDefinition);
       appCopy.triggers['3contact_by_tag'] = appCopy.triggers.contact_by_tag;
       delete appCopy.triggers.contact_by_tag;
       const results = schema.validateAppDefinition(appCopy);
-      results.errors.length.should.eql(2); // invalid name and top-level key doesn't match trigger key
+      results.errors[0].stack.should.eql(
+        'instance.triggers additionalProperty "3contact_by_tag" exists in instance when not allowed'
+      );
+      results.errors.length.should.eql(2); // additional property error + top-level key doesn't match trigger key
+    });
+
+    it('should invalidate a badly named create', () => {
+      const appCopy = copy(appDefinition);
+      appCopy.creates['3contact_by_tag'] = appCopy.creates.tag_create;
+      delete appCopy.creates.tag_create;
+      const results = schema.validateAppDefinition(appCopy);
+      results.errors[0].stack.should.eql(
+        'instance.creates additionalProperty "3contact_by_tag" exists in instance when not allowed'
+      );
+      results.errors.length.should.eql(2); // additional property error + top-level key doesn't match create key
+    });
+
+    it('should invalidate a create with a bad key', () => {
+      const appCopy = copy(appDefinition);
+      appCopy.creates.tag_create.key = '3tag_create';
+      const results = schema.validateAppDefinition(appCopy);
+      results.errors[0].stack.should.eql(
+        'instance.creates.tag_create.key does not match pattern "^[a-zA-Z]+[a-zA-Z0-9_]*$"'
+      );
+      results.errors.length.should.eql(2); // invalid name and top-level key doesn't match create key
     });
 
     it('should run and pass functional constraints', function () {

--- a/packages/schema/test/index.js
+++ b/packages/schema/test/index.js
@@ -52,7 +52,7 @@ describe('app', () => {
 
     it('should invalidate a create with a bad key', () => {
       const appCopy = copy(appDefinition);
-      appCopy.creates.tag_create.key = '3tag_create';
+      appCopy.creates.tag_create.key = 'tag:create';
       const results = schema.validateAppDefinition(appCopy);
       results.errors[0].stack.should.eql(
         'instance.creates.tag_create.key does not match pattern "^[a-zA-Z]+[a-zA-Z0-9_]*$"'


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

We currently have 2 tickets that have come up, reporting action keys that should be invalid:

- [PDE-4948](https://zapierorg.atlassian.net/browse/PDE-4948)
- [PDE-4889](https://zapierorg.atlassian.net/browse/PDE-4889)

I reproduced this issue via CLI, confirming it is currently possible to have an action with a `key` that's invalid (for example, `3create_tag` or `create_order:test`) per the [KeySchema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/lib/schemas/KeySchema.js) and per the [CreatesSchema](https://github.com/zapier/zapier-platform/blob/main/packages/schema/lib/schemas/CreatesSchema.js) `patternProperties`.

The cause seems to be that the library we're using, `jsonschema`, expects us to set `additionalProperties: false` if we want all properties that don't match the `patternProperties` regex to be rejected. `TriggersSchema` has this already, as does `SearchOrCreatesSchema` and most of the other schemas.

This MR adds that `additionalProperties: false` to the `CreatesSchema` so that invalid action keys will be properly rejected. It also adds a test to confirm this new behavior, and improves the other existing tests so that it's clearer what the errors that come up should be.

**One downside:** Ideally, when a dev tried to submit a trigger/action with an invalid key, we would surface the error `instance.creates.tag_create.key does not match pattern "^[a-zA-Z]+[a-zA-Z0-9_]*$"'` to make it clear what the issue is. However, `jsonschema` doesn't seem to have a way to error on bad property names - it just rejects them entirely via `additionalProperties: false`. So the current error users will see is `instance.creates additionalProperty "3contact_by_tag" exists in instance when not allowed`, which is not super clear, but better than allowing it to be uploaded.