### PR TITLE
chore(types): Add missing ResponseError Type

### DIFF
--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -203,6 +203,7 @@ export interface ZObject {
     ExpiredAuthError: typeof ExpiredAuthError;
     RefreshAuthError: typeof RefreshAuthError;
     ThrottledError: typeof ThrottledError;
+    ResponseError: typeof ResponseError;
   };
 
   cache: {

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -73,6 +73,9 @@ declare class RefreshAuthError extends Error {}
 declare class ThrottledError extends Error {
   constructor(message: string, delay?: number);
 }
+declare class ResponseError extends Error {
+  constructor(response: HttpResponse);
+}
 
 // copied http stuff from external typings
 export interface HttpRequestOptions {

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -135,12 +135,13 @@ type DehydrateFunc = <T>(
 export interface ZObject {
   request: {
     // most specific overloads go first
-    (url: string, options: HttpRequestOptions & { raw: true }): Promise<
-      RawHttpResponse
-    >;
-    (options: HttpRequestOptions & { raw: true; url: string }): Promise<
-      RawHttpResponse
-    >;
+    (
+      url: string,
+      options: HttpRequestOptions & { raw: true }
+    ): Promise<RawHttpResponse>;
+    (
+      options: HttpRequestOptions & { raw: true; url: string }
+    ): Promise<RawHttpResponse>;
 
     (url: string, options?: HttpRequestOptions): Promise<HttpResponse>;
     (options: HttpRequestOptions & { url: string }): Promise<HttpResponse>;


### PR DESCRIPTION
Simply adds the occasionally used `z.errors.ResponseError` to the typing declarations.