### PR TITLE
feat(types): Type z.request responses; deprecate `.json`

### DIFF
--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -166,3 +166,36 @@ const app: App = {
   searches: { [search.key]: search },
 };
 expectType<App>(app);
+
+// Return types from z.request
+async (z: ZObject) => {
+  const resp = await z.request<{ id: number; name: string }>(
+    'https://example.com'
+  );
+  expectType<{ id: number; name: string }>(resp.data);
+};
+
+async (z: ZObject) => {
+  const resp = await z.request<{ id: number; name: string }>({
+    url: 'https://example.com',
+  });
+  expectType<{ id: number; name: string }>(resp.data);
+};
+
+// Return types from z.request (raw)
+async (z: ZObject) => {
+  const resp = await z.request<{ id: number; name: string }>(
+    'https://example.com',
+    { raw: true }
+  );
+  const result = await resp.json();
+  expectType<{ id: number; name: string }>(result);
+};
+async (z: ZObject) => {
+  const resp = await z.request<{ id: number; name: string }>({
+    raw: true,
+    url: 'https://example.com',
+  });
+  const result = await resp.json();
+  expectType<{ id: number; name: string }>(result);
+};

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -18,7 +18,7 @@ import type {
   Trigger,
 } from './zapier.generated';
 
-import { expectType } from 'tsd';
+import { expectType, expectDeprecated } from 'tsd';
 
 const basicDisplay: BasicDisplay = {
   label: 'some-label',
@@ -173,6 +173,7 @@ async (z: ZObject) => {
     'https://example.com'
   );
   expectType<{ id: number; name: string }>(resp.data);
+  expectDeprecated(resp.json);
 };
 
 async (z: ZObject) => {

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -117,16 +117,16 @@ interface BaseHttpResponse {
   request: HttpRequestOptions;
 }
 
-export interface HttpResponse extends BaseHttpResponse {
+export interface HttpResponse<T = any> extends BaseHttpResponse {
   content: string;
-  data?: any;
-  json?: any;
+  data: T;
+  json?: T;
 }
 
-export interface RawHttpResponse extends BaseHttpResponse {
+export interface RawHttpResponse<T = any> extends BaseHttpResponse {
   body: NodeJS.ReadableStream;
   buffer(): Promise<Buffer>;
-  json(): Promise<object>;
+  json(): Promise<T>;
   text(): Promise<string>;
 }
 
@@ -138,16 +138,20 @@ type DehydrateFunc = <T>(
 export interface ZObject {
   request: {
     // most specific overloads go first
-    (
+    <T = any>(
       url: string,
       options: HttpRequestOptions & { raw: true }
-    ): Promise<RawHttpResponse>;
-    (
+    ): Promise<RawHttpResponse<T>>;
+    <T = any>(
       options: HttpRequestOptions & { raw: true; url: string }
-    ): Promise<RawHttpResponse>;
+    ): Promise<RawHttpResponse<T>>;
 
-    (url: string, options?: HttpRequestOptions): Promise<HttpResponse>;
-    (options: HttpRequestOptions & { url: string }): Promise<HttpResponse>;
+    <T = any>(url: string, options?: HttpRequestOptions): Promise<
+      HttpResponse<T>
+    >;
+    <T = any>(options: HttpRequestOptions & { url: string }): Promise<
+      HttpResponse<T>
+    >;
   };
 
   console: Console;

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -120,6 +120,7 @@ interface BaseHttpResponse {
 export interface HttpResponse<T = any> extends BaseHttpResponse {
   content: string;
   data: T;
+  /** @deprecated Since v10.0.0. Use `data` instead. */
   json?: T;
 }
 


### PR DESCRIPTION
This adds generic parameters to the `HttpResponse` and `RawHttpResponse` types that allow them to specify what they're returning. If not provided the default is `any`, similar to the previous behaviour.

```ts
interface User {
  id: numner,
  name: string,
}

const resp = await z.request<User>('https://example.com/users');
resp.data.firstName // Error: Type `firstName` doesn't exist on type User, did you mean `name`.
```

---

Because of [this note](https://github.com/zapier/zapier-platform/blob/main/packages/cli/README.md#bundletargeturl) in the CLI docs, I've also marked the `.json` attribute on `HttpResponse` objects as `@deprecated`. It will now show up in the editor struck out, and suggest using `.data` instead. Is this deprecating `.json` correct in your opinion?

![Screen Shot 2024-10-18 at 17 32 53](https://github.com/user-attachments/assets/f21a4dda-87c7-4962-8e19-5b4ac5c9c377)
