### PR TITLE
docs(schema-to-ts): [PDE-5969] Minor doc updates to reference schema-to-ts package

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,5 +26,6 @@ where:
     * schema
     * core
     * legacy-scripting-runner
+    * schema-to-ts
 
 -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,5 +7,6 @@
 ## Technical Organization
 
 - The root folder mostly holds tooling scripts, tooling configuration, examples, and documentation for the platform as a whole.
+  - The `schema-to-ts` folder contains a custom package that generates TypeScript declarations for `zapier-platform-core` based on the `zapier-platform-schema`'s generated `exported-schema.json` file. These generated type declarations are bundled into `zapier-platform-core` and shipped to end-users as part of that NPM package. Type declarations are configured to be generated via the `generate-types` NPM script, which runs automatically as part of a `husky` precommit hook.
 - The individual packages are found in the `packages` directory. Each has its own `ARCHITECTURE.md` file outlining the code for that specific package.
 - The `boilerplate` directory holds a "bare minimum" app that we include with each `zapier-platform-core` version (AKA Platform Version). We use this in combination with the Visual Builder to ship apps that that skip the build step.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ That's it! Now you have a local environment for development.
 
 ## Running Tests
 
-You can run all tests for all packages with yarn test:
+You can run all tests for all packages and configured tooling with yarn test:
 
 ```bash
 yarn test
@@ -44,6 +44,15 @@ For example, this is how you run all the tests for the cli package:
 
 ```bash
 cd packages/cli
+yarn test
+```
+
+### Running All schema-to-ts Tests
+
+The `schema-to-ts` tool also has its own suite of tests which use `vitest` to run. To run only these tests, do the following:
+
+```bash
+cd schema-to-ts
 yarn test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ In the repo directory, install dependencies with yarn:
 yarn
 ```
 
+An additional step is required while we drop Node.js 16 support (see [GitHub comment](https://github.com/zapier/zapier-platform/pull/821#issuecomment-2230958511)) - install `schema-to-ts` dependencies:
+```bash
+cd schema-to-ts
+yarn
+```
+
 That's it! Now you have a local environment for development.
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It consists of a few main packages:
 - [`zapier-platform-schema`](packages/schema): The source of truth for what's allowed in the structure a Zapier app; not typically installed directly
 - [`zapier-platform-legacy-scripting-runner`](packages/legacy-scripting-runner): If your app started as a Legacy Web Builder app, this provides a shim that keeps your app running seamlessly
 - [`example-apps/*`](example-apps): A varied set of example apps to help you get started
+- [`schema-to-ts`](schema-to-ts): Custom tooling to generate TypeScript declarations for `zapier-platform-core` using `zapier-platform-schema`'s output schemas
 
 ## Docs
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "should": "^13"
   },
   "workspaces": [
-    "packages/*",
-    "schema-to-ts"
+    "packages/*"
   ],
   "scripts": {
     "test": "yarn workspaces run test && (cd schema-to-ts && yarn test)",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "should": "^13"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "schema-to-ts"
   ],
   "scripts": {
     "test": "yarn workspaces run test && (cd schema-to-ts && yarn test)",


### PR DESCRIPTION
* ~~Added `schema-to-ts` to `workspaces` key in the root `package.json`, so that running `yarn` from the root of the repo installs `schema-to-ts` packages as well.~~
  * Without this, running `yarn` and then `yarn test` would result in errors around the `vitest` package missing as part of the `(cd schema-to-ts && yarn test)` part.
* Updated some docs to mention `schema-to-ts`