### PR TITLE
PDE-5321 doc: add instructions of how to install development version

### DIFF
--- a/INSTALL_DEV.md
+++ b/INSTALL_DEV.md
@@ -1,0 +1,43 @@
+# Installing Development Version of Zapier Platform CLI
+
+To try out the latest development version of the Zapier Platform CLI tool, you can pull the source code from GitHub and run it directly. Follow the instructions below.
+
+## First Time Setup
+
+Clone the zapier-platform repo and install the dependencies:
+
+```
+cd ~/projects  # or wherever you want to cloen the repo
+git clone git@github.com/zapier/zapier-platform.git
+cd zapier-platform
+yarn
+```
+
+Then add this line to your shell configuration file, such as `~/.bashrc` or `~/.zshrc`:
+
+```
+alias zapier-dev="node ~/Projects/zapier-platform/packages/cli/src/bin/run"
+```
+
+Restart your shell with `exec $SHELL` and `zapier-dev` should be available. Test it out by running `zapier-dev` in your terminal. You should see this:
+
+```
+$ zapier-dev
+The CLI for managing integrations in Zapier Developer Platform.
+
+VERSION
+  zapier-platform-cli/15.16.0 darwin-arm64 node-v21.7.1
+
+USAGE
+  $ zapier [COMMAND]
+```
+
+## Updating the CLI
+
+To update, simply pull from the main branch and update the dependencies:
+
+```
+cd ~/projects/zapier-platform
+git pull origin main
+yarn
+```

--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ It consists of a few main packages:
   - The :point_up: docs are also hosted at https://platform.zapier.com
   - [CHANGELOG.md](CHANGELOG.md)
 * Internal-facing docs:
+  - Testing out new features that haven't been released to npm yet? See [INSTALL_DEV.md](INSTALL_DEV.md)
   - Learn about how this repo is structured in [ARCHITECTURE.md](ARCHITECTURE.md)
   - Looking to contribute to this repo? See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
