### PR TITLE
feat(core): Add node-fetch feature `signal` to request client [PDE-5367]

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4164,6 +4164,7 @@ zapier env:get 1.0.0
 <li><code>compress</code>: support gzip/deflate content encoding. Set to <code>false</code> to disable. Default is <code>true</code>.</li>
 <li><code>agent</code>: Node.js <code>http.Agent</code> instance, allows custom proxy, certificate etc. Default is <code>null</code>.</li>
 <li><code>timeout</code>: request / response timeout in ms. Set to <code>0</code> to disable (OS limit still applies), timeout reset on <code>redirect</code>. Default is <code>0</code> (disabled).</li>
+<li><code>signal</code> (<em>added in v15.14.1</em>): enables cancelling requests via a timeout set by an <code>AbortController</code>. More details in <code>node-fetch</code> docs <a href="https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal">here</a>. Default is <code>null</code>.</li>
 <li><code>size</code>: maximum response body size in bytes. Set to <code>0</code> to disable. Default is <code>0</code> (disabled).</li>
 <li><code>skipThrowForStatus</code> (<em>added in v10.0.0</em>): don&apos;t call <code>response.throwForStatus()</code> before resolving the request with <code>response</code>. See <a href="#http-response-object">HTTP Response Object</a>.</li>
 </ul>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1394,6 +1394,7 @@ Ensure you're handling errors correctly for your platform version. The latest re
 * `compress`: support gzip/deflate content encoding. Set to `false` to disable. Default is `true`.
 * `agent`: Node.js `http.Agent` instance, allows custom proxy, certificate etc. Default is `null`.
 * `timeout`: request / response timeout in ms. Set to `0` to disable (OS limit still applies), timeout reset on `redirect`. Default is `0` (disabled).
+* `signal` (_added in v15.14.1_): enables cancelling requests via a timeout set by an `AbortController`. More details in `node-fetch` docs [here](https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal). Default is `null`.
 * `size`: maximum response body size in bytes. Set to `0` to disable. Default is `0` (disabled).
 * `skipThrowForStatus` (_added in v10.0.0_): don't call `response.throwForStatus()` before resolving the request with `response`. See [HTTP Response Object](#http-response-object).
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2569,6 +2569,7 @@ Ensure you're handling errors correctly for your platform version. The latest re
 * `compress`: support gzip/deflate content encoding. Set to `false` to disable. Default is `true`.
 * `agent`: Node.js `http.Agent` instance, allows custom proxy, certificate etc. Default is `null`.
 * `timeout`: request / response timeout in ms. Set to `0` to disable (OS limit still applies), timeout reset on `redirect`. Default is `0` (disabled).
+* `signal` (_added in v15.14.1_): enables cancelling requests via a timeout set by an `AbortController`. More details in `node-fetch` docs [here](https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal). Default is `null`.
 * `size`: maximum response body size in bytes. Set to `0` to disable. Default is `0` (disabled).
 * `skipThrowForStatus` (_added in v10.0.0_): don't call `response.throwForStatus()` before resolving the request with `response`. See [HTTP Response Object](#http-response-object).
 

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -4164,6 +4164,7 @@ zapier env:get 1.0.0
 <li><code>compress</code>: support gzip/deflate content encoding. Set to <code>false</code> to disable. Default is <code>true</code>.</li>
 <li><code>agent</code>: Node.js <code>http.Agent</code> instance, allows custom proxy, certificate etc. Default is <code>null</code>.</li>
 <li><code>timeout</code>: request / response timeout in ms. Set to <code>0</code> to disable (OS limit still applies), timeout reset on <code>redirect</code>. Default is <code>0</code> (disabled).</li>
+<li><code>signal</code> (<em>added in v15.14.1</em>): enables cancelling requests via a timeout set by an <code>AbortController</code>. More details in <code>node-fetch</code> docs <a href="https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal">here</a>. Default is <code>null</code>.</li>
 <li><code>size</code>: maximum response body size in bytes. Set to <code>0</code> to disable. Default is <code>0</code> (disabled).</li>
 <li><code>skipThrowForStatus</code> (<em>added in v10.0.0</em>): don&apos;t call <code>response.throwForStatus()</code> before resolving the request with <code>response</code>. See <a href="#http-response-object">HTTP Response Object</a>.</li>
 </ul>

--- a/packages/core/src/tools/request-client.js
+++ b/packages/core/src/tools/request-client.js
@@ -21,6 +21,7 @@ const request = (options) => {
     'agent',
     'timeout',
     'size',
+    'signal',
   ]);
 
   return fetch(url, options).then((resp) => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

As Cass reported [here](https://zapier.slack.com/archives/C5Z9BP4U9/p1725954040992739), `node-fetch` supports the `signal` option described here: https://www.npmjs.com/package/node-fetch#request-cancellation-with-abortsignal. Looks like this is supported after Node 8 and replaces `timeout` (although timeout still seems to be supported), according to these comments: https://github.com/node-fetch/node-fetch/tree/2.x?tab=readme-ov-file#options

However, we have not added that to the request options for `z.request`. This PR aims to add that per Fokke's suggestion that we may just need to add it to this picklist.