### PR TITLE
fix(cli) Write bulkReads to separate files

### DIFF
--- a/packages/cli/src/utils/convert.js
+++ b/packages/cli/src/utils/convert.js
@@ -251,6 +251,7 @@ const renderIndex = async (appDefinition) => {
       triggers: 'Trigger',
       creates: 'Create',
       searches: 'Search',
+      bulkReads: 'BulkRead',
     },
     (importNameSuffix, stepType) => {
       _.each(appDefinition[stepType], (definition, key) => {
@@ -380,7 +381,7 @@ const convertApp = async (appInfo, appDefinition, newAppDir) => {
 
   const promises = [];
 
-  ['triggers', 'creates', 'searches'].forEach((stepType) => {
+  ['triggers', 'creates', 'searches', 'bulkReads'].forEach((stepType) => {
     _.each(appDefinition[stepType], (definition, key) => {
       promises.push(
         writeStep(stepType, definition, key, newAppDir),


### PR DESCRIPTION
`zapier` convert is not writing `bulkReads` to their own files with tests, like it does for the other types.

This PR fixes that.

Jira: https://zapierorg.atlassian.net/browse/IP-353