### PR TITLE
PDE-5184 fix(core) - Add base64 encoding before uploading to s3

### DIFF
--- a/packages/core/src/app-middlewares/after/large-response-cacher.js
+++ b/packages/core/src/app-middlewares/after/large-response-cacher.js
@@ -24,7 +24,7 @@ const largeResponseCachePointer = async (output) => {
       size <= autostashLimit) ||
     autostashLimit === -1
   ) {
-    const url = await responseStasher(output.input, payload, size);
+    const url = await responseStasher(output.input, payload);
     output.resultsUrl = url;
     output.results = Array.isArray(output.results) ? [] : {};
   }

--- a/packages/core/src/tools/create-response-stasher.js
+++ b/packages/core/src/tools/create-response-stasher.js
@@ -8,6 +8,7 @@ const withRetry = async (fn, retries = 3, delay = 100, attempt = 0) => {
   try {
     return await fn();
   } catch (error) {
+    console.log(error);
     if (attempt >= retries) {
       throw error;
     }
@@ -18,19 +19,23 @@ const withRetry = async (fn, retries = 3, delay = 100, attempt = 0) => {
 };
 
 // responseStasher uploads the data and returns the URL that points to that data.
-const stashResponse = async (input, response, size) => {
+const stashResponse = async (input, response) => {
   const rpc = _.get(input, '_zapier.rpc');
 
   if (!rpc) {
     throw new Error('rpc is not available');
   }
   const signedPostData = await rpc('get_presigned_upload_post_data');
+
+  // Encode the response to base64 to avoid uploading any non-ascii characters
+  const encodedResponse = Buffer.from(response).toString('base64');
+
   return withRetry(
     _.partial(
       uploader,
       signedPostData,
-      response.toString(), // accept JSON string to send to uploader.
-      size,
+      encodedResponse,
+      encodedResponse.length,
       crypto.randomUUID() + '.txt',
       'text/plain'
     )

--- a/packages/core/src/tools/create-response-stasher.js
+++ b/packages/core/src/tools/create-response-stasher.js
@@ -8,7 +8,6 @@ const withRetry = async (fn, retries = 3, delay = 100, attempt = 0) => {
   try {
     return await fn();
   } catch (error) {
-    console.log(error);
     if (attempt >= retries) {
       throw error;
     }

--- a/packages/core/src/tools/uploader.js
+++ b/packages/core/src/tools/uploader.js
@@ -28,7 +28,6 @@ const uploader = async (
   Object.entries(fields).forEach(([key, value]) => {
     form.append(key, value);
   });
-
   form.append('file', bufferStringStream, {
     knownLength,
     contentType,

--- a/packages/core/test/app-middleware.js
+++ b/packages/core/test/app-middleware.js
@@ -5,6 +5,7 @@ const createApp = require('../src/create-app');
 const createInput = require('../src/tools/create-input');
 const dataTools = require('../src/tools/data');
 const {
+  FAKE_S3_URL,
   makeRpc,
   mockRpcGetPresignedPostCall,
   mockUpload,
@@ -114,8 +115,9 @@ describe('app middleware', () => {
       input._zapier.event.autostashPayloadOutputLimit = 11 * 1024 * 1024;
 
       const output = await app(input);
-      output.resultsUrl.should.eql('https://s3-fake.zapier.com/1234/foo.json');
+      output.resultsUrl.should.eql(`${FAKE_S3_URL}/1234/foo.json`);
     });
+
     it('should not stash if payload is bigger than autostash limit', async () => {
       const rpc = makeRpc();
       mockRpcGetPresignedPostCall('1234/foo.json');
@@ -141,7 +143,7 @@ describe('app middleware', () => {
     });
     it('should always stash if autostash limit is -1', async () => {
       const rpc = makeRpc();
-      mockRpcGetPresignedPostCall('1234/foo.json');
+      mockRpcGetPresignedPostCall('/1234/foo.json');
       mockUpload();
 
       const appDefinition = dataTools.deepCopy(exampleAppDefinition);
@@ -156,11 +158,10 @@ describe('app middleware', () => {
       input._zapier.rpc = rpc;
 
       // set the payload autostash limit
-      // this limit is lower than res, so do not stash, let it fail
       input._zapier.event.autostashPayloadOutputLimit = -1;
 
       const output = await app(input);
-      output.resultsUrl.should.eql('https://s3-fake.zapier.com/1234/foo.json');
+      output.resultsUrl.should.eql(`${FAKE_S3_URL}/1234/foo.json`);
     });
     it('should not stash if limit is not defined', async () => {
       const rpc = makeRpc();

--- a/packages/core/test/tools/response-stasher.js
+++ b/packages/core/test/tools/response-stasher.js
@@ -38,8 +38,8 @@ describe('stash response', () => {
 
     const s3Response = await request({ url });
     should(s3Response.getHeader('content-type')).startWith('text/plain');
-
-    should(s3Response.content).eql(data);
+    const decoded = Buffer.from(s3Response.content, 'base64').toString();
+    should(decoded).eql(data);
   });
   it('retries on failure', async () => {
     mockRpcGetPresignedPostCall('1234/foo.json');
@@ -54,7 +54,8 @@ describe('stash response', () => {
     should(url).eql(`${FAKE_S3_URL}/1234/foo.json`);
 
     const s3Response = await request({ url });
-    should(s3Response.content).eql(data);
+    const decoded = Buffer.from(s3Response.content, 'base64').toString();
+    should(decoded).eql(data);
   });
   it('throws on persistent failures', async () => {
     mockRpcGetPresignedPostCall('1234/foo.json');

--- a/packages/core/types/zapier.generated.d.ts
+++ b/packages/core/types/zapier.generated.d.ts
@@ -4,7 +4,7 @@
  * files, and/or the schema-to-ts tool and run its CLI to regenerate
  * these typings.
  *
- * zapier-platform-schema version: 15.10.0
+ * zapier-platform-schema version: 15.11.0
  *  schema-to-ts compiler version: 0.1.0
  */
 


### PR DESCRIPTION
Currently when using this autostashing payload feature, if the perform call returns non-ascii characters, it won't stash. This MR encodes the data before uploading and we can decode on the way out. 

Planning to release this on 15.11.1, so the backend should account for this by only decode when zpc@15.11.1. 