### PR TITLE
feat(core): Update loadApp to default to CLI definition and merge in external action definition as needed [PDE-5114]

### DIFF
--- a/packages/core/integration-test/integration-test.js
+++ b/packages/core/integration-test/integration-test.js
@@ -488,6 +488,40 @@ const doTest = (runner) => {
       });
     });
 
+    it('should handle array of non-existent appRawOverride (CLI app) with an appRawExtension, and add new trigger', () => {
+      let definition; // CLI apps have no definition override
+
+      const definitionExtension = {
+        triggers: {
+          perform: {
+            key: 'perform',
+            noun: 'Foo',
+            operation: {
+              perform: { source: 'return [{id: 12345}]' },
+            },
+          },
+        },
+      };
+
+      const event = {
+        command: 'execute',
+        method: 'triggers.perform.operation.perform',
+        appRawOverride: [definition, definitionExtension],
+        rpc_base: 'https://mock.zapier.com/platform/rpc/cli',
+        token: 'fake',
+      };
+
+      return runner(event).then((response) => {
+        response.results.should.eql([
+          {
+            id: 12345,
+          },
+        ]);
+        // CLI code should be merged in with extension
+        event.appRawOverride[0].should.not.eql(undefined);
+      });
+    });
+
     it('should handle function source in beforeRequest', async () => {
       const definition = {
         beforeRequest: [

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -116,17 +116,25 @@ const getAppRawOverride = (rpc, appRawOverride) => {
 // so allow for that, and an event.appRawOverride for "buildless" apps.
 const loadApp = (event, rpc, appRawOrPath) => {
   return new ZapierPromise((resolve, reject) => {
+    const appRaw = _.isString(appRawOrPath)
+      ? require(appRawOrPath)
+      : appRawOrPath;
+
     if (event && event.appRawOverride) {
+      if (
+        Array.isArray(event.appRawOverride) &&
+        event.appRawOverride.length > 1 &&
+        !event.appRawOverride[0]
+      ) {
+        event.appRawOverride[0] = appRaw;
+      }
+
       return getAppRawOverride(rpc, event.appRawOverride)
         .then((appRawOverride) => resolve(appRawOverride))
         .catch((err) => reject(err));
     }
 
-    if (_.isString(appRawOrPath)) {
-      return resolve(require(appRawOrPath));
-    }
-
-    return resolve(appRawOrPath);
+    return resolve(appRaw);
   });
 };
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

Allow `loadApp` to default to a CLI integration's definition when no definition override (for Platform UI apps) is passed, so that the partial definition of the external action gets merged in.