### PR TITLE
docs: fix typos, update docs and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 _released `2024-10-11`_
 
-Introducing two major updates to improve your development experience:
+Introducing three major updates, with the first two aimed at improving your development experience:
 
-- The `zapier invoke` command: This powerful new command enables you to emulate Zapier's production environment locally. Test triggers, actions, and authentication flows right from your terminal without deploying to Zapier. This is especially valuable for debugging, development, and quick testing iterations. Learn more about the command in the [README](https://github.com/zapier/zapier-platform/blob/67d55389/packages/cli/README.md#using-zapier-invoke-command) or by typing `zapier invoke --help` in your teriminal.
-- Refreshed "[typescript](https://github.com/zapier/zapier-platform/tree/67d55389/example-apps/typescript)" project template: We've updated the "typescript" project template with the latest type definitions. Enjoy enhanced type safety, improved autocompletion, and a smoother coding experience overall.
+- The `zapier invoke` command: This powerful new command enables you to emulate Zapier's production environment locally. Test triggers, actions, and authentication flows right from your terminal without deploying to Zapier. This is especially valuable for debugging, development, and quick testing iterations. Learn more about the command in the [README](https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#using-zapier-invoke-command) or by typing [`zapier invoke --help`](https://github.com/zapier/zapier-platform/blob/main/docs/cli.md#invoke) in your teriminal.
+- Refreshed "[typescript](https://github.com/zapier/zapier-platform/tree/main/example-apps/typescript)" project template: We've updated the "typescript" project template with the latest type definitions. Enjoy enhanced type safety, improved autocompletion, and a smoother coding experience overall.
+- `zapier-platform-cli` no longer supports Node.js 16: We don't consider this a breaking change because `zapier-platform-core` had stopped supporting Node.js 16 and has been running on Node.js 18 since v15.0.0. The minimum Node.js version required for `zapier-platform-cli` is now Node.js 18, aligning with `zapier-platform-core`.
 
 As usual, all other improvements and bug fixes are listed below.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5102,11 +5102,14 @@ The delay can be customized by the server response containing a specific
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Added in v15.17.0.</em></p><p>The <code>zapier invoke &lt;ACTION_TYPE&gt; &lt;ACTION_KEY&gt;</code> CLI command emulates how the Zapier production environment would invoke your app. Since it runs code locally, it&apos;s a fast way to debug and test interactively without needing to deploy the code to Zapier.</p><p>Its general execution flow invovles calling <code>operation.inputFields</code> of an action, resolving the input data to the expected types, and then calling the <code>operation.perform</code> method.</p><p><code>zapier invoke --help</code> should be self-explanatory, but here&apos;s a quick rundown:</p>
+      <p><em>Added in v15.17.0.</em></p><p>The <code>zapier invoke &lt;ACTION_TYPE&gt; &lt;ACTION_KEY&gt;</code> CLI command emulates how the Zapier production environment would invoke your app. Since it runs code locally, it&apos;s a fast way to debug and test interactively without needing to deploy the code to Zapier.</p><p>Its general execution flow involves calling <code>operation.inputFields</code> of an action, resolving the input data to the expected types, and then calling the <code>operation.perform</code> method.</p><p><code>zapier invoke --help</code> should be self-explanatory, but here&apos;s a quick rundown:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-bash"><span class="hljs-comment"># Intialize auth data in .env file</span>
+      <pre><code class="lang-bash"><span class="hljs-comment"># Initialize auth data in .env file</span>
 zapier invoke auth start
+
+<span class="hljs-comment"># Refresh auth data (for OAuth2 or Session auth)</span>
+zapier invoke auth refresh
 
 <span class="hljs-comment"># Test your auth data in .env</span>
 zapier invoke auth <span class="hljs-built_in">test</span>

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -1799,13 +1799,16 @@ There are several ways to test your Zapier integration:
 
 The `zapier invoke <ACTION_TYPE> <ACTION_KEY>` CLI command emulates how the Zapier production environment would invoke your app. Since it runs code locally, it's a fast way to debug and test interactively without needing to deploy the code to Zapier.
 
