### PR TITLE
chore(legacy-scripting-runner) Release legacy-scripting-runner v3.8.14

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.14
+
+- :bug: Revert `aws-sdk v2` bundling change from 3.8.13 ([#916](https://github.com/zapier/zapier-platform/pull/916)). This release is essentially the same as 3.8.12.
+
 ## 3.8.13
 
 - :hammer: Add `aws-sdk v2` to dependency list ([#912](https://github.com/zapier/zapier-platform/pull/912))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.13",
+  "version": "3.8.14",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",


### PR DESCRIPTION
## 3.8.14

- :bug: Revert `aws-sdk v2` bundling change from 3.8.13 ([#916](https://github.com/zapier/zapier-platform/pull/916)). This release is essentially the same as 3.8.12.