### PR TITLE
PDE-5230 doc(cli): be more accurate on limitation of `primary: true`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5763,7 +5763,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on a field like <code>user__id</code>, it will be ignored.</p>
+      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on both <code>id</code> and <code>user__id</code>, the <code>primary</code> setting on the <code>user__id</code> field will be ignored; only <code>id</code> will be used for deduplication.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/docs/index.html
+++ b/docs/index.html
@@ -5763,7 +5763,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on both <code>id</code> and <code>user__id</code>, the <code>primary</code> setting on the <code>user__id</code> field will be ignored; only <code>id</code> will be used for deduplication.</p>
+      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on both <code>id</code> and <code>user__id</code>, the <code>primary</code> setting on the <code>user__id</code> field will be ignored; only <code>id</code> will be used for deduplication. However, if all the <code>primary</code> fields are all nested, such as <code>user__id</code> + <code>user__name</code>, it will work as expected.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -2155,7 +2155,7 @@ Since v15.6.0, instead of using the default `id` field, you can also define one 
 
 will tell Zapier to use `(userId, slug)` as the unique primary key to deduplicate items when running a polling trigger.
 
-**Limitation:** The `primary` option currently doesn't support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set `primary: true` on both `id` and `user__id`, the `primary` setting on the `user__id` field will be ignored; only `id` will be used for deduplication.
+**Limitation:** The `primary` option currently doesn't support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set `primary: true` on both `id` and `user__id`, the `primary` setting on the `user__id` field will be ignored; only `id` will be used for deduplication. However, if all the `primary` fields are all nested, such as `user__id` + `user__name`, it will work as expected.
 
 ### Node X No Longer Supported
 

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -2155,7 +2155,7 @@ Since v15.6.0, instead of using the default `id` field, you can also define one 
 
 will tell Zapier to use `(userId, slug)` as the unique primary key to deduplicate items when running a polling trigger.
 
-**Limitation:** The `primary` option currently doesn't support nested fields that use double underscores in their keys. For example, if you set `primary: true` on a field like `user__id`, it will be ignored.
+**Limitation:** The `primary` option currently doesn't support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set `primary: true` on both `id` and `user__id`, the `primary` setting on the `user__id` field will be ignored; only `id` will be used for deduplication.
 
 ### Node X No Longer Supported
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3669,7 +3669,7 @@ Since v15.6.0, instead of using the default `id` field, you can also define one 
 
 will tell Zapier to use `(userId, slug)` as the unique primary key to deduplicate items when running a polling trigger.
 
-**Limitation:** The `primary` option currently doesn't support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set `primary: true` on both `id` and `user__id`, the `primary` setting on the `user__id` field will be ignored; only `id` will be used for deduplication.
+**Limitation:** The `primary` option currently doesn't support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set `primary: true` on both `id` and `user__id`, the `primary` setting on the `user__id` field will be ignored; only `id` will be used for deduplication. However, if all the `primary` fields are all nested, such as `user__id` + `user__name`, it will work as expected.
 
 ### Node X No Longer Supported
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3669,7 +3669,7 @@ Since v15.6.0, instead of using the default `id` field, you can also define one 
 
 will tell Zapier to use `(userId, slug)` as the unique primary key to deduplicate items when running a polling trigger.
 
-**Limitation:** The `primary` option currently doesn't support nested fields that use double underscores in their keys. For example, if you set `primary: true` on a field like `user__id`, it will be ignored.
+**Limitation:** The `primary` option currently doesn't support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set `primary: true` on both `id` and `user__id`, the `primary` setting on the `user__id` field will be ignored; only `id` will be used for deduplication.
 
 ### Node X No Longer Supported
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -5763,7 +5763,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on a field like <code>user__id</code>, it will be ignored.</p>
+      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on both <code>id</code> and <code>user__id</code>, the <code>primary</code> setting on the <code>user__id</code> field will be ignored; only <code>id</code> will be used for deduplication.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -5763,7 +5763,7 @@ zapier push
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on both <code>id</code> and <code>user__id</code>, the <code>primary</code> setting on the <code>user__id</code> field will be ignored; only <code>id</code> will be used for deduplication.</p>
+      <p>will tell Zapier to use <code>(userId, slug)</code> as the unique primary key to deduplicate items when running a polling trigger.</p><p><strong>Limitation:</strong> The <code>primary</code> option currently doesn&apos;t support mixing top-level fields with nested fields that use double underscores in their keys. For example, if you set <code>primary: true</code> on both <code>id</code> and <code>user__id</code>, the <code>primary</code> setting on the <code>user__id</code> field will be ignored; only <code>id</code> will be used for deduplication. However, if all the <code>primary</code> fields are all nested, such as <code>user__id</code> + <code>user__name</code>, it will work as expected.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
       


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Be more accurate and specific on the limitation of the `primary: true` setting.

Previous PR: https://github.com/zapier/zapier-platform/pull/834