-Its general execution flow invovles calling `operation.inputFields` of an action, resolving the input data to the expected types, and then calling the `operation.perform` method.
+Its general execution flow involves calling `operation.inputFields` of an action, resolving the input data to the expected types, and then calling the `operation.perform` method.
 
 `zapier invoke --help` should be self-explanatory, but here's a quick rundown:
 
 ```bash
-# Intialize auth data in .env file
+# Initialize auth data in .env file
 zapier invoke auth start
+
+# Refresh auth data (for OAuth2 or Session auth)
+zapier invoke auth refresh
 
 # Test your auth data in .env
 zapier invoke auth test

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3180,13 +3180,16 @@ There are several ways to test your Zapier integration:
 
 The `zapier invoke <ACTION_TYPE> <ACTION_KEY>` CLI command emulates how the Zapier production environment would invoke your app. Since it runs code locally, it's a fast way to debug and test interactively without needing to deploy the code to Zapier.
 
-Its general execution flow invovles calling `operation.inputFields` of an action, resolving the input data to the expected types, and then calling the `operation.perform` method.
+Its general execution flow involves calling `operation.inputFields` of an action, resolving the input data to the expected types, and then calling the `operation.perform` method.
 
 `zapier invoke --help` should be self-explanatory, but here's a quick rundown:
 
 ```bash
-# Intialize auth data in .env file
+# Initialize auth data in .env file
 zapier invoke auth start
+
+# Refresh auth data (for OAuth2 or Session auth)
+zapier invoke auth refresh
 
 # Test your auth data in .env
 zapier invoke auth test

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -5102,11 +5102,14 @@ The delay can be customized by the server response containing a specific
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p><em>Added in v15.17.0.</em></p><p>The <code>zapier invoke &lt;ACTION_TYPE&gt; &lt;ACTION_KEY&gt;</code> CLI command emulates how the Zapier production environment would invoke your app. Since it runs code locally, it&apos;s a fast way to debug and test interactively without needing to deploy the code to Zapier.</p><p>Its general execution flow invovles calling <code>operation.inputFields</code> of an action, resolving the input data to the expected types, and then calling the <code>operation.perform</code> method.</p><p><code>zapier invoke --help</code> should be self-explanatory, but here&apos;s a quick rundown:</p>
+      <p><em>Added in v15.17.0.</em></p><p>The <code>zapier invoke &lt;ACTION_TYPE&gt; &lt;ACTION_KEY&gt;</code> CLI command emulates how the Zapier production environment would invoke your app. Since it runs code locally, it&apos;s a fast way to debug and test interactively without needing to deploy the code to Zapier.</p><p>Its general execution flow involves calling <code>operation.inputFields</code> of an action, resolving the input data to the expected types, and then calling the <code>operation.perform</code> method.</p><p><code>zapier invoke --help</code> should be self-explanatory, but here&apos;s a quick rundown:</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
-      <pre><code class="lang-bash"><span class="hljs-comment"># Intialize auth data in .env file</span>
+      <pre><code class="lang-bash"><span class="hljs-comment"># Initialize auth data in .env file</span>
 zapier invoke auth start
+
+<span class="hljs-comment"># Refresh auth data (for OAuth2 or Session auth)</span>
+zapier invoke auth refresh
 
 <span class="hljs-comment"># Test your auth data in .env</span>
 zapier invoke auth <span class="hljs-built_in">test</span>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,7 @@
     "/oclif.manifest.json"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "docs": "ZAPIER_BASE_ENDPOINT='' node scripts/docs.js && cp -r docs ../..",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

- Update links in changelog
- Fix typos in README on `invoke` command
- Add a changelog item on zapier-platform-cli not supporting Node.js 16
- Bump `engines.node` from `>=16` to `>=18` for zapier-platform-cli