### PR TITLE
feat(core) Type bundle.meta.timezone

### DIFF
--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -43,6 +43,7 @@ export interface Bundle<InputData = { [x: string]: any }> {
     isTestingAuth: boolean;
     limit: number;
     page: number;
+    timezone: string | null;
     zap?: { id: string };
   };
   rawRequest?: Partial<{


### PR DESCRIPTION
Types `bundle.meta.timezone`, which once https://gitlab.com/zapier/zapier/-/merge_requests/60106 is merged will be set regardless of `zapier-platform-core` version.
