### PR TITLE
[PARTOPS-1224] docs(schema) - Add additional details to inputFormat property in fieldSchema

### DIFF
--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -965,7 +965,7 @@ Key | Required | Type | Description
 `computed` | no | `boolean` | Is this field automatically populated (and hidden from the user)? Note: Only OAuth and Session Auth support fields with this key.
 `altersDynamicFields` | no | `boolean` | Does the value of this field affect the definitions of other fields in the set?
 `steadyState` | no | `boolean` | Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. It can be used to, e.g., not trigger on a new contact until the contact has completed typing their name. NOTE that this only applies to the `outputFields` of polling triggers.
-`inputFormat` | no | `string` | Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user's input (IE: "https://{{input}}.yourdomain.com").
+`inputFormat` | no | `string` | Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user's input (IE: "https://{{input}}.yourdomain.com"). Renders a [copy to clipboard field](https://cdn.zappy.app/67a9d787493dd56a9916c7cd294eff80.png) when used, which is not advisable for action input fields.
 
 #### Examples
 


### PR DESCRIPTION
Lefthook developers tried using the `inputFormat` field property for an action input field and the copy to clipboard field that renders in the Editor is not well suited for action step as it disables the ability to map a value to the field. Noting this in the docs explicitly. Slack thread with editor team [here](https://zapier.slack.com/archives/C02TQNXKEBF/p1725870227224329?thread_ts=1725653551.771619&cid=C02TQNXKEBF).