### PR TITLE
feat(core): Allow relative paths via z.require() [PDE-5116]

### DIFF
--- a/packages/core/src/app-middlewares/before/z-object.js
+++ b/packages/core/src/app-middlewares/before/z-object.js
@@ -29,7 +29,10 @@ const injectZObject = (input) => {
     generateCallbackUrl: createCallbackHigherOrderFunction(input),
     hash: hashing.hashify,
     JSON: createJSONtool(),
-    require: (moduleName) => require(moduleName),
+    require: (moduleName) =>
+      require(require.resolve(moduleName, {
+        paths: module.paths.concat([process.cwd()]),
+      })),
     stashFile: createFileStasher(input),
   };
 

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -116,25 +116,17 @@ const getAppRawOverride = (rpc, appRawOverride) => {
 // so allow for that, and an event.appRawOverride for "buildless" apps.
 const loadApp = (event, rpc, appRawOrPath) => {
   return new ZapierPromise((resolve, reject) => {
-    const appRaw = _.isString(appRawOrPath)
-      ? require(appRawOrPath)
-      : appRawOrPath;
-
     if (event && event.appRawOverride) {
-      if (
-        Array.isArray(event.appRawOverride) &&
-        event.appRawOverride.length > 1 &&
-        !event.appRawOverride[0]
-      ) {
-        event.appRawOverride[0] = appRaw;
-      }
-
       return getAppRawOverride(rpc, event.appRawOverride)
         .then((appRawOverride) => resolve(appRawOverride))
         .catch((err) => reject(err));
     }
 
-    return resolve(appRaw);
+    if (_.isString(appRawOrPath)) {
+      return resolve(require(appRawOrPath));
+    }
+
+    return resolve(appRawOrPath);
   });
 };
 

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -116,17 +116,25 @@ const getAppRawOverride = (rpc, appRawOverride) => {
 // so allow for that, and an event.appRawOverride for "buildless" apps.
 const loadApp = (event, rpc, appRawOrPath) => {
   return new ZapierPromise((resolve, reject) => {
+    const appRaw = _.isString(appRawOrPath)
+      ? require(appRawOrPath)
+      : appRawOrPath;
+
     if (event && event.appRawOverride) {
+      if (
+        Array.isArray(event.appRawOverride) &&
+        event.appRawOverride.length > 1 &&
+        !event.appRawOverride[0]
+      ) {
+        event.appRawOverride[0] = appRaw;
+      }
+
       return getAppRawOverride(rpc, event.appRawOverride)
         .then((appRawOverride) => resolve(appRawOverride))
         .catch((err) => reject(err));
     }
 
-    if (_.isString(appRawOrPath)) {
-      return resolve(require(appRawOrPath));
-    }
-
-    return resolve(appRawOrPath);
+    return resolve(appRaw);
   });
 };
 

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -602,6 +602,16 @@ describe('create-app', () => {
         /Cannot find module 'non-existing-package'/
       );
     });
+
+    it('should be able to import from other paths using zRequire', async () => {
+      const input = createTestInput(
+        'resources.listrequire.list.operation.perform'
+      );
+      const appPass = createApp(appDefinition);
+
+      const { results } = await appPass(input);
+      results.should.eql('www.base-url.com');
+    });
   });
 
   describe('response.content parsing', () => {

--- a/packages/core/test/userapp/constants.js
+++ b/packages/core/test/userapp/constants.js
@@ -1,0 +1,5 @@
+const BASE_URL = 'www.base-url.com';
+
+module.exports = {
+  BASE_URL,
+};

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -36,9 +36,7 @@ const ListRequire = {
     },
     operation: {
       perform: (z, bundle) => {
-        // need to specify the full /test/userapp path because
-        // it's not possible to mock process.cwd for require.resolve
-        // but in prod, that will return the app root directory
+        // in prod, process.cwd will return the app root directory
         const { BASE_URL } = z.require('./test/userapp/constants.js');
         return BASE_URL;
       },

--- a/packages/core/test/userapp/index.js
+++ b/packages/core/test/userapp/index.js
@@ -26,6 +26,26 @@ const List = {
   },
 };
 
+const ListRequire = {
+  key: 'listrequire',
+  noun: 'List',
+  list: {
+    display: {
+      description: 'Trigger on new thing in list.',
+      label: 'List',
+    },
+    operation: {
+      perform: (z, bundle) => {
+        // need to specify the full /test/userapp path because
+        // it's not possible to mock process.cwd for require.resolve
+        // but in prod, that will return the app root directory
+        const { BASE_URL } = z.require('./test/userapp/constants.js');
+        return BASE_URL;
+      },
+    },
+  },
+};
+
 const Contact = {
   key: 'contact',
   noun: 'Contact',
@@ -386,9 +406,7 @@ const CachedCustomInputFields = {
       description: 'Get/Set custom input fields in zcache',
     },
     operation: {
-      inputFields: [
-        helpers.getCustomFields,
-      ],
+      inputFields: [helpers.getCustomFields],
       perform: () => {},
     },
   },
@@ -582,6 +600,7 @@ const App = {
   afterResponse: [],
   resources: {
     [List.key]: List,
+    [ListRequire.key]: ListRequire,
     [Contact.key]: Contact,
     [ContactError.key]: ContactError,
     [ContactSource.key]: ContactSource,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Based on the POC patch logic here: https://gitlab.com/zapier/zapier/-/merge_requests/57310/diffs#note_1923825583

`z.require('./constants')` should work relative to the app root rather than to `node_modules/zapier-platform-core/src/app-middlewares/before`.