### PR TITLE
feat(cli): Add OAuth to TS init output [IQQ-1860]

### DIFF
--- a/example-apps/typescript/src/authentication.ts
+++ b/example-apps/typescript/src/authentication.ts
@@ -1,0 +1,32 @@
+import type { Authentication } from 'zapier-platform-core';
+
+import { SCOPES } from './constants';
+
+export default {
+  type: 'oauth2',
+  test: { url: 'https://api.example.com/v2/token/authorized_by' },
+  connectionLabel: '{{email}}',
+  oauth2Config: {
+    authorizeUrl: {
+      url: 'https://example.com/oauth/authorize',
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        response_type: 'code',
+        scope: SCOPES.join(' '),
+        redirect_uri: '{{bundle.inputData.redirect_uri}}',
+        state: '{{bundle.inputData.state}}',
+      },
+    },
+    getAccessToken: {
+      url: 'https://api.example.com/oauth/access_token',
+      method: 'POST',
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        client_secret: '{{process.env.CLIENT_SECRET}}',
+        code: '{{bundle.inputData.code}}',
+        grant_type: 'authorization_code',
+        redirect_uri: '{{bundle.inputData.redirect_uri}}',
+      },
+    },
+  },
+} satisfies Authentication;

--- a/example-apps/typescript/src/authentication.ts
+++ b/example-apps/typescript/src/authentication.ts
@@ -1,14 +1,14 @@
 import type { Authentication } from 'zapier-platform-core';
 
