### PR TITLE
feat(core) - PDE-5490 calling lambda callback doesnt wait for event loop

### DIFF
--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -191,8 +191,7 @@ const createLambdaHandler = (appRawOrPath) => {
     // using the callback; just putting it here to be explicit.
     // In some cases, the code hangs and never exits because the event loop is not
     // empty, so we can override the default behavior and exit after the app is done.
-    context.callbackWaitsForEmptyEventLoop =
-      event.waitForAsyncBeforeExit ?? true;
+    context.callbackWaitsForEmptyEventLoop = !event.skipWaitForAsync || true;
 
     // replace native Promise with bluebird (works better with domains)
     if (!event.calledFromCli) {

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -192,7 +192,7 @@ const createLambdaHandler = (appRawOrPath) => {
     // In some cases, the code hangs and never exits because the event loop is not
     // empty.
     context.callbackWaitsForEmptyEventLoop =
-      event.callbackExitsAfterApp || true;
+      event.waitForAsyncBeforeExit ?? true;
 
     // replace native Promise with bluebird (works better with domains)
     if (!event.calledFromCli) {

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -190,7 +190,7 @@ const createLambdaHandler = (appRawOrPath) => {
     // This is not strictly necessary since this is the default now when
     // using the callback; just putting it here to be explicit.
     // In some cases, the code hangs and never exits because the event loop is not
-    // empty.
+    // empty, so we can override the default behavior and exit after the app is done.
     context.callbackWaitsForEmptyEventLoop =
       event.waitForAsyncBeforeExit ?? true;
 

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -264,6 +264,13 @@ const createLambdaHandler = (appRawOrPath) => {
           const compiledApp = schemaTools.prepareApp(appRaw);
 
           const input = createInput(compiledApp, event, logger, logBuffer, rpc);
+
+          // When the app is done, callback() will be called and the Lambda function will end.
+          // In some cases, perhaps due to fetching large data blobs, the Lambda function
+          // will hang waiting for the event loop to drain. Setting this to false will
+          // prevent that and return when the callback is called.
+          context.callbackWaitsForEmptyEventLoop = false;
+
           return app(input);
         })
         .then((output) => {

--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -191,7 +191,10 @@ const createLambdaHandler = (appRawOrPath) => {
     // using the callback; just putting it here to be explicit.
     // In some cases, the code hangs and never exits because the event loop is not
     // empty, so we can override the default behavior and exit after the app is done.
-    context.callbackWaitsForEmptyEventLoop = !event.skipWaitForAsync || true;
+    context.callbackWaitsForEmptyEventLoop = true;
+    if (event.skipWaitForAsync === true) {
+      context.callbackWaitsForEmptyEventLoop = false;
+    }
 
     // replace native Promise with bluebird (works better with domains)
     if (!event.calledFromCli) {


### PR DESCRIPTION
In debugging some apps, it seems like sometimes lambdas may be hanging indefinitely until the timeout expires.
This causes the action to fail, even if all the app code has completed. 
Debugging further it looks like it's possible that when processing larger datasets, some open connections will be kept open and block the event loop from clearing. 

This heuristic is something we can add from Lambda
https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html
the gist is, if we set `context.callbackWaitsForEmptyEventLoop = false;` then once the callback is called, we exit, despite having other connections

https://zapierorg.atlassian.net/browse/PDE-5490
