### PR TITLE
feat(core) Update extendAppRaw to override arrays as well as objects [PDE-5114]

### DIFF
--- a/packages/core/integration-test/integration-test.js
+++ b/packages/core/integration-test/integration-test.js
@@ -198,7 +198,13 @@ const doTest = (runner) => {
             noun: 'Foo',
             operation: {
               perform: { source: 'return [{id: 12345}]' },
-              inputFields: [{ key: 'name', type: 'string' }],
+              inputFields: [
+                { key: 'name', type: 'string' },
+                { key: 'testing', type: 'string' },
+              ],
+              sample: {
+                id: 123,
+              },
             },
           },
         },
@@ -209,11 +215,12 @@ const doTest = (runner) => {
       const definitionExtension = {
         creates: {
           foo: {
-            noun: 'Foobar',
+            noun: 'Foo',
             operation: {
+              perform: { source: 'return [{id: 12345}]' },
               inputFields: [{ key: 'message', type: 'string' }],
               sample: {
-                id: 678,
+                name: 'sample',
               },
             },
           },
@@ -273,6 +280,59 @@ const doTest = (runner) => {
       const event = {
         command: 'execute',
         method: 'creates.foo.operation.inputFields',
+        appRawOverride: [definitionHash, definitionExtension],
+        rpc_base: 'https://mock.zapier.com/platform/rpc/cli',
+        token: 'fake',
+      };
+
+      return runner(event).then((response) => {
+        response.results.should.eql([{ key: 'message', type: 'string' }]);
+      });
+    });
+
+    it('should handle array of [appRawOverrideHash, appRawExtension] and overrides with an operation trigger key', () => {
+      const definition = {
+        creates: {
+          operation: {
+            key: 'operation',
+            operation: {
+              perform: { source: 'return [{id: 12345}]' },
+              inputFields: [
+                { key: 'name', type: 'string' },
+                { key: 'testing', type: 'string' },
+              ],
+              sample: {
+                id: 123,
+              },
+            },
+          },
+        },
+      };
+
+      mocky.mockRpcCall(definition);
+
+      const definitionExtension = {
+        creates: {
+          operation: {
+            operation: {
+              perform: { source: 'return [{id: 123}]' },
+              inputFields: [{ key: 'message', type: 'string' }],
+              sample: {
+                name: 'sample',
+              },
+            },
+          },
+        },
+      };
+
+      const definitionHash = crypto
+        .createHash('md5')
+        .update(JSON.stringify(definition))
+        .digest('hex');
+
+      const event = {
+        command: 'execute',
+        method: 'creates.operation.operation.inputFields',
         appRawOverride: [definitionHash, definitionExtension],
         rpc_base: 'https://mock.zapier.com/platform/rpc/cli',
         token: 'fake',

--- a/packages/core/integration-test/integration-test.js
+++ b/packages/core/integration-test/integration-test.js
@@ -215,6 +215,7 @@ const doTest = (runner) => {
       const definitionExtension = {
         creates: {
           foo: {
+            key: 'foo',
             noun: 'Foo',
             operation: {
               perform: { source: 'return [{id: 12345}]' },
@@ -290,7 +291,7 @@ const doTest = (runner) => {
       });
     });
 
-    it('should handle array of [appRawOverrideHash, appRawExtension] and overrides with an operation trigger key', () => {
+    it('should handle array of [appRawOverrideHash, appRawExtension] and overrides with an operation create key', () => {
       const definition = {
         creates: {
           operation: {

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -30,17 +30,15 @@ const isRequestOrFunction = (obj) => {
 
 const extendAppRaw = (base, extension) => {
   const keysToOverride = [
-    'test',
+    'inputFields',
     'perform',
     'performList',
     'performSubscribe',
     'performUnsubscribe',
+    'sample',
+    'test',
   ];
   const concatArrayAndOverrideKeys = (objValue, srcValue, key) => {
-    if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-      return objValue.concat(srcValue);
-    }
-
     if (
       // Do full replacement when it comes to keysToOverride
       keysToOverride.indexOf(key) !== -1 &&

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -31,12 +31,14 @@ const isRequestOrFunction = (obj) => {
 const extendAppRaw = (base, extension) => {
   const keysToOverride = [
     'inputFields',
+    'outputFields',
     'perform',
     'performList',
     'performSubscribe',
     'performUnsubscribe',
     'sample',
     'test',
+    'throttle',
   ];
   const concatArrayAndOverrideKeys = (objValue, srcValue, key) => {
     if (


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner

-->

The `extendAppRaw` function in `createLambdaHandler` currently assumes it should always/only concatenate arrays in an app definition. However, for many cases we actually do want to override the array, not concatenate it - for example for inputFields coming in from an external action, we should fully overwrite the base inputFields with the partial inputFields.
