### PR TITLE
fix(core): [PDE-5470] Force exit process on EMFILE error inside checkMemory

### DIFF
--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -198,20 +198,7 @@ const createLambdaHandler = (appRawOrPath) => {
 
     // If we're running out of memory or file descriptors, force exit the process.
     // The backend will try again via @retry(ProcessExitedException).
-    try {
-      checkMemory(event);
-    } catch (err) {
-      if (err.code === 'EMFILE') {
-        console.error(
-          'Force killing process by Zapier for too many open file descriptors'
-        );
-
-        /* eslint no-process-exit: 0 */
-        process.exit(1);
-      } else {
-        throw err;
-      }
-    }
+    checkMemory(event);
 
     environmentTools.cleanEnvironment();
 

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -196,13 +196,18 @@ const createLambdaHandler = (appRawOrPath) => {
       ZapierPromise.patchGlobal();
     }
 
-    // If we're running out of memory, exit the process. Backend will try again.
+    // If we're running out of memory or file descriptors, force exit the process.
+    // The backend will try again via @retry(ProcessExitedException).
     try {
       checkMemory(event);
     } catch (err) {
-      // Don't crash the invocation if we can't check memory usage.
       if (err.code === 'EMFILE') {
-        console.error('Too many open files, skipping memory usage check...');
+        console.error(
+          'Force killing process by Zapier for too many open file descriptors'
+        );
+
+        /* eslint no-process-exit: 0 */
+        process.exit(1);
       } else {
         throw err;
       }

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -197,7 +197,16 @@ const createLambdaHandler = (appRawOrPath) => {
     }
 
     // If we're running out of memory, exit the process. Backend will try again.
-    checkMemory(event);
+    try {
+      checkMemory(event);
+    } catch (err) {
+      // Don't crash the invocation if we can't check memory usage.
+      if (err.code === 'EMFILE') {
+        console.error('Too many open files, skipping memory usage check...');
+      } else {
+        throw err;
+      }
+    }
 
     environmentTools.cleanEnvironment();
 

--- a/packages/core/src/tools/memory-checker.js
+++ b/packages/core/src/tools/memory-checker.js
@@ -8,22 +8,31 @@ let zrun = 0;
 const checkMemory = (event) => {
   event = event || {};
 
+  let memUsage;
+
+  try {
+    memUsage = process.memoryUsage();
+  } catch (err) {
+    if (err.code === 'EMFILE') {
+      console.error(
+        'Force killing process by Zapier for too many open file descriptors'
+      );
+
+      /* eslint no-process-exit: 0 */
+      process.exit(1);
+    } else {
+      throw err;
+    }
+  }
+
   zrun += 1;
   if (!constants.IS_TESTING && !event.calledFromCli) {
-    console.log(
-      'ZID:',
-      zid,
-      'pid',
-      'ZRUN:',
-      zrun,
-      'RSSMEM:',
-      process.memoryUsage()
-    );
+    console.log('ZID:', zid, 'pid', 'ZRUN:', zrun, 'RSSMEM:', memUsage);
   }
 
   if (
     zrun > constants.KILL_MIN_LIMIT &&
-    process.memoryUsage().rss > constants.KILL_MAX_LIMIT
+    memUsage.rss > constants.KILL_MAX_LIMIT
   ) {
     // should throw "Process exited before completing request"
     // and a @retry in our stack will attempt again - and this


### PR DESCRIPTION
See related Slack thread: https://zapier.slack.com/archives/C04P5J5R8E4/p1729720807731419?thread_ts=1729271444.276339&cid=C04P5J5R8E4

You can recreate the `EMFILE` error locally like:

```js
const fs = require('fs');
const path = require('path');

// Path to a file you want to repeatedly open (can be any existing file)
const filePath = path.resolve(__dirname, 'testfile.txt');

// Ensure the test file exists
fs.writeFileSync(filePath, 'This is a test file.');

const openFiles = [];

function openFileRepeatedly() {
  try {
    // Attempt to open a file repeatedly without closing it
    for (let i = 0; i < 10000000; i++) {
      const fd = fs.openSync(filePath, 'r');
      openFiles.push(fd);
      console.log(`Opened file descriptor ${fd}`);
    }
  } catch (err) {
    console.log(`Error code: ${err.code}`)
    console.error(`Error occurred: ${err.message}`);
  } finally {
    // Clean up and close all open file descriptors
    openFiles.forEach(fd => fs.closeSync(fd));
    console.log('Cleaned up opened file descriptors.');
  }
}

openFileRepeatedly();
```