### PR TITLE
fix(core): HTTP patch breaks aws-sdk v3 (or other libraries) intermittently

### DIFF
--- a/packages/core/src/tools/create-http-patch.js
+++ b/packages/core/src/tools/create-http-patch.js
@@ -62,10 +62,12 @@ const createHttpPatch = (event) => {
         const requestContentType = getContentType(options.headers || {});
         const responseContentType = getContentType(response.headers || {});
 
-        const shouldIncludeRequestData =
-          ALLOWED_HTTP_DATA_CONTENT_TYPES.has(requestContentType);
-        const shouldIncludeResponseData =
-          ALLOWED_HTTP_DATA_CONTENT_TYPES.has(responseContentType);
+        const shouldIncludeRequestData = ALLOWED_HTTP_DATA_CONTENT_TYPES.has(
+          requestContentType
+        );
+        const shouldIncludeResponseData = ALLOWED_HTTP_DATA_CONTENT_TYPES.has(
+          responseContentType
+        );
 
         const sendToLogger = (responseBody) => {
           // Prepare data for GL
@@ -112,7 +114,14 @@ const createHttpPatch = (event) => {
           }
         };
 
-        response.on('data', (chunk) => chunks.push(chunk));
+        const originalEmit = response.emit;
+
+        response.emit = function (event, ...args) {
+          if (event === 'data') {
+            chunks.push(args[0]);
+          }
+          return originalEmit.apply(this, [event, ...args]);
+        };
         response.on('end', logResponse);
         response.on('error', logResponse);
 

--- a/packages/core/src/tools/http.js
+++ b/packages/core/src/tools/http.js
@@ -7,6 +7,7 @@ const JSON_TYPE_UTF8 = 'application/json; charset=utf-8';
 const BINARY_TYPE = 'application/octet-stream';
 const HTML_TYPE = 'text/html';
 const TEXT_TYPE = 'text/plain';
+const TEXT_TYPE_UTF8 = 'text/plain; charset=utf-8';
 const YAML_TYPE = 'application/yaml';
 const XML_TYPE = 'application/xml';
 const JSONAPI_TYPE = 'application/vnd.api+json';
@@ -17,6 +18,7 @@ const ALLOWED_HTTP_DATA_CONTENT_TYPES = new Set([
   JSON_TYPE_UTF8,
   HTML_TYPE,
   TEXT_TYPE,
+  TEXT_TYPE_UTF8,
   YAML_TYPE,
   XML_TYPE,
   JSONAPI_TYPE,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes an issue where a late listener of a third-party library (like aws-sdk v3) attached to HTTP response stream could miss data chunks that were already consumed by our HTTP logger. The fix involves:

1. Replacing direct `response.on('data')` listener with a patched `emit` function so that we don't attach a listener earlier than any other listeners

2. Maintaining the original event emission behavior by calling the original `emit` with all arguments

3. Adding a test that verifies:
   - Late listeners receive complete data without missing bytes
   - Logger captures the complete response as expected

The changes also include:
- Adding `text/plain; charset=utf-8` to allowed content types

See also this [video](https://zapier.slack.com/archives/C5Z9BP4U9/p1730112195116519) (internal-only) to walk through my thought process.