### PR TITLE
PDE-5114 fix(core): prevent standalone 'creates' in `extension` from colliding with resource keys in `base`

### DIFF
--- a/packages/core/integration-test/integration-test.js
+++ b/packages/core/integration-test/integration-test.js
@@ -344,6 +344,32 @@ const doTest = (runner) => {
       });
     });
 
+    it('should handle array of [null, appRawExtension] without resource key collision', async () => {
+      const definitionExtension = {
+        // Example app test/userapp/index.js has a 'contact' resource with a
+        // 'create' operation ('contactCreate' after compiled). So this should
+        // merge with that and not collide.
+        creates: {
+          contactCreate: {
+            operation: {
+              perform: {
+                source: 'return { id: 8, name: "Yoshi" }',
+              },
+            },
+          },
+        },
+      };
+
+      const event = {
+        comamnd: 'execute',
+        method: 'creates.contactCreate.operation.perform',
+        appRawOverride: [null, definitionExtension],
+      };
+
+      const response = await runner(event);
+      response.results.should.deepEqual({ id: 8, name: 'Yoshi' });
+    });
+
     it('should handle array of [appRawOverrideHash, appRawExtension] and override perform with request', () => {
       const definition = {
         triggers: {


### PR DESCRIPTION
MR [57964](https://gitlab.com/zapier/zapier/-/merge_requests/57964) and [57983](https://gitlab.com/zapier/zapier/-/merge_requests/57983) are temporary fixes. This one is the long-term fix.