### PR TITLE
PDE-5323 docs(cli): sync CLI docs, backporting docs for `pull`

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -256,6 +256,7 @@ a code {
 <li><a href="#logs">logs</a></li>
 <li><a href="#migrate">migrate</a></li>
 <li><a href="#promote">promote</a></li>
+<li><a href="#pull">pull</a></li>
 <li><a href="#push">push</a></li>
 <li><a href="#register">register</a></li>
 <li><a href="#scaffold">scaffold</a></li>
@@ -1010,6 +1011,32 @@ zapier invoke auth label  # invokes authentication.test and renders connection l
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier promote 1.0.0</code></li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="pull">pull</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Retrieve and update your local integration files with the latest version.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier pull</code></p><p>This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.</p><p>Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running <code>zapier pull</code>:</p><ul>
+<li>push to the promoted version</li>
+<li>promote a new version</li>
+<li>migrate users from one version to another</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -553,6 +553,24 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * `zapier promote 1.0.0`
 
 
+## pull
+
+> Retrieve and update your local integration files with the latest version.
+
+**Usage**: `zapier pull`
+
+This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
+
+Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running `zapier pull`:
+
+* push to the promoted version
+* promote a new version
+* migrate users from one version to another
+
+**Flags**
+* `-d, --debug` | Show extra debugging output.
+
+
 ## push
 
 > Build and upload the current integration.

--- a/docs/index.html
+++ b/docs/index.html
@@ -249,6 +249,7 @@ a code {
 <li><a href="#private-app-version-default">Private App Version (default)</a></li>
 <li><a href="#sharing-an-app-version">Sharing an App Version</a></li>
 <li><a href="#promoting-an-app-version">Promoting an App Version</a></li>
+<li><a href="#pulling-latest-version-from-zapier">Pulling Latest Version from Zapier</a></li>
 </ul>
 </li>
 <li><a href="#converting-an-existing-app">Converting an Existing App</a></li>
@@ -474,6 +475,7 @@ a code {
 <li><a href="#private-app-version-default">Private App Version (default)</a></li>
 <li><a href="#sharing-an-app-version">Sharing an App Version</a></li>
 <li><a href="#promoting-an-app-version">Promoting an App Version</a></li>
+<li><a href="#pulling-latest-version-from-zapier">Pulling Latest Version from Zapier</a></li>
 </ul>
 </li>
 <li><a href="#converting-an-existing-app">Converting an Existing App</a></li>
@@ -1058,6 +1060,7 @@ zapier versions
 <li><code>zapier deprecate 1.0.0 2020-06-01</code> - mark a version as deprecated, but let users continue to use it (we&apos;ll email them)</li>
 <li><code>zapier env:set 1.0.0 KEY=VALUE</code> - set an environment variable to some value</li>
 <li><code>zapier delete:version 1.0.0</code> - delete a version entirely. This is mostly for clearing out old test apps you used personally. It will fail if there are any users. You probably want <code>deprecate</code> instead.</li>
+<li><code>zapier pull</code> - pull the latest version from Zapier server. This is used in the event that Zapier made an update since your last version.</li>
 </ul><blockquote>
 <p>Note: To see the changes that were just pushed reflected in the browser, you have to manually refresh the browser each time you push.</p>
 </blockquote>
@@ -1140,6 +1143,24 @@ zapier migrate 1.0.0 1.0.1
 <span class="hljs-comment"># OR - mark the old version as deprecated</span>
 zapier deprecate 1.0.0 2020-06-01
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="pulling-latest-version-from-zapier">Pulling Latest Version from Zapier</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Zapier may fix bugs or add new features to your integration and release a new version. If you attempt to use <code>zapier push</code> and we&apos;ve released a newer version, you will be prevented from pushing until you run <code>zapier pull</code> to update your local files with the latest version.</p><p>Any destructive file changes will prompt you with a confirmation dialog before continuing.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/README-source.md
+++ b/packages/cli/README-source.md
@@ -245,6 +245,7 @@ If you'd like to manage your **Version**, use these commands:
 * `zapier deprecate 1.0.0 2020-06-01` - mark a version as deprecated, but let users continue to use it (we'll email them)
 * `zapier env:set 1.0.0 KEY=VALUE` - set an environment variable to some value
 * `zapier delete:version 1.0.0` - delete a version entirely. This is mostly for clearing out old test apps you used personally. It will fail if there are any users. You probably want `deprecate` instead.
+* `zapier pull` - pull the latest version from Zapier server. This is used in the event that Zapier made an update since your last version.
 
 > Note: To see the changes that were just pushed reflected in the browser, you have to manually refresh the browser each time you push.
 
@@ -284,6 +285,12 @@ zapier migrate 1.0.0 1.0.1
 # OR - mark the old version as deprecated
 zapier deprecate 1.0.0 2020-06-01
 ```
+
+### Pulling Latest Version from Zapier
+
+Zapier may fix bugs or add new features to your integration and release a new version. If you attempt to use `zapier push` and we've released a newer version, you will be prevented from pushing until you run `zapier pull` to update your local files with the latest version.
+
+Any destructive file changes will prompt you with a confirmation dialog before continuing.
 
 ## Converting an Existing App
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,6 +47,7 @@ This doc describes the latest CLI version (**15.17.0**), as of this writing. If 
   * [Private App Version (default)](#private-app-version-default)
   * [Sharing an App Version](#sharing-an-app-version)
   * [Promoting an App Version](#promoting-an-app-version)
+  * [Pulling Latest Version from Zapier](#pulling-latest-version-from-zapier)
 - [Converting an Existing App](#converting-an-existing-app)
 - [Authentication](#authentication)
   * [Basic](#basic)
@@ -399,6 +400,7 @@ If you'd like to manage your **Version**, use these commands:
 * `zapier deprecate 1.0.0 2020-06-01` - mark a version as deprecated, but let users continue to use it (we'll email them)
 * `zapier env:set 1.0.0 KEY=VALUE` - set an environment variable to some value
 * `zapier delete:version 1.0.0` - delete a version entirely. This is mostly for clearing out old test apps you used personally. It will fail if there are any users. You probably want `deprecate` instead.
+* `zapier pull` - pull the latest version from Zapier server. This is used in the event that Zapier made an update since your last version.
 
 > Note: To see the changes that were just pushed reflected in the browser, you have to manually refresh the browser each time you push.
 
@@ -438,6 +440,12 @@ zapier migrate 1.0.0 1.0.1
 # OR - mark the old version as deprecated
 zapier deprecate 1.0.0 2020-06-01
 ```
+
+### Pulling Latest Version from Zapier
+
+Zapier may fix bugs or add new features to your integration and release a new version. If you attempt to use `zapier push` and we've released a newer version, you will be prevented from pushing until you run `zapier pull` to update your local files with the latest version.
+
+Any destructive file changes will prompt you with a confirmation dialog before continuing.
 
 ## Converting an Existing App
 

--- a/packages/cli/docs/cli.html
+++ b/packages/cli/docs/cli.html
@@ -256,6 +256,7 @@ a code {
 <li><a href="#logs">logs</a></li>
 <li><a href="#migrate">migrate</a></li>
 <li><a href="#promote">promote</a></li>
+<li><a href="#pull">pull</a></li>
 <li><a href="#push">push</a></li>
 <li><a href="#register">register</a></li>
 <li><a href="#scaffold">scaffold</a></li>
@@ -1010,6 +1011,32 @@ zapier invoke auth label  # invokes authentication.test and renders connection l
 <li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul><p><strong>Examples</strong></p><ul>
 <li><code>zapier promote 1.0.0</code></li>
+</ul>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h2 id="pull">pull</h2>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <blockquote>
+<p>Retrieve and update your local integration files with the latest version.</p>
+</blockquote><p><strong>Usage</strong>: <code>zapier pull</code></p><p>This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.</p><p>Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running <code>zapier pull</code>:</p><ul>
+<li>push to the promoted version</li>
+<li>promote a new version</li>
+<li>migrate users from one version to another</li>
+</ul><p><strong>Flags</strong></p><ul>
+<li><code>-d, --debug</code> | Show extra debugging output.</li>
 </ul>
     </div>
     <div class="col-md-7 col-sm-12 col-height is-empty docs-code">

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -553,6 +553,24 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 * `zapier promote 1.0.0`
 
 
+## pull
+
+> Retrieve and update your local integration files with the latest version.
+
+**Usage**: `zapier pull`
+
+This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
+
+Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running `zapier pull`:
+
+* push to the promoted version
+* promote a new version
+* migrate users from one version to another
+
+**Flags**
+* `-d, --debug` | Show extra debugging output.
+
+
 ## push
 
 > Build and upload the current integration.

--- a/packages/cli/docs/index.html
+++ b/packages/cli/docs/index.html
@@ -249,6 +249,7 @@ a code {
 <li><a href="#private-app-version-default">Private App Version (default)</a></li>
 <li><a href="#sharing-an-app-version">Sharing an App Version</a></li>
 <li><a href="#promoting-an-app-version">Promoting an App Version</a></li>
+<li><a href="#pulling-latest-version-from-zapier">Pulling Latest Version from Zapier</a></li>
 </ul>
 </li>
 <li><a href="#converting-an-existing-app">Converting an Existing App</a></li>
@@ -474,6 +475,7 @@ a code {
 <li><a href="#private-app-version-default">Private App Version (default)</a></li>
 <li><a href="#sharing-an-app-version">Sharing an App Version</a></li>
 <li><a href="#promoting-an-app-version">Promoting an App Version</a></li>
+<li><a href="#pulling-latest-version-from-zapier">Pulling Latest Version from Zapier</a></li>
 </ul>
 </li>
 <li><a href="#converting-an-existing-app">Converting an Existing App</a></li>
@@ -1058,6 +1060,7 @@ zapier versions
 <li><code>zapier deprecate 1.0.0 2020-06-01</code> - mark a version as deprecated, but let users continue to use it (we&apos;ll email them)</li>
 <li><code>zapier env:set 1.0.0 KEY=VALUE</code> - set an environment variable to some value</li>
 <li><code>zapier delete:version 1.0.0</code> - delete a version entirely. This is mostly for clearing out old test apps you used personally. It will fail if there are any users. You probably want <code>deprecate</code> instead.</li>
+<li><code>zapier pull</code> - pull the latest version from Zapier server. This is used in the event that Zapier made an update since your last version.</li>
 </ul><blockquote>
 <p>Note: To see the changes that were just pushed reflected in the browser, you have to manually refresh the browser each time you push.</p>
 </blockquote>
@@ -1140,6 +1143,24 @@ zapier migrate 1.0.0 1.0.1
 <span class="hljs-comment"># OR - mark the old version as deprecated</span>
 zapier deprecate 1.0.0 2020-06-01
 </code></pre>
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <h3 id="pulling-latest-version-from-zapier">Pulling Latest Version from Zapier</h3>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
+    </div>
+  </div>
+</div><div class="row">
+  <div class="row-height">
+    <div class="col-md-5 col-sm-12 col-height  docs-primary">
+      <p>Zapier may fix bugs or add new features to your integration and release a new version. If you attempt to use <code>zapier push</code> and we&apos;ve released a newer version, you will be prevented from pushing until you run <code>zapier pull</code> to update your local files with the latest version.</p><p>Any destructive file changes will prompt you with a confirmation dialog before continuing.</p>
+    </div>
+    <div class="col-md-7 col-sm-12 col-height is-empty docs-code">
+      
     </div>
   </div>
 </div><div class="row">

--- a/packages/cli/src/oclif/commands/pull.js
+++ b/packages/cli/src/oclif/commands/pull.js
@@ -45,8 +45,16 @@ class PullCommand extends ZapierBaseCommand {
 }
 
 PullCommand.flags = buildFlags();
-PullCommand.description =
-  'Pull the source code of the latest version of your integration from Zapier, overwriting your local integration files.';
+PullCommand.description = `Retrieve and update your local integration files with the latest version.
+
+This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
+
+Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running \`zapier pull\`:
+
+* push to the promoted version
+* promote a new version
+* migrate users from one version to another`;
+
 PullCommand.skipValidInstallCheck = true;
 
 module.exports = PullCommand;

--- a/packages/cli/src/oclif/oCommands.js
+++ b/packages/cli/src/oclif/oCommands.js
@@ -31,6 +31,7 @@ module.exports = {
   logout: require('./commands/logout'),
   migrate: require('./commands/migrate'),
   promote: require('./commands/promote'),
+  pull: require('./commands/pull'),
   push: require('./commands/push'),
   scaffold: require('./commands/scaffold'),
   register: require('./commands/register'),


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Some docs about the [`zapier pull`](https://platform.zapier.com/reference/cli#pull) command are on https://platform.zapier.com but not in this repo. This PR backports those contents.