### PR TITLE
feat(core): Add support for providing the cache expiration for hydrators

### DIFF
--- a/packages/core/src/tools/create-dehydrator.js
+++ b/packages/core/src/tools/create-dehydrator.js
@@ -9,19 +9,25 @@ const wrapHydrate = require('./wrap-hydrate');
 const createDehydrator = (input, type = 'method') => {
   const app = _.get(input, '_zapier.app');
 
-  return (func, inputData) => {
+  return (func, inputData, cacheExpiration) => {
     inputData = inputData || {};
     if (inputData.inputData) {
       throw new DehydrateError(
         'Oops! You passed a full `bundle` - really you should pass what you want under `inputData`!'
       );
     }
-    return wrapHydrate({
+    const payload = {
       type,
       method: resolveMethodPath(app, func),
       // inputData vs. bundle is a legacy oddity
       bundle: _.omit(inputData, 'environment'), // don't leak the environment
-    });
+    };
+
+    if (cacheExpiration) {
+      payload.cacheExpiration = cacheExpiration;
+    }
+
+    return wrapHydrate(payload);
   };
 };
 

--- a/packages/core/test/hydration.js
+++ b/packages/core/test/hydration.js
@@ -52,6 +52,13 @@ describe('hydration', () => {
       );
     });
 
+    it('should allow passing of cache expiration argument along in the dehydrated data', () => {
+      const result = dehydrate(funcToFind, {}, 60);
+      result.should.eql(
+        'hydrate|||{"type":"method","method":"some.path.to","bundle":{},"cacheExpiration":60}|||hydrate'
+      );
+    });
+
     it('should not accept payload size bigger than 12000 bytes.', () => {
       const inputData = { key: 'a'.repeat(12001) };
       (() => {
@@ -88,6 +95,14 @@ describe('hydration', () => {
       const result = dehydrateFile(funcToFind, inputData);
       result.should.eql(
         'hydrate|||{"type":"file","method":"some.path.to","bundle":{"key":"value"}}|||hydrate'
+      );
+    });
+
+    it('should allow passing of cache expiration argument along in the dehydrated data', () => {
+      const inputData = { key: 'value' };
+      const result = dehydrateFile(funcToFind, inputData, 60);
+      result.should.eql(
+        'hydrate|||{"type":"file","method":"some.path.to","bundle":{"key":"value"},"cacheExpiration":60}|||hydrate'
       );
     });
 

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -133,7 +133,8 @@ export interface RawHttpResponse<T = any> extends BaseHttpResponse {
 
 type DehydrateFunc = <T>(
   func: (z: ZObject, bundle: Bundle<T>) => any,
-  inputData: T
+  inputData?: T,
+  cacheExpiration?: number,
 ) => string;
 
 export interface ZObject {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
