### PR TITLE
feat(core) - Add scopes as an option for zcache usage

### DIFF
--- a/packages/core/src/tools/create-cache.js
+++ b/packages/core/src/tools/create-cache.js
@@ -12,7 +12,7 @@ const createCache = (input) => {
     key,
     value = null,
     ttl = null,
-    scopes = null
+    scope = null
   ) => {
     if (!rpc) {
       throw new Error('rpc is not available');
@@ -26,12 +26,9 @@ const createCache = (input) => {
       throw new TypeError('ttl must be an integer');
     }
 
-    if (
-      scopes != null &&
-      !scopes.every((scope) => scope === 'user' || scope === 'auth')
-    ) {
+    if (scope != null && !scope.every((v) => v === 'user' || v === 'auth')) {
       throw new TypeError(
-        'scopes must be an array of strings with values "user" or "auth"'
+        'scope must be an array of strings with values "user" or "auth"'
       );
     }
 
@@ -39,21 +36,21 @@ const createCache = (input) => {
   };
 
   return {
-    get: async (key, scopes = null) => {
-      runValidationChecks(rpc, key);
+    get: async (key, scope = null) => {
+      runValidationChecks(rpc, key, scope);
 
-      const result = await rpc('zcache_get', key);
+      const result = await rpc('zcache_get', key, scope);
       return result ? JSON.parse(result) : null;
     },
-    set: async (key, value, ttl = null, scopes = null) => {
-      runValidationChecks(rpc, key, value, ttl, scopes);
+    set: async (key, value, ttl = null, scope = []) => {
+      runValidationChecks(rpc, key, value, ttl, scope);
 
-      return await rpc('zcache_set', key, JSON.stringify(value), ttl, scopes);
+      return await rpc('zcache_set', key, JSON.stringify(value), ttl, scope);
     },
-    delete: async (key, scopes) => {
-      runValidationChecks(rpc, key, scopes);
+    delete: async (key, scope = []) => {
+      runValidationChecks(rpc, key, scope);
 
-      return await rpc('zcache_delete', key);
+      return await rpc('zcache_delete', key, scope);
     },
   };
 };

--- a/packages/core/src/tools/create-cache.js
+++ b/packages/core/src/tools/create-cache.js
@@ -7,7 +7,13 @@ const ensureJSONEncodable = require('./ensure-json-encodable');
 
 const createCache = (input) => {
   const rpc = _.get(input, '_zapier.rpc');
-  const runValidationChecks = (rpc, key, value = null, ttl = null) => {
+  const runValidationChecks = (
+    rpc,
+    key,
+    value = null,
+    ttl = null,
+    scopes = null
+  ) => {
     if (!rpc) {
       throw new Error('rpc is not available');
     }
@@ -20,23 +26,32 @@ const createCache = (input) => {
       throw new TypeError('ttl must be an integer');
     }
 
+    if (
+      scopes != null &&
+      !scopes.every((scope) => scope === 'user' || scope === 'auth')
+    ) {
+      throw new TypeError(
+        'scopes must be an array of strings with values "user" or "auth"'
+      );
+    }
+
     ensureJSONEncodable(value);
   };
 
   return {
-    get: async (key) => {
+    get: async (key, scopes = null) => {
       runValidationChecks(rpc, key);
 
       const result = await rpc('zcache_get', key);
       return result ? JSON.parse(result) : null;
     },
-    set: async (key, value, ttl = null) => {
-      runValidationChecks(rpc, key, value, ttl);
+    set: async (key, value, ttl = null, scopes = null) => {
+      runValidationChecks(rpc, key, value, ttl, scopes);
 
-      return await rpc('zcache_set', key, JSON.stringify(value), ttl);
+      return await rpc('zcache_set', key, JSON.stringify(value), ttl, scopes);
     },
-    delete: async (key) => {
-      runValidationChecks(rpc, key);
+    delete: async (key, scopes) => {
+      runValidationChecks(rpc, key, scopes);
 
       return await rpc('zcache_delete', key);
     },

--- a/packages/core/src/tools/create-cache.js
+++ b/packages/core/src/tools/create-cache.js
@@ -26,7 +26,10 @@ const createCache = (input) => {
       throw new TypeError('ttl must be an integer');
     }
 
-    if (scope != null && !scope.every((v) => v === 'user' || v === 'auth')) {
+    if (
+      (scope != null && !_.isArray(scope)) ||
+      !scope.every((v) => v === 'user' || v === 'auth')
+    ) {
       throw new TypeError(
         'scope must be an array of strings with values "user" or "auth"'
       );

--- a/packages/core/src/tools/create-cache.js
+++ b/packages/core/src/tools/create-cache.js
@@ -27,8 +27,9 @@ const createCache = (input) => {
     }
 
     if (
-      (scope != null && !_.isArray(scope)) ||
-      !scope.every((v) => v === 'user' || v === 'auth')
+      scope !== null &&
+      (!Array.isArray(scope) ||
+        !scope.every((v) => v === 'user' || v === 'auth'))
     ) {
       throw new TypeError(
         'scope must be an array of strings with values "user" or "auth"'
@@ -45,12 +46,12 @@ const createCache = (input) => {
       const result = await rpc('zcache_get', key, scope);
       return result ? JSON.parse(result) : null;
     },
-    set: async (key, value, ttl = null, scope = []) => {
+    set: async (key, value, ttl = null, scope = null) => {
       runValidationChecks(rpc, key, value, ttl, scope);
 
       return await rpc('zcache_set', key, JSON.stringify(value), ttl, scope);
     },
-    delete: async (key, scope = []) => {
+    delete: async (key, scope = null) => {
       runValidationChecks(rpc, key, scope);
 
       return await rpc('zcache_delete', key, scope);

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -88,22 +88,26 @@ describe('zcache: get, set, delete', () => {
   });
 
   describe('scopes', () => {
-    beforeEach(() => {
-      mockRpcCall('ok');
-    });
     it('zcache_set: no scopes is ok', async () => {
+      mockRpcCall('ok');
       const res = await cache.set('key', 'ok');
       should(res).eql('ok');
     });
     it('zcache_set: empty array scopes is ok', async () => {
+      mockRpcCall('ok');
+
       const res = await cache.set('key', 'ok', 1, []);
       should(res).eql('ok');
     });
     it('zcache_set: user and auth scopes is ok', async () => {
+      mockRpcCall('ok');
+
       const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
       should(res).eql('ok');
     });
     it('zcache_set: bad scopes is not ok', async () => {
+      mockRpcCall('ok');
+
       await cache
         .set('key', 'ok', 1, ['bad', 'scope'])
         .should.be.rejectedWith(
@@ -111,6 +115,8 @@ describe('zcache: get, set, delete', () => {
         );
     });
     it('zcache_set: mix of good and bad is not ok', async () => {
+      mockRpcCall('ok');
+
       await cache
         .set('key', 'ok', 1, ['bad', 'auth'])
         .should.be.rejectedWith(

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -27,6 +27,7 @@ describe('zcache: get, set, delete', () => {
   it('zcache_get: should throw error for non-string keys', async () => {
     await cache.get(12345).should.be.rejectedWith('key must be a string');
   });
+
   it("zcache_set: should set a cache entry based on the app's rate-limit", async () => {
     const key1 = 'random-key1';
     const key2 = 'random-key2';

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -87,41 +87,41 @@ describe('zcache: get, set, delete', () => {
     should(result).eql(false);
   });
 
-  describe('scope', () => {
-    it('zcache_set: no scope is ok', async () => {
-      mockRpcCall('ok');
-      const res = await cache.set('key', 'ok');
-      should(res).eql('ok');
-    });
-    it('zcache_set: empty array scope is ok', async () => {
-      mockRpcCall('ok');
+  // describe('scope', () => {
+  //   it('zcache_set: no scope is ok', async () => {
+  //     mockRpcCall('ok');
+  //     const res = await cache.set('key', 'ok');
+  //     should(res).eql('ok');
+  //   });
+  //   it('zcache_set: empty array scope is ok', async () => {
+  //     mockRpcCall('ok');
 
-      const res = await cache.set('key', 'ok', 1, []);
-      should(res).eql('ok');
-    });
-    it('zcache_set: user and auth scope is ok', async () => {
-      mockRpcCall('ok');
+  //     const res = await cache.set('key', 'ok', 1, []);
+  //     should(res).eql('ok');
+  //   });
+  //   it('zcache_set: user and auth scope is ok', async () => {
+  //     mockRpcCall('ok');
 
-      const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
-      should(res).eql('ok');
-    });
-    it('zcache_set: bad scope is not ok', async () => {
-      mockRpcCall('ok');
+  //     const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
+  //     should(res).eql('ok');
+  //   });
+  //   it('zcache_set: bad scope is not ok', async () => {
+  //     mockRpcCall('ok');
 
-      await cache
-        .set('key', 'ok', 1, ['bad', 'scope'])
-        .should.be.rejectedWith(
-          'scope must be an array of strings with values "user" or "auth"'
-        );
-    });
-    it('zcache_set: mix of good and bad is not ok', async () => {
-      mockRpcCall('ok');
+  //     await cache
+  //       .set('key', 'ok', 1, ['bad', 'scope'])
+  //       .should.be.rejectedWith(
+  //         'scope must be an array of strings with values "user" or "auth"'
+  //       );
+  //   });
+  //   it('zcache_set: mix of good and bad is not ok', async () => {
+  //     mockRpcCall('ok');
 
-      await cache
-        .set('key', 'ok', 1, ['bad', 'auth'])
-        .should.be.rejectedWith(
-          'scope must be an array of strings with values "user" or "auth"'
-        );
-    });
-  });
+  //     await cache
+  //       .set('key', 'ok', 1, ['bad', 'auth'])
+  //       .should.be.rejectedWith(
+  //         'scope must be an array of strings with values "user" or "auth"'
+  //       );
+  //   });
+  // });
 });

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -87,41 +87,39 @@ describe('zcache: get, set, delete', () => {
     should(result).eql(false);
   });
 
-  // describe('scope', () => {
-  //   it('zcache_set: no scope is ok', async () => {
-  //     mockRpcCall('ok');
-  //     const res = await cache.set('key', 'ok');
-  //     should(res).eql('ok');
-  //   });
-  //   it('zcache_set: empty array scope is ok', async () => {
-  //     mockRpcCall('ok');
+  it('zcache_set: no scope is ok', async () => {
+    mockRpcCall('ok');
+    const res = await cache.set('key', 'ok');
+    should(res).eql('ok');
+  });
+  it('zcache_set: empty array scope is ok', async () => {
+    mockRpcCall('ok');
 
-  //     const res = await cache.set('key', 'ok', 1, []);
-  //     should(res).eql('ok');
-  //   });
-  //   it('zcache_set: user and auth scope is ok', async () => {
-  //     mockRpcCall('ok');
+    const res = await cache.set('key', 'ok', 1, []);
+    should(res).eql('ok');
+  });
+  it('zcache_set: user and auth scope is ok', async () => {
+    mockRpcCall('ok');
 
-  //     const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
-  //     should(res).eql('ok');
-  //   });
-  //   it('zcache_set: bad scope is not ok', async () => {
-  //     mockRpcCall('ok');
+    const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
+    should(res).eql('ok');
+  });
+  it('zcache_set: bad scope is not ok', async () => {
+    mockRpcCall('ok');
 
-  //     await cache
-  //       .set('key', 'ok', 1, ['bad', 'scope'])
-  //       .should.be.rejectedWith(
-  //         'scope must be an array of strings with values "user" or "auth"'
-  //       );
-  //   });
-  //   it('zcache_set: mix of good and bad is not ok', async () => {
-  //     mockRpcCall('ok');
+    await cache
+      .set('key', 'ok', 1, ['bad', 'scope'])
+      .should.be.rejectedWith(
+        'scope must be an array of strings with values "user" or "auth"'
+      );
+  });
+  it('zcache_set: mix of good and bad is not ok', async () => {
+    mockRpcCall('ok');
 
-  //     await cache
-  //       .set('key', 'ok', 1, ['bad', 'auth'])
-  //       .should.be.rejectedWith(
-  //         'scope must be an array of strings with values "user" or "auth"'
-  //       );
-  //   });
-  // });
+    await cache
+      .set('key', 'ok', 1, ['bad', 'auth'])
+      .should.be.rejectedWith(
+        'scope must be an array of strings with values "user" or "auth"'
+      );
+  });
 });

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -105,8 +105,6 @@ describe('zcache: get, set, delete', () => {
     should(res).eql(true);
   });
   it('zcache_set: bad scope is not ok', async () => {
-    mockRpcCall(true);
-
     await cache
       .set('key', 'ok', 1, ['bad', 'scope'])
       .should.be.rejectedWith(
@@ -114,8 +112,6 @@ describe('zcache: get, set, delete', () => {
       );
   });
   it('zcache_set: mix of good and bad is not ok', async () => {
-    mockRpcCall(true);
-
     await cache
       .set('key', 'ok', 1, ['bad', 'auth'])
       .should.be.rejectedWith(

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -86,40 +86,4 @@ describe('zcache: get, set, delete', () => {
     const result = await cache.delete('non-existing-key');
     should(result).eql(false);
   });
-
-  it('zcache_set: no scope is ok', async () => {
-    mockRpcCall('ok');
-    const res = await cache.set('key', 'ok');
-    should(res).eql('ok');
-  });
-  it('zcache_set: empty array scope is ok', async () => {
-    mockRpcCall('ok');
-
-    const res = await cache.set('key', 'ok', 1, []);
-    should(res).eql('ok');
-  });
-  it('zcache_set: user and auth scope is ok', async () => {
-    mockRpcCall('ok');
-
-    const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
-    should(res).eql('ok');
-  });
-  it('zcache_set: bad scope is not ok', async () => {
-    mockRpcCall('ok');
-
-    await cache
-      .set('key', 'ok', 1, ['bad', 'scope'])
-      .should.be.rejectedWith(
-        'scope must be an array of strings with values "user" or "auth"'
-      );
-  });
-  it('zcache_set: mix of good and bad is not ok', async () => {
-    mockRpcCall('ok');
-
-    await cache
-      .set('key', 'ok', 1, ['bad', 'auth'])
-      .should.be.rejectedWith(
-        'scope must be an array of strings with values "user" or "auth"'
-      );
-  });
 });

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -104,6 +104,13 @@ describe('zcache: get, set, delete', () => {
     const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
     should(res).eql(true);
   });
+  it('zcache_set: scope as string is not ok', async () => {
+    await cache
+      .set('key', 'ok', 1, 'bad')
+      .should.be.rejectedWith(
+        'scope must be an array of strings with values "user" or "auth"'
+      );
+  });
   it('zcache_set: bad scope is not ok', async () => {
     await cache
       .set('key', 'ok', 1, ['bad', 'scope'])

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -87,31 +87,31 @@ describe('zcache: get, set, delete', () => {
     should(result).eql(false);
   });
 
-  describe('scopes', () => {
-    it('zcache_set: no scopes is ok', async () => {
+  describe('scope', () => {
+    it('zcache_set: no scope is ok', async () => {
       mockRpcCall('ok');
       const res = await cache.set('key', 'ok');
       should(res).eql('ok');
     });
-    it('zcache_set: empty array scopes is ok', async () => {
+    it('zcache_set: empty array scope is ok', async () => {
       mockRpcCall('ok');
 
       const res = await cache.set('key', 'ok', 1, []);
       should(res).eql('ok');
     });
-    it('zcache_set: user and auth scopes is ok', async () => {
+    it('zcache_set: user and auth scope is ok', async () => {
       mockRpcCall('ok');
 
       const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
       should(res).eql('ok');
     });
-    it('zcache_set: bad scopes is not ok', async () => {
+    it('zcache_set: bad scope is not ok', async () => {
       mockRpcCall('ok');
 
       await cache
         .set('key', 'ok', 1, ['bad', 'scope'])
         .should.be.rejectedWith(
-          'scopes must be an array of strings with values "user" or "auth"'
+          'scope must be an array of strings with values "user" or "auth"'
         );
     });
     it('zcache_set: mix of good and bad is not ok', async () => {
@@ -120,7 +120,7 @@ describe('zcache: get, set, delete', () => {
       await cache
         .set('key', 'ok', 1, ['bad', 'auth'])
         .should.be.rejectedWith(
-          'scopes must be an array of strings with values "user" or "auth"'
+          'scope must be an array of strings with values "user" or "auth"'
         );
     });
   });

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -86,4 +86,40 @@ describe('zcache: get, set, delete', () => {
     const result = await cache.delete('non-existing-key');
     should(result).eql(false);
   });
+
+  it('zcache_set: no scope is ok', async () => {
+    mockRpcCall(true);
+    const res = await cache.set('key', 'ok');
+    should(res).eql(true);
+  });
+  it('zcache_set: empty array scope is ok', async () => {
+    mockRpcCall(true);
+
+    const res = await cache.set('key', 'ok', 1, []);
+    should(res).eql(true);
+  });
+  it('zcache_set: user and auth scope is ok', async () => {
+    mockRpcCall(true);
+
+    const res = await cache.set('key', 'ok', 1, ['user', 'auth']);
+    should(res).eql(true);
+  });
+  it('zcache_set: bad scope is not ok', async () => {
+    mockRpcCall(true);
+
+    await cache
+      .set('key', 'ok', 1, ['bad', 'scope'])
+      .should.be.rejectedWith(
+        'scope must be an array of strings with values "user" or "auth"'
+      );
+  });
+  it('zcache_set: mix of good and bad is not ok', async () => {
+    mockRpcCall(true);
+
+    await cache
+      .set('key', 'ok', 1, ['bad', 'auth'])
+      .should.be.rejectedWith(
+        'scope must be an array of strings with values "user" or "auth"'
+      );
+  });
 });


### PR DESCRIPTION
Internal: Adds an scope option to z.cache. Currently it uses scope internally with user and auth only. We may want to exercise one or the other only so providing this flexibility from the interface.