### PR TITLE
fix(types): Fix HTTP Option types that used `object`

### DIFF
--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -77,14 +77,14 @@ declare class ThrottledError extends Error {
 // copied http stuff from external typings
 export interface HttpRequestOptions {
   agent?: Agent;
-  body?: string | Buffer | NodeJS.ReadableStream | object;
+  body?: string | Buffer | NodeJS.ReadableStream | Record<string, any>;
   compress?: boolean;
   follow?: number;
-  form?: object;
+  form?: any;
   headers?: { [name: string]: string };
-  json?: object | any[];
+  json?: any;
   method?: HttpMethod;
-  params?: object;
+  params?: Record<string, any>;
   raw?: boolean;
   redirect?: 'manual' | 'error' | 'follow';
   removeMissingValuesFrom?: {


### PR DESCRIPTION
Minor fix to help with HTTP Option typing, notably `.params` in middleware. 