### PR TITLE
PDE-5159 feat(core) - Increase hydration payload limit

### DIFF
--- a/packages/core/src/tools/wrap-hydrate.js
+++ b/packages/core/src/tools/wrap-hydrate.js
@@ -5,7 +5,8 @@ const crypto = require('crypto');
 const { DehydrateError } = require('../errors');
 
 // https://nodejs.org/docs/latest-v16.x/api/http.html#httpmaxheadersize
-// base64 encoding is approx 4/3, so our limit should be:
+// Base64 encoding adds approx 4/3 to the original size
+// To account for encoding, we use the inverse to calc the max original size (3/4)
 // 16kb limit * 1024 * (3 / 4) = 12.228 kb max, minus some room for additional overhead
 const MAX_PAYLOAD_SIZE = 12000;
 

--- a/packages/core/src/tools/wrap-hydrate.js
+++ b/packages/core/src/tools/wrap-hydrate.js
@@ -4,9 +4,10 @@ const crypto = require('crypto');
 
 const { DehydrateError } = require('../errors');
 
-// Max URL length for Node is 8KB (https://stackoverflow.com/a/56954244/)
-// 8 * 1024 * (3 / 4) = 6144 max, minus some room for additional overhead
-const MAX_PAYLOAD_SIZE = 6000;
+// https://nodejs.org/docs/latest-v16.x/api/http.html#httpmaxheadersize
+// base64 encoding is approx 4/3, so our limit should be:
+// 16kb limit * 1024 * (3 / 4) = 12.228 kb max, minus some room for additional overhead
+const MAX_PAYLOAD_SIZE = 12000;
 
 const wrapHydrate = (payload) => {
   payload = JSON.stringify(payload);

--- a/packages/core/test/hydration.js
+++ b/packages/core/test/hydration.js
@@ -52,8 +52,8 @@ describe('hydration', () => {
       );
     });
 
-    it('should not accept payload size bigger than 6000 bytes.', () => {
-      const inputData = { key: 'a'.repeat(6001) };
+    it('should not accept payload size bigger than 12000 bytes.', () => {
+      const inputData = { key: 'a'.repeat(12001) };
       (() => {
         dehydrate(funcToFind, inputData);
       }).should.throw(/Oops! You passed too much data/);
@@ -91,8 +91,8 @@ describe('hydration', () => {
       );
     });
 
-    it('should not accept payload size bigger than 6000 bytes.', () => {
-      const inputData = { key: 'a'.repeat(6001) };
+    it('should not accept payload size bigger than 12000 bytes.', () => {
+      const inputData = { key: 'a'.repeat(12001) };
       (() => {
         dehydrateFile(funcToFind, inputData);
       }).should.throw(/Oops! You passed too much data/);


### PR DESCRIPTION
Increases the hydration payload limit. In older Node versions, this was capped at 8kb due to the hydration URL that we need to call eventually. Since Node 16, this is now 16kb.