### PR TITLE
docs(cli) Explain why hidden triggers for dynamic dropdowns need to declare input fields #886

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2623,7 +2623,9 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The <a href="https://zapier.com/apps/google-sheets/integrations#triggers-and-actions">Google Sheets</a> integration is an example of this pattern.</p><p>If you want your trigger to perform specific scripting for a dynamic dropdown you will need to make use of <code>bundle.meta.isFillingDynamicDropdown</code>. This can be useful if need to make use of <a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">pagination</a> in the dynamic dropdown to load more options.</p>
+      <blockquote>
+<p>Note: Even if a trigger to power a dynamic dropdown is hidden for direct use, you still need to define the input fields, and whether these are required. In the above example, when the Worksheet trigger defines a required <code>spreadsheet_id</code> field, products such as the editor will use this in two ways. Firstly, the worksheet field will be disabled until the spreadsheet field has been set. Secondly, when the user changes the spreadsheet field, the worksheet field gets cleared.</p>
+</blockquote><p>The <a href="https://zapier.com/apps/google-sheets/integrations#triggers-and-actions">Google Sheets</a> integration is an example of this pattern.</p><p>If you want your trigger to perform specific scripting for a dynamic dropdown you will need to make use of <code>bundle.meta.isFillingDynamicDropdown</code>. This can be useful if need to make use of <a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">pagination</a> in the dynamic dropdown to load more options.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     }
   },
   "lint-staged": {
-    "*.{js}": [
+    "*.js": [
       "eslint --fix --quiet"
     ],
     "*.{js,json}": [

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -785,6 +785,8 @@ And your New Records trigger has a Spreadsheet and a Worksheet dynamic dropdown.
 [insert-file:./snippets/dynamic-dropdowns-six.js]
 ```
 
+> Note: Even if a trigger to power a dynamic dropdown is hidden for direct use, you still need to define the input fields, and whether these are required. In the above example, when the Worksheet trigger defines a required `spreadsheet_id` field, products such as the editor will use this in two ways. Firstly, the worksheet field will be disabled until the spreadsheet field has been set. Secondly, when the user changes the spreadsheet field, the worksheet field gets cleared.
+
 The [Google Sheets](https://zapier.com/apps/google-sheets/integrations#triggers-and-actions) integration is an example of this pattern.
 
 If you want your trigger to perform specific scripting for a dynamic dropdown you will need to make use of `bundle.meta.isFillingDynamicDropdown`. This can be useful if need to make use of [pagination](#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work) in the dynamic dropdown to load more options.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1568,6 +1568,8 @@ const App = {
 
 ```
 
+> Note: Even if a trigger to power a dynamic dropdown is hidden for direct use, you still need to define the input fields, and whether these are required. In the above example, when the Worksheet trigger defines a required `spreadsheet_id` field, products such as the editor will use this in two ways. Firstly, the worksheet field will be disabled until the spreadsheet field has been set. Secondly, when the user changes the spreadsheet field, the worksheet field gets cleared.
+
 The [Google Sheets](https://zapier.com/apps/google-sheets/integrations#triggers-and-actions) integration is an example of this pattern.
 
 If you want your trigger to perform specific scripting for a dynamic dropdown you will need to make use of `bundle.meta.isFillingDynamicDropdown`. This can be useful if need to make use of [pagination](#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work) in the dynamic dropdown to load more options.

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -2623,7 +2623,9 @@ new records in your system (add a recipe to the catalog).</p><p>The definition f
 </div><div class="row">
   <div class="row-height">
     <div class="col-md-5 col-sm-12 col-height  docs-primary">
-      <p>The <a href="https://zapier.com/apps/google-sheets/integrations#triggers-and-actions">Google Sheets</a> integration is an example of this pattern.</p><p>If you want your trigger to perform specific scripting for a dynamic dropdown you will need to make use of <code>bundle.meta.isFillingDynamicDropdown</code>. This can be useful if need to make use of <a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">pagination</a> in the dynamic dropdown to load more options.</p>
+      <blockquote>
+<p>Note: Even if a trigger to power a dynamic dropdown is hidden for direct use, you still need to define the input fields, and whether these are required. In the above example, when the Worksheet trigger defines a required <code>spreadsheet_id</code> field, products such as the editor will use this in two ways. Firstly, the worksheet field will be disabled until the spreadsheet field has been set. Secondly, when the user changes the spreadsheet field, the worksheet field gets cleared.</p>
+</blockquote><p>The <a href="https://zapier.com/apps/google-sheets/integrations#triggers-and-actions">Google Sheets</a> integration is an example of this pattern.</p><p>If you want your trigger to perform specific scripting for a dynamic dropdown you will need to make use of <code>bundle.meta.isFillingDynamicDropdown</code>. This can be useful if need to make use of <a href="#whats-the-deal-with-pagination-when-is-it-used-and-how-does-it-work">pagination</a> in the dynamic dropdown to load more options.</p>
     </div>
     <div class="col-md-7 col-sm-12 col-height  docs-code">
       <pre><code class="lang-js"><span class="hljs-keyword">const</span> App = {


### PR DESCRIPTION
Explain why hidden triggers for dynamic dropdowns need to declare input fields.

See https://zapier.slack.com/archives/C053ZLBM4SV/p1728630326891899?thread_ts=1728427664.388689&cid=C053ZLBM4SV