### PR TITLE
fix(core): Allow Async Middleware Functions Types

### DIFF
--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -124,6 +124,9 @@ const addBearerHeader: BeforeRequestMiddleware = (request, z, bundle) => {
 };
 expectType<BeforeRequestMiddleware>(addBearerHeader);
 
+const asyncBeforeRequest: BeforeRequestMiddleware = async (request) => request;
+expectType<BeforeRequestMiddleware>(asyncBeforeRequest);
+
 const checkPermissionsError: AfterResponseMiddleware = (response, z) => {
   if (response.status === 403) {
     throw new z.errors.Error(
@@ -135,12 +138,18 @@ const checkPermissionsError: AfterResponseMiddleware = (response, z) => {
 };
 expectType<AfterResponseMiddleware>(checkPermissionsError);
 
+const asyncAfterResponse: AfterResponseMiddleware = async (response) =>
+  response;
+expectType<AfterResponseMiddleware>(asyncAfterResponse);
+
 const app: App = {
   platformVersion: '0.0.1',
   version: '0.0.1',
 
-  beforeRequest: [addBearerHeader],
-  afterResponse: [checkPermissionsError],
+  beforeRequest: [addBearerHeader, asyncBeforeRequest],
+  afterResponse: [checkPermissionsError, asyncAfterResponse],
+
+  authentication,
 
   creates: { [create.key]: create },
   triggers: {

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -216,10 +216,10 @@ export type BeforeRequestMiddleware = (
   request: HttpRequestOptions,
   z?: ZObject,
   bundle?: Bundle
-) => HttpRequestOptions;
+) => HttpRequestOptions | Promise<HttpRequestOptions>;
 
 export type AfterResponseMiddleware = (
   response: HttpResponse,
   z: ZObject,
   bundle?: Bundle
-) => HttpResponse;
+) => HttpResponse | Promise<HttpResponse>;


### PR DESCRIPTION
This allows for `beforeRequest`/`afterResponse` middleware functions to be asynchronous, which is reasonably common in the integration monorepo ([Xero example](https://gitlab.com/zapier/team-integrations/zapier-platform-integrations/-/blob/3f539106d79b8c6a7a4a58470eeabaabe85996fd/apps/xero/middleware.js#L92))