### PR TITLE
PDE-5125 - feat(core) Handle large response payloads

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
     "node-fetch": "2.6.7",
     "oauth-sign": "0.9.0",
     "semver": "7.5.2",
-    "uuid": "^10.0.0",
     "zapier-platform-schema": "15.8.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,7 @@
     "node-fetch": "2.6.7",
     "oauth-sign": "0.9.0",
     "semver": "7.5.2",
+    "uuid": "^10.0.0",
     "zapier-platform-schema": "15.8.0"
   },
   "devDependencies": {

--- a/packages/core/src/app-middlewares/after/large-response-cacher.js
+++ b/packages/core/src/app-middlewares/after/large-response-cacher.js
@@ -2,19 +2,31 @@
 
 const constants = require('../../constants');
 const cleaner = require('../../tools/cleaner');
+const createResponseStasher = require('../../tools/create-response-stasher');
 
 /*
   TODO: Some services _do not_ enjoy having 6mb+ responses returned, so
   we may need to user/request pre-signed S3 URLs (or somewhere else?)
   to stash the large response, and return a pointer.
 */
-const largeResponseCachePointer = (output) => {
-  const size = JSON.stringify(cleaner.maskOutput(output)).length;
+const largeResponseCachePointer = async (output) => {
+  const response = cleaner.maskOutput(output);
+
+  const autostashOutputLimit =
+    output.input._zapier.event.autostashPayloadOutputLimit;
+  const size = JSON.stringify(response).length;
   if (size > constants.RESPONSE_SIZE_LIMIT) {
     console.log(
       `Oh no! Payload is ${size}, which is larger than ${constants.RESPONSE_SIZE_LIMIT}.`
     );
-    // TODO: use envelope feature and to build RPC to get signed S3 upload URL.
+
+    if (autostashOutputLimit && size <= autostashOutputLimit) {
+      const stasher = createResponseStasher(output.input);
+
+      const url = await stasher(JSON.stringify(output.results));
+      output.resultsUrl = url;
+      output.results = Array.isArray(output.results) ? [] : {};
+    }
   }
   return output;
 };

--- a/packages/core/src/app-middlewares/after/large-response-cacher.js
+++ b/packages/core/src/app-middlewares/after/large-response-cacher.js
@@ -2,7 +2,7 @@
 
 const constants = require('../../constants');
 const cleaner = require('../../tools/cleaner');
-const createResponseStasher = require('../../tools/create-response-stasher');
+const responseStasher = require('../../tools/create-response-stasher');
 
 /*
   TODO: Some services _do not_ enjoy having 6mb+ responses returned, so
@@ -14,16 +14,16 @@ const largeResponseCachePointer = async (output) => {
 
   const autostashOutputLimit =
     output.input._zapier.event.autostashPayloadOutputLimit;
-  const size = JSON.stringify(response).length;
+
+  const payload = JSON.stringify(response.results);
+  const size = payload.length;
   if (size > constants.RESPONSE_SIZE_LIMIT) {
     console.log(
       `Oh no! Payload is ${size}, which is larger than ${constants.RESPONSE_SIZE_LIMIT}.`
     );
 
     if (autostashOutputLimit && size <= autostashOutputLimit) {
-      const stasher = createResponseStasher(output.input);
-
-      const url = await stasher(JSON.stringify(output.results));
+      const url = await responseStasher(output.input, payload, size);
       output.resultsUrl = url;
       output.results = Array.isArray(output.results) ? [] : {};
     }

--- a/packages/core/src/app-middlewares/after/large-response-cacher.js
+++ b/packages/core/src/app-middlewares/after/large-response-cacher.js
@@ -4,11 +4,6 @@ const constants = require('../../constants');
 const cleaner = require('../../tools/cleaner');
 const responseStasher = require('../../tools/create-response-stasher');
 
-/*
-  TODO: Some services _do not_ enjoy having 6mb+ responses returned, so
-  we may need to user/request pre-signed S3 URLs (or somewhere else?)
-  to stash the large response, and return a pointer.
-*/
 const largeResponseCachePointer = async (output) => {
   const response = cleaner.maskOutput(output);
 
@@ -22,6 +17,8 @@ const largeResponseCachePointer = async (output) => {
       `Oh no! Payload is ${size}, which is larger than ${constants.RESPONSE_SIZE_LIMIT}.`
     );
 
+    // Stash if response is larger than lambda limit, but smaller than autostash limit
+    // otherwise, let lambda deal with it
     if (autostashOutputLimit && size <= autostashOutputLimit) {
       const url = await responseStasher(output.input, payload, size);
       output.resultsUrl = url;

--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -130,7 +130,8 @@ const createBundleBank = (appRaw, event = {}, serializeFunc = (x) => x) => {
   }, {});
 };
 
-const maskOutput = (output) => _.pick(output, 'results', 'status');
+const maskOutput = (output) =>
+  _.pick(output, 'results', 'status', 'resultsUrl');
 
 // These normalize functions are called after the initial before middleware that
 // cleans the request. The reason is that we need to know why a value is empty

--- a/packages/core/src/tools/create-response-stasher.js
+++ b/packages/core/src/tools/create-response-stasher.js
@@ -31,8 +31,8 @@ const stashResponse = async (input, response, size) => {
       signedPostData,
       response.toString(), // accept JSON string to send to uploader.
       size,
-      crypto.randomUUID() + '.json',
-      'application/json'
+      crypto.randomUUID() + '.txt',
+      'text/plain'
     )
   );
 };

