### PR TITLE
PDE-5189 docs: document `bundle.meta.withSearch`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3347,6 +3347,11 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 <td><code>false</code></td>
 <td>(legacy property) If true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> or during setup). We use this data to populate the auth label, but it&apos;s mostly used to verify we made a successful authenticated request</td>
 </tr>
+<tr>
+<td><code>withSearch</code></td>
+<td><code>undefined</code></td>
+<td>When a create is called as part of a search-or-create step, <code>withSearch</code> will be the key of the search.</td>
+</tr>
 </tbody>
 </table>
     </div>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1019,6 +1019,7 @@ You'll usually want to use `bundle.inputData` instead.
 | `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
 | `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
 | `isTestingAuth` | `false` | (legacy property) If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
+| `withSearch` | `undefined` | When a create is called as part of a search-or-create step, `withSearch` will be the key of the search. |
 
 > Before v8.0.0, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes) for a mapping of old values to new.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1994,6 +1994,7 @@ You'll usually want to use `bundle.inputData` instead.
 | `limit` | `-1` | The number of items you should fetch. `-1` indicates there's no limit. Build this into your calls insofar as you are able |
 | `page` | `0` | Used in [paging](#paging) to uniquely identify which page of results should be returned |
 | `isTestingAuth` | `false` | (legacy property) If true, the poll was triggered by a user testing their account (via [clicking "test"](https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png) or during setup). We use this data to populate the auth label, but it's mostly used to verify we made a successful authenticated request |
+| `withSearch` | `undefined` | When a create is called as part of a search-or-create step, `withSearch` will be the key of the search. |
 
 > Before v8.0.0, the information in `bundle.meta` was different. See [the old docs](https://github.com/zapier/zapier-platform-cli/blob/a058e6d538a75d215d2e0c52b9f49a97218640c4/README.md#bundlemeta) for the previous values and [the wiki](https://github.com/zapier/zapier-platform/wiki/bundle.meta-changes) for a mapping of old values to new.
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -3347,6 +3347,11 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 <td><code>false</code></td>
 <td>(legacy property) If true, the poll was triggered by a user testing their account (via <a href="https://cdn.zapier.com/storage/photos/5c94c304ce11b02c073a973466a7b846.png">clicking &quot;test&quot;</a> or during setup). We use this data to populate the auth label, but it&apos;s mostly used to verify we made a successful authenticated request</td>
 </tr>
+<tr>
+<td><code>withSearch</code></td>
+<td><code>undefined</code></td>
+<td>When a create is called as part of a search-or-create step, <code>withSearch</code> will be the key of the search.</td>
+</tr>
 </tbody>
 </table>
     </div>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Documents this change: https://gitlab.com/zapier/zapier/-/merge_requests/58080