### PR TITLE
[PDE-5063] feat(core): Add afterResponse middleware to check if HTTP redirect is made to disallowed domain

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,8 @@
     "aws-sdk": "^2.1397.0",
     "dicer": "^0.3.1",
     "fs-extra": "^11.1.1",
-    "mock-fs": "^5.2.0"
+    "mock-fs": "^5.2.0",
+    "nock": "^13.5.4"
   },
   "optionalDependencies": {
     "@types/node": "^20.3.1"

--- a/packages/core/src/http-middlewares/after/prepare-response.js
+++ b/packages/core/src/http-middlewares/after/prepare-response.js
@@ -45,7 +45,9 @@ const prepareContentResponse = async (resp, request) => {
 
   // trim down the response signature a ton for simplicity
   const preppedResp = {
+    url: resp.url,
     status: resp.status,
+    redirected: resp.redirected,
     json: undefined,
     data: undefined,
     content,

--- a/packages/core/src/http-middlewares/after/throw-for-disallowed-hostname-after-redirect.js
+++ b/packages/core/src/http-middlewares/after/throw-for-disallowed-hostname-after-redirect.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { DisallowedRedirectError } = require('../../errors');
+const { Error } = require('../../errors');
 
 const disallowedRedirectHosts = [
   // Loopback addresses (IPv4)
@@ -24,8 +24,10 @@ function isDisallowedAfterRedirect(url) {
 }
 
 const throwForDisallowedHostnameAfterRedirect = (resp) => {
-  if (resp.redirected && isDisallowedAfterRedirect(resp.request.url)) {
-    throw new DisallowedRedirectError();
+  // Looking at the response URL instead of the request URL
+  // because the response URL can change after a redirect
+  if (resp.redirected && isDisallowedAfterRedirect(resp.url)) {
+    throw new Error('Redirecting to disallowed hostname');
   }
 
   return resp;

--- a/packages/core/src/http-middlewares/after/throw-for-disallowed-hostname-after-redirect.js
+++ b/packages/core/src/http-middlewares/after/throw-for-disallowed-hostname-after-redirect.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { DisallowedRedirectError } = require('../../errors');
+
+const disallowedRedirectHosts = [
+  // Loopback addresses (IPv4)
+  'localhost',
+  '127.0.0.1',
+
+  // Loopback addresses (IPv6)
+  '::1',
+  '[::1]',
+];
+
+function isDisallowedAfterRedirect(url) {
+  try {
+    const { hostname } = new URL(url);
+    return disallowedRedirectHosts.includes(hostname);
+  } catch (e) {
+    // If URL parsing fails, consider it allowed
+    // (being permissive just in case it affects backwards compatibility)
+    return false;
+  }
+}
+
+const throwForDisallowedHostnameAfterRedirect = (resp) => {
+  if (resp.redirected && isDisallowedAfterRedirect(resp.request.url)) {
+    throw new DisallowedRedirectError();
+  }
+
+  return resp;
+};
+
+module.exports = throwForDisallowedHostnameAfterRedirect;

--- a/packages/core/src/tools/create-app-request-client.js
+++ b/packages/core/src/tools/create-app-request-client.js
@@ -65,8 +65,8 @@ const createAppRequestClient = (input, options) => {
 
   const httpAfters = [
     prepareResponse,
-    logResponse,
     throwForDisallowedHostnameAfterRedirect,
+    logResponse,
     ...(includeAutoRefresh ? [throwForStaleAuth] : []),
     ...ensureArray(app.afterResponse),
     throwForStatusMiddleware,

--- a/packages/core/src/tools/create-app-request-client.js
+++ b/packages/core/src/tools/create-app-request-client.js
@@ -20,6 +20,7 @@ const { logResponse } = require('../http-middlewares/after/log-response');
 const prepareResponse = require('../http-middlewares/after/prepare-response');
 const throwForStaleAuth = require('../http-middlewares/after/throw-for-stale-auth');
 const throwForStatusMiddleware = require('../http-middlewares/after/throw-for-status');
+const throwForDisallowedHostnameAfterRedirect = require('../http-middlewares/after/throw-for-disallowed-hostname-after-redirect');
 
 const createAppRequestClient = (input, options) => {
   input = ensurePath(input, '_zapier.app');
@@ -68,6 +69,7 @@ const createAppRequestClient = (input, options) => {
     ...(includeAutoRefresh ? [throwForStaleAuth] : []),
     ...ensureArray(app.afterResponse),
     throwForStatusMiddleware,
+    throwForDisallowedHostnameAfterRedirect,
   ];
 
   return createRequestClient(httpBefores, httpAfters, options);

--- a/packages/core/src/tools/create-app-request-client.js
+++ b/packages/core/src/tools/create-app-request-client.js
@@ -66,10 +66,10 @@ const createAppRequestClient = (input, options) => {
   const httpAfters = [
     prepareResponse,
     logResponse,
+    throwForDisallowedHostnameAfterRedirect,
     ...(includeAutoRefresh ? [throwForStaleAuth] : []),
     ...ensureArray(app.afterResponse),
     throwForStatusMiddleware,
-    throwForDisallowedHostnameAfterRedirect,
   ];
 
   return createRequestClient(httpBefores, httpAfters, options);

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -638,8 +638,6 @@ describe('http throwForDisallowedHostnameAfterRedirect after middleware', () => 
     const localUrl = 'https://zapier.com';
     const localScope = nock(localUrl).get('/test').reply(200, 'redirected!!');
 
-    // It would be strange that a developer would redirect to a different domain
-    // using a subdomain like this, but as long as it isn't
     const externalScope = nock('https://my-redirect-domain.com')
       .get('/')
       .reply(301, '', { Location: `${localUrl}/test` });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8455,6 +8455,15 @@ nock@^13.0.0:
     lodash "^4.17.21"
     propagate "^2.0.0"
 
+nock@^13.5.4:
+  version "13.5.4"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.5.4.tgz#8918f0addc70a63736170fef7106a9721e0dc479"
+  integrity sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    propagate "^2.0.0"
+
 node-abort-controller@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
@@ -10791,7 +10800,7 @@ string-length@4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10808,15 +10817,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.1.1:
   version "2.1.1"
@@ -10919,7 +10919,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10953,13 +10953,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11964,7 +11957,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11986,15 +11979,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
As mentioned in the [work ticket](https://zapierorg.atlassian.net/browse/PDE-5063), `node-fetch` doesn't support conditional erroring on redirects. In this MR, we add an "after" middleware to check if the `z.request` experienced a redirect, and error out if the redirection ended up in a disallowed domain (currently only disallowing localhost). We need to check the `resp.url` as the `req.url` does not change on redirect.

Changes:
* Install `nock` explicitly in `core` package
* Add a `throwForDisallowedHostnameAfterRedirect` middleware and use it by default in the `httpAfters` middleware list (after `logResponse`) 
* Update `prepare-response.js` in order to surface the `resp.redirected` and `resp.url` properties for the new middleware. An alternative here could be to move the new middleware even higher on the list.

An alternative approach here could be to set `redirect: 'manual'` as an [option](https://github.com/node-fetch/node-fetch?tab=readme-ov-file#manual-redirect) and then perform manual parsing of the headers [here](https://github.com/zapier/zapier-platform/blob/31bbfec850cfc26eb8e4ad2893b7b1e47022d2f0/packages/core/src/tools/request-client.js#L27).

The big upside to the alternative approach is that we could prevent the `disallowed` domain request from even happening, as opposed to just catching it like we do here. A potential downside is that it could potentially introduce breaking changes by not fully understanding how integrations are leveraging redirects (speaking for myself!) But ultimately, this change is just an attempt to help protect partners from end-user redirect abuse, which this this MR tackles.
