### PR TITLE
PDE-5460 test(cli): CLI is actually much smaller now since many docs are deleted

### DIFF
--- a/packages/cli/src/smoke-tests/smoke-tests.js
+++ b/packages/cli/src/smoke-tests/smoke-tests.js
@@ -127,7 +127,7 @@ describe('smoke tests - setup will take some time', function () {
     const latestVersion = await getPackageLatestVersion(packageName);
     const baselineSize = await getPackageSize(packageName, latestVersion);
     const newSize = fs.statSync(context.package.path).size;
-    newSize.should.be.within(baselineSize * 0.7, baselineSize * 1.3);
+    newSize.should.be.within(baselineSize * 0.5, baselineSize * 1.3);
 
     this.test.title += ` (${baselineSize} -> ${newSize} bytes)`;
   });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes a failing smoke test on the CLI package size. CLI is actually much smaller now since many docs are deleted. We may want to bump the ratio from 0.5 back to 0.7 after we release the next version.