### PR TITLE
feat(schema) Add configurable poll delay for HookToPoll

### DIFF
--- a/packages/core/types/zapier.generated.d.ts
+++ b/packages/core/types/zapier.generated.d.ts
@@ -1260,6 +1260,12 @@ export interface BasicHookToPollOperation {
    * this belongs to a resource that has a top-level sample
    */
   sample?: { [k: string]: unknown };
+
+  /**
+   * The maximum amount of time to wait between polling requests in
+   * seconds.
+   */
+  maxPollingDelay?: number;
 }
 
 /**

--- a/packages/core/types/zapier.generated.d.ts
+++ b/packages/core/types/zapier.generated.d.ts
@@ -1263,7 +1263,8 @@ export interface BasicHookToPollOperation {
 
   /**
    * The maximum amount of time to wait between polling requests in
-   * seconds.
+   * seconds. Minimum value is 20s and will default to 20 if not set,
+   * or set to a lower value.
    */
   maxPollingDelay?: number;
 }

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -1285,6 +1285,10 @@
               "value": "**yes** (with exceptions, see description)"
             }
           }
+        },
+        "maxPollingDelay": {
+          "description": "The maximum amount of time to wait between polling requests in seconds.",
+          "type": "integer"
         }
       },
       "additionalProperties": false,

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -1287,7 +1287,7 @@
           }
         },
         "maxPollingDelay": {
-          "description": "The maximum amount of time to wait between polling requests in seconds.",
+          "description": "The maximum amount of time to wait between polling requests in seconds. Minimum value is 20s and will default to 20 if not set, or set to a lower value.",
           "type": "integer"
         }
       },

--- a/packages/schema/lib/schemas/BasicHookToPollOperationSchema.js
+++ b/packages/schema/lib/schemas/BasicHookToPollOperationSchema.js
@@ -61,6 +61,11 @@ BasicHookToPollOperationSchema.properties = {
   inputFields: BasicHookToPollOperationSchema.properties.inputFields,
   outputFields: BasicHookToPollOperationSchema.properties.outputFields,
   sample: BasicHookToPollOperationSchema.properties.sample,
+  maxPollingDelay: {
+    description:
+      'The maximum amount of time to wait between polling requests in seconds.',
+    type: 'integer',
+  },
 };
 
 BasicHookToPollOperationSchema.examples = [

--- a/packages/schema/lib/schemas/BasicHookToPollOperationSchema.js
+++ b/packages/schema/lib/schemas/BasicHookToPollOperationSchema.js
@@ -63,7 +63,7 @@ BasicHookToPollOperationSchema.properties = {
   sample: BasicHookToPollOperationSchema.properties.sample,
   maxPollingDelay: {
     description:
-      'The maximum amount of time to wait between polling requests in seconds.',
+      'The maximum amount of time to wait between polling requests in seconds. Minimum value is 20s and will default to 20 if not set, or set to a lower value.',
     type: 'integer',
   },
 };


### PR DESCRIPTION
Adds a new optional field for "hook to poll" triggers.
`maxPollingDelay` represents the value (in seconds) to set for the poll part.