### PR TITLE
fix(core): Censor OAuth1 getAccessToken HTTP logs [PDE-5390]

### DIFF
--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -166,7 +166,8 @@ const buildSensitiveValues = (event, data) => {
   const isGettingNewSecret =
     event.method &&
     (event.method.endsWith('refreshAccessToken') ||
-      event.method.endsWith('sessionConfig.perform'));
+      event.method.endsWith('sessionConfig.perform') ||
+      event.method.endsWith('oauth1Config.getAccessToken'));
 
   for (const prop of ['response_content', 'request_data']) {
     if (data[prop]) {

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -177,6 +177,14 @@ const buildSensitiveValues = (event, data) => {
   if (data.request_params) {
     result.push(...findSensitiveValues(querystringParse(data.request_params)));
   }
+  if (
+    data.response_content &&
+    event.method.endsWith('oauth1Config.getAccessToken')
+  ) {
+    result.push(
+      ...findSensitiveValues(querystringParse(data.response_content))
+    );
+  }
   // unique- no point in duplicates
   return [...new Set(result)];
 };

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -177,14 +177,6 @@ const buildSensitiveValues = (event, data) => {
   if (data.request_params) {
     result.push(...findSensitiveValues(querystringParse(data.request_params)));
   }
-  if (
-    data.response_content &&
-    event.method.endsWith('oauth1Config.getAccessToken')
-  ) {
-    result.push(
-      ...findSensitiveValues(querystringParse(data.response_content))
-    );
-  }
   // unique- no point in duplicates
   return [...new Set(result)];
 };

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -337,7 +337,7 @@ describe('logger', () => {
     ]);
   });
 
-  it('should replace secret in response content as query params', async () => {
+  it('should replace secret in response content for oauth1 as query params', async () => {
     const event = {
       method: 'authentication.oauth1Config.getAccessToken',
     };

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -337,6 +337,44 @@ describe('logger', () => {
     ]);
   });
 
+  it('should replace secret in response content as query params', async () => {
+    const event = {
+      method: 'authentication.oauth1Config.getAccessToken',
+    };
+    const logger = createlogger(event, options);
+
+    const { message, data } = prepareTestRequest({
+      reqBody: {
+        username: 'user1234',
+        password: 'password1234',
+      },
+      resBody: '"oauth_token=1234"',
+    });
+
+    logger(message, data);
+    const response = await logger.end(1000);
+    response.status.should.eql(200);
+
+    response.content.logs.should.deepEqual([
+      {
+        message: '200 POST http://example.com',
+        data: {
+          log_type: 'http',
+          request_type: 'devplatform-outbound',
+          request_url: 'http://example.com',
+          request_method: 'POST',
+          request_headers: 'accept: application/json',
+          request_data:
+            '{"username":"user1234","password":":censored:12:60562c5b6c:"}',
+          request_via_client: true,
+          response_status_code: 200,
+          response_headers: 'content-type: application/json',
+          response_content: '":censored:16:766f32ee8c:"',
+        },
+      },
+    ]);
+  });
+
   it('should replace set-cookie header', async () => {
     const event = {
       method: 'authentication.sessionConfig.perform',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

When invoking methods like authentication.oauth1Config.getAccessToken or authentication.oauth2Config.refreshAccessToken, some servers return querystring formatted data containing secrets. We should censor those properly in HTTP logs.