### PR TITLE
chore: use team as the code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # these are the root owners and will be tagged for every PR
-* @eliangcs @rnegron
+* @zapier/epd-dev-platform-backend
 
 # more specific owners can go down here if we want to match certain parts of the codebase, such as legacy-scripting-runner


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->
