### PR TITLE
PDE-5488 fix(cli): `zapier invoke --debug` should print non-z.request http logs

### DIFF
--- a/packages/core/src/tools/create-lambda-handler.js
+++ b/packages/core/src/tools/create-lambda-handler.js
@@ -192,7 +192,7 @@ const createLambdaHandler = (appRawOrPath) => {
     context.callbackWaitsForEmptyEventLoop = true;
 
     // replace native Promise with bluebird (works better with domains)
-    if (!event.calledFromCli) {
+    if (!event.calledFromCli || event.calledFromCliInvoke) {
       ZapierPromise.patchGlobal();
     }
 
@@ -253,7 +253,10 @@ const createLambdaHandler = (appRawOrPath) => {
 
           const { skipHttpPatch } = appRaw.flags || {};
           // Adds logging for _all_ kinds of http(s) requests, no matter the library
-          if (!skipHttpPatch && !event.calledFromCli) {
+          if (
+            !skipHttpPatch &&
+            (!event.calledFromCli || event.calledFromCliInvoke)
+          ) {
             const httpPatch = createHttpPatch(event);
             httpPatch(require('http'), logger);
             httpPatch(require('https'), logger); // 'https' needs to be patched separately


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

While working on #905, I noticed that `zapier invoke --debug` didn’t print HTTP logs for requests not sent by `z.request()`. This happened because the HTTP patch (`packages/core/create-http-patch.js`) wasn’t applied, as the CLI client set `event.calledFromCli` to true before calling an app command. The `event.calledFromCli` flag has existed for a long time, initially based on the assumption that we wouldn’t need to patch native `http` and `https` Node.js modules when running app commands from the local CLI. However, this assumption no longer holds now with the `invoke` command.

To avoid changing behavior in existing platform-core versions, I'm keeping `event.calledFromCli` set to true for the `invoke` CLI command, and introducing a new flag, `event.calledFromCliInvoke`, so platform-core can distinguish when the command is run from the `invoke` CLI command.

------

Before:

![](https://cdn.zappy.app/a05fa8b2bc4b7e671764e7388cdb4717.png)

------

After:

![](https://cdn.zappy.app/3acd14dca0f5f4699c7be89ca163e6b9.png)