### PR TITLE
chore(types): Add `customOptions` field to z.request options

### DIFF
--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -101,7 +101,10 @@ expectType<Trigger>(hookTrigger);
 
 const searchOperation: BasicActionOperation = {
   inputFields: [{ key: 'some-input-key-1', type: 'file', required: true }],
-  perform: async (z: ZObject, b: Bundle) => [{ data: true }],
+  perform: async (z: ZObject, b: Bundle) => {
+    z.request('https://example.com', { customOptions: { resumable: true } });
+    return [{ data: true }];
+  },
 };
 expectType<BasicActionOperation>(searchOperation);
 
@@ -124,7 +127,12 @@ const addBearerHeader: BeforeRequestMiddleware = (request, z, bundle) => {
 };
 expectType<BeforeRequestMiddleware>(addBearerHeader);
 
-const asyncBeforeRequest: BeforeRequestMiddleware = async (request) => request;
+const asyncBeforeRequest: BeforeRequestMiddleware = async (request) => {
+  if (request.customOptions?.resumable) {
+    // do something async etc.
+  }
+  return request;
+};
 expectType<BeforeRequestMiddleware>(asyncBeforeRequest);
 
 const checkPermissionsError: AfterResponseMiddleware = (response, z) => {

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -2,7 +2,6 @@ import type {
   AfterResponseMiddleware,
   BeforeRequestMiddleware,
   Bundle,
-  PerformFunction,
   ZObject,
 } from './zapier.custom';
 import type {
@@ -102,7 +101,7 @@ expectType<Trigger>(hookTrigger);
 const searchOperation: BasicActionOperation = {
   inputFields: [{ key: 'some-input-key-1', type: 'file', required: true }],
   perform: async (z: ZObject, b: Bundle) => {
-    z.request('https://example.com', { customOptions: { resumable: true } });
+    z.request('https://example.com', { middlewareData: { resumable: true } });
     return [{ data: true }];
   },
 };
@@ -128,7 +127,7 @@ const addBearerHeader: BeforeRequestMiddleware = (request, z, bundle) => {
 expectType<BeforeRequestMiddleware>(addBearerHeader);
 
 const asyncBeforeRequest: BeforeRequestMiddleware = async (request) => {
-  if (request.customOptions?.resumable) {
+  if (request.middlewareData?.resumable) {
     // do something async etc.
   }
   return request;

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -95,6 +95,14 @@ export interface HttpRequestOptions {
   timeout?: number;
   url?: string;
   skipThrowForStatus?: boolean;
+
+  /**
+   * Custom options for the request. These do not affect the request
+   * itself, but can be used to pass data to middleware. For example,
+   * this is recommended for things like `prefixErrorMessage` fields
+   * etc.
+   */
+  customOptions?: Record<string, any>;
 }
 
 interface BaseHttpResponse {

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -97,12 +97,12 @@ export interface HttpRequestOptions {
   skipThrowForStatus?: boolean;
 
   /**
-   * Custom options for the request. These do not affect the request
-   * itself, but can be used to pass data to middleware. For example,
-   * this is recommended for things like `prefixErrorMessage` fields
-   * etc.
+   * This is a special field that can be used to pass data to
+   * middleware. It is not sent with the request, but is available in
+   * the `response` object that middleware receives. This is useful for
+   * things like `prefixErrorMessage` fields etc.
    */
-  customOptions?: Record<string, any>;
+  middlewareData?: Record<string, any>;
 }
 
 interface BaseHttpResponse {


### PR DESCRIPTION
This is a sanctioned object that can be used freely for extra middleware options etc. without needing to bend over backwards to support patching the `z.request` options