### PR TITLE
feat(core) Adds nx argument to z.cache.set()

### DIFF
--- a/packages/core/src/tools/create-cache.js
+++ b/packages/core/src/tools/create-cache.js
@@ -12,7 +12,8 @@ const createCache = (input) => {
     key,
     value = null,
     ttl = null,
-    scope = null
+    scope = null,
+    nx = null
   ) => {
     if (!rpc) {
       throw new Error('rpc is not available');
@@ -36,6 +37,10 @@ const createCache = (input) => {
       );
     }
 
+    if (nx !== null && !_.isBoolean(nx)) {
+      throw new TypeError('nx must be a boolean');
+    }
+
     ensureJSONEncodable(value);
   };
 
@@ -46,10 +51,10 @@ const createCache = (input) => {
       const result = await rpc('zcache_get', key, scope);
       return result ? JSON.parse(result) : null;
     },
-    set: async (key, value, ttl = null, scope = null) => {
-      runValidationChecks(rpc, key, value, ttl, scope);
+    set: async (key, value, ttl = null, scope = null, nx = null) => {
+      runValidationChecks(rpc, key, value, ttl, scope, nx);
 
-      return await rpc('zcache_set', key, JSON.stringify(value), ttl, scope);
+      return await rpc('zcache_set', key, JSON.stringify(value), ttl, scope, nx);
     },
     delete: async (key, scope = null) => {
       runValidationChecks(rpc, key, scope);

--- a/packages/core/test/tools/create-cache.js
+++ b/packages/core/test/tools/create-cache.js
@@ -73,6 +73,12 @@ describe('zcache: get, set, delete', () => {
       .should.be.rejectedWith('ttl must be an integer');
   });
 
+  it('zcache_set: should throw error for a non-boolean nx', async () => {
+    await cache
+      .set('random-key', 'random-value', 1, [], 1)
+      .should.be.rejectedWith('nx must be a boolean');
+  });
+
   it('zcache_delete: should delete the cache entry of an existing key', async () => {
     mockRpcCall(true);
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
Adds nx argument to z.cache.set().

**NOTE:** `z.cache.set()` is still for internal usage.