--- a/packages/core/src/tools/create-response-stasher.js
+++ b/packages/core/src/tools/create-response-stasher.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const uploader = require('./uploader');
-const { v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
 
 const withRetry = async (fn, retries = 3, delay = 100, attempt = 0) => {
   try {
@@ -31,7 +31,7 @@ const stashResponse = async (input, response, size) => {
       signedPostData,
       response.toString(), // accept JSON string to send to uploader.
       size,
-      uuidv4() + '.json',
+      crypto.randomUUID() + '.json',
       'application/json'
     )
   );

--- a/packages/core/src/tools/create-response-stasher.js
+++ b/packages/core/src/tools/create-response-stasher.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const _ = require('lodash');
+const request = require('./request-client-internal');
+
+const withRetry = async (fn, retries = 3, delay = 100, attempt = 0) => {
+  try {
+    return await fn();
+  } catch (error) {
+    if (attempt >= retries) {
+      throw error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return withRetry(fn, retries, delay, attempt + 1);
+  }
+};
+
+// Function to handle uploading JSON payload
+const uploader = async (signedPostData, jsonData) => {
+  const response = await request({
+    url: signedPostData.url,
+    method: 'POST',
+    body: jsonData,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (response.status === 204) {
+    return new URL(signedPostData.fields.key, signedPostData.url).href;
+  }
+
+  throw new Error(
+    `Response stasher failed with status ${response.status} - ${response.content}`
+  );
+};
+
+// Main function to process the request or data for uploading
+const createResponseStasher = (input) => {
+  const rpc = _.get(input, '_zapier.rpc');
+
+  return async (jsonData) => {
+    if (!rpc) {
+      throw new Error('RPC is not available');
+    }
+
+    const signedPostData = await rpc('get_presigned_upload_post_data');
+    return withRetry(uploader(signedPostData, jsonData));
+  };
+};
+
+module.exports = createResponseStasher;

--- a/packages/core/src/tools/uploader.js
+++ b/packages/core/src/tools/uploader.js
@@ -1,0 +1,69 @@
+const path = require('path');
+
+const FormData = require('form-data');
+const contentDisposition = require('content-disposition');
+
+const request = require('./request-client-internal');
+const LENGTH_ERR_MESSAGE =
+  'We could not calculate the length of your file - please ' +
+  'pass a knownLength like z.stashFile(f, knownLength)';
+
+const uploader = async (
+  signedPostData,
+  bufferStringStream,
+  knownLength,
+  filename,
+  contentType
+) => {
+  filename = path.basename(filename).replace('"', '');
+
+  const fields = {
+    ...signedPostData.fields,
+    'Content-Disposition': contentDisposition(filename),
+    'Content-Type': contentType,
+  };
+
+  const form = new FormData();
+
+  Object.entries(fields).forEach(([key, value]) => {
+    form.append(key, value);
+  });
+
+  form.append('file', bufferStringStream, {
+    knownLength,
+    contentType,
+    filename,
+  });
+
+  // Try to catch the missing length early, before upload to S3 fails.
+  try {
+    form.getLengthSync();
+  } catch (err) {
+    throw new Error(LENGTH_ERR_MESSAGE);
+  }
+
+  // Send to S3 with presigned request.
+  const response = await request({
+    url: signedPostData.url,
+    method: 'POST',
+    body: form,
+  });
+
+  if (response.status === 204) {
+    return new URL(signedPostData.fields.key, signedPostData.url).href;
+  }
+
+  if (
+    response.content &&
+    response.content.includes &&
+    response.content.includes(
+      'You must provide the Content-Length HTTP header.'
+    )
+  ) {
+    throw new Error(LENGTH_ERR_MESSAGE);
+  }
+
+  throw new Error(`Got ${response.status} - ${response.content}`);
+};
+
+module.exports = uploader;

--- a/packages/core/test/app-middleware.js
+++ b/packages/core/test/app-middleware.js
@@ -70,8 +70,8 @@ describe('app middleware', () => {
       .catch(done);
   });
 
-  describe('large-response-cacher', (done) => {
-    it('after middleware should stash large payloads', (done) => {
+  describe('large-response-cacher', async () => {
+    it('after middleware should stash large payloads', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');
       mockUpload();
@@ -91,16 +91,10 @@ describe('app middleware', () => {
       // set the payload autostash limit
       input._zapier.event.autostashPayloadOutputLimit = 11 * 1024 * 1024;
 
-      app(input)
-        .then((output) => {
-          output.resultsUrl.should.eql(
-            'https://s3-fake.zapier.com/1234/foo.json'
-          );
-          done();
-        })
-        .catch(done);
+      const output = await app(input);
+      output.resultsUrl.should.eql('https://s3-fake.zapier.com/1234/foo.json');
     });
-    it('should stash big payloads', (done) => {
+    it('should stash big payloads', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');
       mockUpload();
@@ -120,14 +114,10 @@ describe('app middleware', () => {
       // this limit is lower than res, so do not stash, let it fail
       input._zapier.event.autostashPayloadOutputLimit = 8 * 1024 * 1024;
 
-      app(input)
-        .then((output) => {
-          output.should.not.have.property('resultsUrl');
-          done();
-        })
-        .catch(done);
+      const output = await app(input);
+      output.should.not.have.property('resultsUrl');
     });
-    it('should not stash if payload is bigger than autostash limit', (done) => {
+    it('should not stash if payload is bigger than autostash limit', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');
       mockUpload();
@@ -147,14 +137,10 @@ describe('app middleware', () => {
       // this limit is lower than res, so do not stash, let it fail
       input._zapier.event.autostashPayloadOutputLimit = 8 * 1024 * 1024;
 
-      app(input)
-        .then((output) => {
-          output.should.not.have.property('resultsUrl');
-          done();
-        })
-        .catch(done);
+      const output = app(input);
+      output.should.not.have.property('resultsUrl');
     });
-    it('should always stash if autostash limit is -1', (done) => {
+    it('should always stash if autostash limit is -1', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');
       mockUpload();
@@ -174,16 +160,10 @@ describe('app middleware', () => {
       // this limit is lower than res, so do not stash, let it fail
       input._zapier.event.autostashPayloadOutputLimit = -1;
 
-      app(input)
-        .then((output) => {
-          output.resultsUrl.should.eql(
-            'https://s3-fake.zapier.com/1234/foo.json'
-          );
-          done();
-        })
-        .catch(done);
+      const output = await app(input);
+      output.resultsUrl.should.eql('https://s3-fake.zapier.com/1234/foo.json');
     });
-    it('should not stash if limit is not defined', (done) => {
+    it('should not stash if limit is not defined', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');
       mockUpload();
@@ -201,9 +181,8 @@ describe('app middleware', () => {
 
       // omit setting the payload autostash limit
 
-      app(input).then((output) => {
-        output.should.not.have.property('resultsUrl');
-      });
+      const output = app(input);
+      output.should.not.have.property('resultsUrl');
 
       // returns 10mb regular response
       const bigInputCall = createTestInput(
@@ -214,12 +193,8 @@ describe('app middleware', () => {
 
       // omit setting the payload autostash limit
 
-      app(bigInputCall)
-        .then((output) => {
-          output.should.not.have.property('resultsUrl');
-          done();
-        })
-        .catch(done);
+      const bigOutput = app(bigInputCall);
+      bigOutput.should.not.have.property('resultsUrl');
     });
   });
 });

--- a/packages/core/test/app-middleware.js
+++ b/packages/core/test/app-middleware.js
@@ -94,29 +94,6 @@ describe('app middleware', () => {
       const output = await app(input);
       output.resultsUrl.should.eql('https://s3-fake.zapier.com/1234/foo.json');
     });
-    it('should stash big payloads', async () => {
-      const rpc = makeRpc();
-      mockRpcGetPresignedPostCall('1234/foo.json');
-      mockUpload();
-
-      const appDefinition = dataTools.deepCopy(exampleAppDefinition);
-
-      const app = createApp(appDefinition);
-
-      // returns 10mb of response
-      const input = createTestInput(
-        'resources.really_big_response.list.operation.perform',
-        appDefinition
-      );
-      input._zapier.rpc = rpc;
-
-      // set the payload autostash limit
-      // this limit is lower than res, so do not stash, let it fail
-      input._zapier.event.autostashPayloadOutputLimit = 8 * 1024 * 1024;
-
-      const output = await app(input);
-      output.should.not.have.property('resultsUrl');
-    });
     it('should not stash if payload is bigger than autostash limit', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');

--- a/packages/core/test/tools/response-stasher.js
+++ b/packages/core/test/tools/response-stasher.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const should = require('should');
+
+const { HTTPBIN_URL } = require('../constants');
+const {
+  FAKE_S3_URL,
+  makeRpc,
+  mockRpcGetPresignedPostCall,
+  mockUpload,
+} = require('./mocky');
+
+const stashResponse = require('../../src/tools/create-response-stasher');
+const createAppRequestClient = require('../../src/tools/create-app-request-client');
+const createInput = require('../../src/tools/create-input');
+
+describe('file upload', () => {
+  const testLogger = () => Promise.resolve({});
+  const rpc = makeRpc();
+  const input = createInput({}, {}, testLogger);
+
+  const request = createAppRequestClient(input);
+
+  it('should upload json response', async () => {
+    mockRpcGetPresignedPostCall('1234/foo.json');
+    mockUpload();
+
+    const response = await request(`${HTTPBIN_URL}/json`);
+    const data = JSON.stringify(response.json);
+    const url = await stashResponse(
+      {
+        _zapier: {
+          rpc,
+        },
+      },
+      data
+    );
+    should(url).eql(`${FAKE_S3_URL}/1234/foo.json`);
+
+    const s3Response = await request({ url });
+    should(s3Response.getHeader('content-type')).startWith('application/json');
+    // should(s3Response.getHeader('content-disposition')).eql(
+    //   'attachment; filename="unnamedfile.txt"'
+    // );
+
+    should(s3Response.content).eql(data);
+  });
+  // it('retries on failure', async () => {
+  //   mockRpcGetPresignedPostCall('1234/foo.json');
+  //   mockUpload()
+  //   const response = await request(`${HTTPBIN_URL}/json`);
+  //   const data = JSON.stringify(response.json)
+  //   const url = await stashResponse({
+  //     _zapier: {
+  //       rpc,
+  //     },
+  //   }, data);
+  //   should(url).eql(`${FAKE_S3_URL}/1234/foo.json`);
+
+  //   // mockRpcFail()
+  //   const s3Response = await request({ url});
+  //   should(await s3Response.text()).eql(data);
+  // });
+});

--- a/packages/core/test/tools/response-stasher.js
+++ b/packages/core/test/tools/response-stasher.js
@@ -37,10 +37,7 @@ describe('stash response', () => {
     should(url).eql(`${FAKE_S3_URL}/1234/foo.json`);
 
     const s3Response = await request({ url });
-    should(s3Response.getHeader('content-type')).startWith('application/json');
-    // should(s3Response.getHeader('content-disposition')).eql(
-    //   'attachment; filename="unnamedfile.txt"'
-    // );
+    should(s3Response.getHeader('content-type')).startWith('text/plain');
 
     should(s3Response.content).eql(data);
   });

--- a/packages/core/test/tools/response-stasher.js
+++ b/packages/core/test/tools/response-stasher.js
@@ -23,6 +23,10 @@ describe('stash response', () => {
 
   const request = createAppRequestClient(input);
 
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
   it('should upload json response', async () => {
     mockRpcGetPresignedPostCall('1234/foo.json');
     mockUpload();
@@ -60,7 +64,6 @@ describe('stash response', () => {
 
     // Mock fail the first upload, then succeed
     nock(FAKE_S3_URL)
-      .persist()
       .post('/')
       .reply(500, 'uh oh')
       .post('/')

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -386,9 +386,7 @@ const CachedCustomInputFields = {
       description: 'Get/Set custom input fields in zcache',
     },
     operation: {
-      inputFields: [
-        helpers.getCustomFields,
-      ],
+      inputFields: [helpers.getCustomFields],
       perform: () => {},
     },
   },
@@ -566,6 +564,32 @@ const BadCallback = {
   },
 };
 
+const createLargeResponse = (targetSizeInMB) => {
+  const targetSize = targetSizeInMB * 1024 * 1024; // Convert MB to bytes
+  const sampleData = {
+    id: 1,
+    data: 'a'.repeat(targetSize),
+  };
+  return sampleData;
+};
+
+// 10mb of data
+const ReallyBigResponse = {
+  key: 'really_big_response',
+  noun: 'Really Big Response',
+  list: {
+    display: {
+      label: 'Really Big Response',
+      description: 'This is a really big response.',
+    },
+    operation: {
+      perform: (z, bundle) => {
+        return createLargeResponse(10);
+      },
+    },
+  },
+};
+
 // custom HTTP middlewares /////
 
 /*
@@ -606,6 +630,7 @@ const App = {
     [ExecuteCallbackRequest.key]: ExecuteCallbackRequest,
     [EnvironmentVariable.key]: EnvironmentVariable,
     [BadCallback.key]: BadCallback,
+    [ReallyBigResponse.key]: ReallyBigResponse,
   },
   hydrators: {
     getBigStuff: () => {},


### PR DESCRIPTION
https://zapierorg.atlassian.net/browse/PDE-5125

This PR addresses a new event field: `autostashPayloadOutputLimit` that we can process.
If this value is set from the backend, we can conditionally stash the payload response. This is to work around the Lambda 6mb output limit. 
There are some changes as well to refactor some things around, as we will be reusing the `uploader()` functionality to stash the payload. 