-import { SCOPES } from './constants';
+import { API_URL, SCOPES } from './constants';
 
 export default {
   type: 'oauth2',
-  test: { url: 'https://auth-json-server.zapier-staging.com/me' },
+  test: { url: `${API_URL}/me` },
   connectionLabel: '{{email}}', // Set this from the test data.
   oauth2Config: {
     authorizeUrl: {
-      url: 'https://auth-json-server.zapier-staging.com/oauth/authorize',
+      url: `${API_URL}/oauth/authorize`,
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
         response_type: 'code',
@@ -18,7 +18,7 @@ export default {
       },
     },
     getAccessToken: {
-      url: 'https://auth-json-server.zapier-staging.com/oauth/access-token',
+      url: `${API_URL}/oauth/access-token`,
       method: 'POST',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
@@ -29,7 +29,7 @@ export default {
       },
     },
     refreshAccessToken: {
-      url: 'https://auth-json-server.zapier-staging.com/oauth/refresh-token',
+      url: `${API_URL}/oauth/refresh-token`,
       method: 'POST',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',

--- a/example-apps/typescript/src/authentication.ts
+++ b/example-apps/typescript/src/authentication.ts
@@ -4,11 +4,11 @@ import { SCOPES } from './constants';
 
 export default {
   type: 'oauth2',
-  test: { url: 'https://api.example.com/v2/token/authorized_by' },
-  connectionLabel: '{{email}}',
+  test: { url: 'https://auth-json-server.zapier-staging.com/me' },
+  connectionLabel: '{{email}}', // Set this from the test data.
   oauth2Config: {
     authorizeUrl: {
-      url: 'https://example.com/oauth/authorize',
+      url: 'https://auth-json-server.zapier-staging.com/oauth/authorize',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
         response_type: 'code',
@@ -18,7 +18,7 @@ export default {
       },
     },
     getAccessToken: {
-      url: 'https://api.example.com/oauth/access_token',
+      url: 'https://auth-json-server.zapier-staging.com/oauth/access-token',
       method: 'POST',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
@@ -26,6 +26,16 @@ export default {
         code: '{{bundle.inputData.code}}',
         grant_type: 'authorization_code',
         redirect_uri: '{{bundle.inputData.redirect_uri}}',
+      },
+    },
+    refreshAccessToken: {
+      url: 'https://auth-json-server.zapier-staging.com/oauth/refresh-token',
+      method: 'POST',
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        client_secret: '{{process.env.CLIENT_SECRET}}',
+        refresh_token: '{{bundle.authData.refresh_token}}',
+        grant_type: 'refresh_token',
       },
     },
   },

--- a/example-apps/typescript/src/constants.ts
+++ b/example-apps/typescript/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_URL = 'https://api.example.com/v1';
+
+export const SCOPES = ['movies:read', 'movies:write'];

--- a/example-apps/typescript/src/constants.ts
+++ b/example-apps/typescript/src/constants.ts
@@ -1,3 +1,3 @@
-export const API_URL = 'https://api.example.com/v1';
+export const API_URL = 'https://auth-json-server.zapier-staging.com';
 
 export const SCOPES = ['movies:read', 'movies:write'];

--- a/example-apps/typescript/src/creates/movie.ts
+++ b/example-apps/typescript/src/creates/movie.ts
@@ -1,9 +1,10 @@
-import { Create, PerformFunction } from 'zapier-platform-core';
+import type { Create, PerformFunction } from 'zapier-platform-core';
+import { API_URL } from '../constants';
 
 const perform: PerformFunction = async (z, bundle) => {
   const response = await z.request({
     method: 'POST',
-    url: 'https://auth-json-server.zapier-staging.com/movies',
+    url: `${API_URL}/movies`,
     body: {
       title: bundle.inputData.title,
       year: bundle.inputData.year,

--- a/example-apps/typescript/src/index.ts
+++ b/example-apps/typescript/src/index.ts
@@ -1,23 +1,19 @@
-import type { App, BeforeRequestMiddleware } from 'zapier-platform-core';
-
-import MovieCreate from './creates/movie';
-import MovieTrigger from './triggers/movie';
+import type { App } from 'zapier-platform-core';
 import { version as platformVersion } from 'zapier-platform-core';
 
 import packageJson from '../package.json';
 
-const addApiKeyHeader: BeforeRequestMiddleware = (req, z, bundle) => {
-  // Hard-coded api key just to demo. DON'T do auth like this for your production app!
-  req.headers = req.headers || {};
-  req.headers['X-Api-Key'] = 'secret';
-  return req;
-};
+import MovieCreate from './creates/movie';
+import MovieTrigger from './triggers/movie';
+import authentication from './authentication';
+import { addBearerHeader } from './middleware';
 
 export default {
   version: packageJson.version,
   platformVersion,
 
-  beforeRequest: [addApiKeyHeader],
+  authentication,
+  beforeRequest: [addBearerHeader],
 
   triggers: {
     [MovieTrigger.key]: MovieTrigger,

--- a/example-apps/typescript/src/middleware.ts
+++ b/example-apps/typescript/src/middleware.ts
@@ -1,0 +1,11 @@
+import type { BeforeRequestMiddleware } from 'zapier-platform-core';
+
+export const addBearerHeader: BeforeRequestMiddleware = (request, z, bundle) => {
+  if (bundle.authData.access_token && !request.headers?.Authorization) {
+    request.headers = {
+      ...request.headers,
+      Authorization: `Bearer ${bundle.authData.access_token}`,
+    }
+  }
+  return request;
+};

--- a/example-apps/typescript/src/test/creates.test.ts
+++ b/example-apps/typescript/src/test/creates.test.ts
@@ -8,7 +8,10 @@ tools.env.inject();
 
 describe('movie', () => {
   test('create a movie', async () => {
-    const bundle = { inputData: { title: 'hello', year: 2020 } };
+    const bundle = {
+      inputData: { title: 'hello', year: 2020 },
+      authData: { access_token: 'a_token' },
+    };
     const result = await appTester(App.creates.movie.operation.perform, bundle);
     expect(result).toMatchObject({
       title: 'hello',

--- a/example-apps/typescript/src/test/triggers.test.ts
+++ b/example-apps/typescript/src/test/triggers.test.ts
@@ -8,7 +8,7 @@ tools.env.inject();
 
 describe('movie', () => {
   test('list movies', async () => {
-    const bundle = { inputData: {} };
+    const bundle = { inputData: {}, authData: { access_token: 'a_token' } };
     const results = (await appTester(
       App.triggers.movie.operation.perform,
       bundle

--- a/example-apps/typescript/src/triggers/movie.ts
+++ b/example-apps/typescript/src/triggers/movie.ts
@@ -1,9 +1,8 @@
-import { PerformFunction, Trigger } from 'zapier-platform-core';
+import type { PerformFunction, Trigger } from 'zapier-platform-core';
+import { API_URL } from '../constants';
 
 const perform: PerformFunction = async (z, bundle) => {
-  const response = await z.request(
-    'https://auth-json-server.zapier-staging.com/movies'
-  );
+  const response = await z.request(`${API_URL}/movies`);
   return response.data;
 };
 

--- a/example-apps/typescript/tsconfig.json
+++ b/example-apps/typescript/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "skipLibCheck": true,
     "outDir": "./dist",

--- a/packages/cli/src/generators/templates/typescript/src/authentication.ts
+++ b/packages/cli/src/generators/templates/typescript/src/authentication.ts
@@ -1,14 +1,14 @@
 import type { Authentication } from 'zapier-platform-core';
 
-import { SCOPES } from './constants';
+import { API_URL, SCOPES } from './constants';
 
 export default {
   type: 'oauth2',
-  test: { url: 'https://auth-json-server.zapier-staging.com/me' },
+  test: { url: `${API_URL}/me` },
   connectionLabel: '{{email}}', // Set this from the test data.
   oauth2Config: {
     authorizeUrl: {
-      url: 'https://auth-json-server.zapier-staging.com/oauth/authorize',
+      url: `${API_URL}/oauth/authorize`,
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
         response_type: 'code',
@@ -18,7 +18,7 @@ export default {
       },
     },
     getAccessToken: {
-      url: 'https://auth-json-server.zapier-staging.com/oauth/access-token',
+      url: `${API_URL}/oauth/access-token`,
       method: 'POST',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
@@ -29,7 +29,7 @@ export default {
       },
     },
     refreshAccessToken: {
-      url: 'https://auth-json-server.zapier-staging.com/oauth/refresh-token',
+      url: `${API_URL}/oauth/refresh-token`,
       method: 'POST',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
@@ -37,6 +37,6 @@ export default {
         refresh_token: '{{bundle.authData.refresh_token}}',
         grant_type: 'refresh_token',
       },
-    }
+    },
   },
 } satisfies Authentication;

--- a/packages/cli/src/generators/templates/typescript/src/authentication.ts
+++ b/packages/cli/src/generators/templates/typescript/src/authentication.ts
@@ -4,11 +4,11 @@ import { SCOPES } from './constants';
 
 export default {
   type: 'oauth2',
-  test: { url: 'https://api.example.com/v2/token/authorized_by' },
-  connectionLabel: '{{email}}',
+  test: { url: 'https://auth-json-server.zapier-staging.com/me' },
+  connectionLabel: '{{email}}', // Set this from the test data.
   oauth2Config: {
     authorizeUrl: {
-      url: 'https://example.com/oauth/authorize',
+      url: 'https://auth-json-server.zapier-staging.com/oauth/authorize',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
         response_type: 'code',
@@ -18,7 +18,7 @@ export default {
       },
     },
     getAccessToken: {
-      url: 'https://api.example.com/oauth/access_token',
+      url: 'https://auth-json-server.zapier-staging.com/oauth/access-token',
       method: 'POST',
       params: {
         client_id: '{{process.env.CLIENT_ID}}',
@@ -28,5 +28,15 @@ export default {
         redirect_uri: '{{bundle.inputData.redirect_uri}}',
       },
     },
+    refreshAccessToken: {
+      url: 'https://auth-json-server.zapier-staging.com/oauth/refresh-token',
+      method: 'POST',
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        client_secret: '{{process.env.CLIENT_SECRET}}',
+        refresh_token: '{{bundle.authData.refresh_token}}',
+        grant_type: 'refresh_token',
+      },
+    }
   },
 } satisfies Authentication;

--- a/packages/cli/src/generators/templates/typescript/src/authentication.ts
+++ b/packages/cli/src/generators/templates/typescript/src/authentication.ts
@@ -1,0 +1,32 @@
+import type { Authentication } from 'zapier-platform-core';
+
+import { SCOPES } from './constants';
+
+export default {
+  type: 'oauth2',
+  test: { url: 'https://api.example.com/v2/token/authorized_by' },
+  connectionLabel: '{{email}}',
+  oauth2Config: {
+    authorizeUrl: {
+      url: 'https://example.com/oauth/authorize',
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        response_type: 'code',
+        scope: SCOPES.join(' '),
+        redirect_uri: '{{bundle.inputData.redirect_uri}}',
+        state: '{{bundle.inputData.state}}',
+      },
+    },
+    getAccessToken: {
+      url: 'https://api.example.com/oauth/access_token',
+      method: 'POST',
+      params: {
+        client_id: '{{process.env.CLIENT_ID}}',
+        client_secret: '{{process.env.CLIENT_SECRET}}',
+        code: '{{bundle.inputData.code}}',
+        grant_type: 'authorization_code',
+        redirect_uri: '{{bundle.inputData.redirect_uri}}',
+      },
+    },
+  },
+} satisfies Authentication;

--- a/packages/cli/src/generators/templates/typescript/src/constants.ts
+++ b/packages/cli/src/generators/templates/typescript/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_URL = 'https://api.example.com/v1';
+
+export const SCOPES = ['movies:read', 'movies:write'];

--- a/packages/cli/src/generators/templates/typescript/src/constants.ts
+++ b/packages/cli/src/generators/templates/typescript/src/constants.ts
@@ -1,3 +1,3 @@
-export const API_URL = 'https://api.example.com/v1';
+export const API_URL = 'https://auth-json-server.zapier-staging.com';
 
 export const SCOPES = ['movies:read', 'movies:write'];

--- a/packages/cli/src/generators/templates/typescript/src/creates/movie.ts
+++ b/packages/cli/src/generators/templates/typescript/src/creates/movie.ts
@@ -1,9 +1,10 @@
-import { Create, PerformFunction } from 'zapier-platform-core';
+import type { Create, PerformFunction } from 'zapier-platform-core';
+import { API_URL } from '../constants';
 
 const perform: PerformFunction = async (z, bundle) => {
   const response = await z.request({
     method: 'POST',
-    url: 'https://auth-json-server.zapier-staging.com/movies',
+    url: `${API_URL}/movies`,
     body: {
       title: bundle.inputData.title,
       year: bundle.inputData.year,

--- a/packages/cli/src/generators/templates/typescript/src/index.ts
+++ b/packages/cli/src/generators/templates/typescript/src/index.ts
@@ -1,23 +1,19 @@
-import type { App, BeforeRequestMiddleware } from 'zapier-platform-core';
-
-import MovieCreate from './creates/movie';
-import MovieTrigger from './triggers/movie';
+import type { App } from 'zapier-platform-core';
 import { version as platformVersion } from 'zapier-platform-core';
 
 import packageJson from '../package.json';
 
-const addApiKeyHeader: BeforeRequestMiddleware = (req, z, bundle) => {
-  // Hard-coded api key just to demo. DON'T do auth like this for your production app!
-  req.headers = req.headers || {};
-  req.headers['X-Api-Key'] = 'secret';
-  return req;
-};
+import MovieCreate from './creates/movie';
+import MovieTrigger from './triggers/movie';
+import authentication from './authentication';
+import { addBearerHeader } from './middleware';
 
 export default {
   version: packageJson.version,
   platformVersion,
 
-  beforeRequest: [addApiKeyHeader],
+  authentication,
+  beforeRequest: [addBearerHeader],
 
   triggers: {
     [MovieTrigger.key]: MovieTrigger,

--- a/packages/cli/src/generators/templates/typescript/src/middleware.ts
+++ b/packages/cli/src/generators/templates/typescript/src/middleware.ts
@@ -1,0 +1,11 @@
+import type { BeforeRequestMiddleware } from 'zapier-platform-core';
+
+export const addBearerHeader: BeforeRequestMiddleware = (request, z, bundle) => {
+  if (bundle.authData.access_token && !request.headers?.Authorization) {
+    request.headers = {
+      ...request.headers,
+      Authorization: `Bearer ${bundle.authData.access_token}`,
+    }
+  }
+  return request;
+};

--- a/packages/cli/src/generators/templates/typescript/src/test/creates.test.ts
+++ b/packages/cli/src/generators/templates/typescript/src/test/creates.test.ts
@@ -8,7 +8,10 @@ tools.env.inject();
 
 describe('movie', () => {
   test('create a movie', async () => {
-    const bundle = { inputData: { title: 'hello', year: 2020 } };
+    const bundle = {
+      inputData: { title: 'hello', year: 2020 },
+      authData: { access_token: 'a_token' }, 
+    };
     const result = await appTester(App.creates.movie.operation.perform, bundle);
     expect(result).toMatchObject({
       title: 'hello',

--- a/packages/cli/src/generators/templates/typescript/src/test/triggers.test.ts
+++ b/packages/cli/src/generators/templates/typescript/src/test/triggers.test.ts
@@ -8,7 +8,7 @@ tools.env.inject();
 
 describe('movie', () => {
   test('list movies', async () => {
-    const bundle = { inputData: {} };
+    const bundle = { inputData: {}, authData: { access_token: 'a_token' } };
     const results = (await appTester(
       App.triggers.movie.operation.perform,
       bundle

--- a/packages/cli/src/generators/templates/typescript/src/triggers/movie.ts
+++ b/packages/cli/src/generators/templates/typescript/src/triggers/movie.ts
@@ -1,9 +1,8 @@
-import { PerformFunction, Trigger } from 'zapier-platform-core';
+import type { PerformFunction, Trigger } from 'zapier-platform-core';
+import { API_URL } from '../constants';
 
 const perform: PerformFunction = async (z, bundle) => {
-  const response = await z.request(
-    'https://auth-json-server.zapier-staging.com/movies'
-  );
+  const response = await z.request(`${API_URL}/movies`);
   return response.data;
 };
 

--- a/packages/cli/src/generators/templates/typescript/tsconfig.json
+++ b/packages/cli/src/generators/templates/typescript/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true,
     "isolatedModules": true,
     "skipLibCheck": true,
     "outDir": "./dist",

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -226,14 +226,14 @@ export type PerformFunction<BI = Record<string, any>, R = any> = (
 
 export type BeforeRequestMiddleware = (
   request: HttpRequestOptions,
-  z?: ZObject,
-  bundle?: Bundle
+  z: ZObject,
+  bundle: Bundle
 ) => HttpRequestOptions | Promise<HttpRequestOptions>;
 
 export type AfterResponseMiddleware = (
   response: HttpResponse,
   z: ZObject,
-  bundle?: Bundle
+  bundle: Bundle
 ) => HttpResponse | Promise<HttpResponse>;
 
 export interface BufferedItem<InputData = { [x: string]: any }> {


### PR DESCRIPTION
This upgrades the `zapier init` TypeScript example (and the example reference application as well) to use a much closer to real-world OAuth2 example configuration with scopes and `API_URL` constants.

A minor tweak was made to the Before and After Middelware types to make the arguments provided no longer optional, as they are always present.