### PR TITLE
PDE-5321 doc(cli): update current limitations of `invoke`

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -794,7 +794,7 @@ zapier invoke trigger new_recipe
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>To add input data, use the <code>--inputData</code> flag. The input data can come from the command directly, a file, or stdin. See <strong>EXAMPLES</strong> below.</p><p>The following are current limitations and may be supported in the future:</p><ul>
+      <p>To add input data, use the <code>--inputData</code> flag. The input data can come from the command directly, a file, or stdin. See <strong>EXAMPLES</strong> below.</p><p>The following is a non-exhaustive list of current limitations and may be supported in the future:</p><ul>
 <li><p><code>zapier invoke auth start</code> to help you initialize the auth data in <code>.env</code></p>
 </li>
 <li><p><code>zapier invoke auth refresh</code> to refresh the auth data in <code>.env</code></p>
@@ -812,6 +812,14 @@ zapier invoke trigger new_recipe
 <li><p>Function-based connection label</p>
 </li>
 <li><p>Buffered create actions</p>
+</li>
+<li><p>Search-or-create actions</p>
+</li>
+<li><p>Search-powered fields</p>
+</li>
+<li><p>Field choices</p>
+</li>
+<li><p>autoRefresh for OAuth2 and session auth</p>
 </li>
 </ul><p><strong>Arguments</strong></p><ul>
 <li><code>actionType</code> | The action type you want to invoke.</li>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -348,7 +348,7 @@ zapier invoke trigger new_recipe
 
 To add input data, use the `--inputData` flag. The input data can come from the command directly, a file, or stdin. See **EXAMPLES** below.
 
-The following are current limitations and may be supported in the future:
+The following is a non-exhaustive list of current limitations and may be supported in the future:
 
 - `zapier invoke auth start` to help you initialize the auth data in `.env`
 
@@ -367,6 +367,14 @@ The following are current limitations and may be supported in the future:
 - Function-based connection label
 
 - Buffered create actions
+
+- Search-or-create actions
+
+- Search-powered fields
+
+- Field choices
+
+- autoRefresh for OAuth2 and session auth
 
 **Arguments**
 * `actionType` | The action type you want to invoke.

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -794,7 +794,7 @@ zapier invoke trigger new_recipe
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>To add input data, use the <code>--inputData</code> flag. The input data can come from the command directly, a file, or stdin. See <strong>EXAMPLES</strong> below.</p><p>The following are current limitations and may be supported in the future:</p><ul>
+      <p>To add input data, use the <code>--inputData</code> flag. The input data can come from the command directly, a file, or stdin. See <strong>EXAMPLES</strong> below.</p><p>The following is a non-exhaustive list of current limitations and may be supported in the future:</p><ul>
 <li><p><code>zapier invoke auth start</code> to help you initialize the auth data in <code>.env</code></p>
 </li>
 <li><p><code>zapier invoke auth refresh</code> to refresh the auth data in <code>.env</code></p>
@@ -812,6 +812,14 @@ zapier invoke trigger new_recipe
 <li><p>Function-based connection label</p>
 </li>
 <li><p>Buffered create actions</p>
+</li>
+<li><p>Search-or-create actions</p>
+</li>
+<li><p>Search-powered fields</p>
+</li>
+<li><p>Field choices</p>
+</li>
+<li><p>autoRefresh for OAuth2 and session auth</p>
 </li>
 </ul><p><strong>Arguments</strong></p><ul>
 <li><code>actionType</code> | The action type you want to invoke.</li>

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -348,7 +348,7 @@ zapier invoke trigger new_recipe
 
 To add input data, use the `--inputData` flag. The input data can come from the command directly, a file, or stdin. See **EXAMPLES** below.
 
-The following are current limitations and may be supported in the future:
+The following is a non-exhaustive list of current limitations and may be supported in the future:
 
 - `zapier invoke auth start` to help you initialize the auth data in `.env`
 
@@ -367,6 +367,14 @@ The following are current limitations and may be supported in the future:
 - Function-based connection label
 
 - Buffered create actions
+
+- Search-or-create actions
+
+- Search-powered fields
+
+- Field choices
+
+- autoRefresh for OAuth2 and session auth
 
 **Arguments**
 * `actionType` | The action type you want to invoke.

--- a/packages/cli/src/oclif/commands/invoke.js
+++ b/packages/cli/src/oclif/commands/invoke.js
@@ -829,7 +829,7 @@ zapier invoke trigger new_recipe
 
 To add input data, use the \`--inputData\` flag. The input data can come from the command directly, a file, or stdin. See **EXAMPLES** below.
 
-The following are current limitations and may be supported in the future:
+The following is a non-exhaustive list of current limitations and may be supported in the future:
 
 - \`zapier invoke auth start\` to help you initialize the auth data in \`.env\`
 - \`zapier invoke auth refresh\` to refresh the auth data in \`.env\`
@@ -840,6 +840,10 @@ The following are current limitations and may be supported in the future:
 - Dynamic dropdown pagination
 - Function-based connection label
 - Buffered create actions
+- Search-or-create actions
+- Search-powered fields
+- Field choices
+- autoRefresh for OAuth2 and session auth
 `;
 
 module.exports = InvokeCommand;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Just an edit on the help text for `zapier invoke`.