### PR TITLE
Correct casing on bulk reads action type

### DIFF
--- a/packages/schema/lib/functional-constraints/labelWhenVisible.js
+++ b/packages/schema/lib/functional-constraints/labelWhenVisible.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const jsonschema = require('jsonschema');
 
-const actionTypes = ['triggers', 'searches', 'creates', 'bulk_reads'];
+const actionTypes = ['triggers', 'searches', 'creates', 'bulkReads'];
 
 const labelWhenVisible = (definition) => {
   const errors = [];


### PR DESCRIPTION
[The previous MR](https://github.com/zapier/zapier-platform/pull/829) to add bulk reads to schema validation used snake case - this corrects it to use camel case