### PR TITLE
Add bulk_reads to display functional constraint

### DIFF
--- a/packages/schema/lib/functional-constraints/labelWhenVisible.js
+++ b/packages/schema/lib/functional-constraints/labelWhenVisible.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const jsonschema = require('jsonschema');
 
-const actionTypes = ['triggers', 'searches', 'creates'];
+const actionTypes = ['triggers', 'searches', 'creates', 'bulk_reads'];
 
 const labelWhenVisible = (definition) => {
   const errors = [];


### PR DESCRIPTION
Small change to add `bulk_reads` to the functional constraint which validates the `display` property. 

It's a minor thing I discovered while adding schema validation for external actions. Currently it's possible to have a `bulk_read` action type with a partially complete display property 😨 