### PR TITLE
chore(ts): Update bundle.meta typings [IQQ-2105]

### DIFF
--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -37,13 +37,71 @@ export interface Bundle<InputData = { [x: string]: any }> {
   inputDataRaw: { [x: string]: string };
   meta: {
     isBulkRead: boolean;
+
+    /**
+     * If true, this poll is being used to populate a dynamic dropdown.
+     * You only need to return the fields you specified (such as id and
+     * name), though returning everything is fine too.
+     */
     isFillingDynamicDropdown: boolean;
+
+    /**
+     * If true, this run was initiated manually via the Zap Editor.
+     */
     isLoadingSample: boolean;
+
+    /**
+     * If true, the results of this poll will be used to initialize the
+     * deduplication list rather than trigger a zap. You should grab as
+     * many items as possible.
+     */
     isPopulatingDedupe: boolean;
+
+    /**
+     * (legacy property) If true, the poll was triggered by a user
+     * testing their account (via clicking “test” or during setup). We
+     * use this data to populate the auth label, but it’s mostly used to
+     * verify we made a successful authenticated request
+     *
+     * @deprecated
+     */
     isTestingAuth: boolean;
+
+    /**
+     * The number of items you should fetch. -1 indicates there’s no
+     * limit. Build this into your calls insofar as you are able.
+     */
     limit: number;
+
+    /**
+     * Used in paging to uniquely identify which page of results should
+     * be returned.
+     */
     page: number;
-    zap?: { id: string };
+
+    /**
+     * When a create is called as part of a search-or-create step,
+     * this will be the key of the search.
+     */
+    withSearch: string | undefined;
+
+    /**
+     * The timezone the user has configured for their account or
+     * specific automation. Received as TZ identifier, such as
+     * “America/New_York”.
+     */
+    timezone: string | null;
+
+    /** @deprecated */
+    zap?: {
+      /** @deprecated */
+      id: string;
+      /** @deprecated */
+      user: {
+        /** @deprecated use meta.timezone instead. */
+        timezone: string;
+      };
+    };
   };
   rawRequest?: Partial<{
     method: HttpMethod;
@@ -134,7 +192,7 @@ export interface RawHttpResponse<T = any> extends BaseHttpResponse {
 type DehydrateFunc = <T>(
   func: (z: ZObject, bundle: Bundle<T>) => any,
   inputData?: T,
-  cacheExpiration?: number,
+  cacheExpiration?: number
 ) => string;
 
 export interface ZObject {

--- a/packages/core/types/zapier.custom.d.ts
+++ b/packages/core/types/zapier.custom.d.ts
@@ -83,7 +83,7 @@ export interface Bundle<InputData = { [x: string]: any }> {
      * When a create is called as part of a search-or-create step,
      * this will be the key of the search.
      */
-    withSearch: string | undefined;
+    withSearch?: string;
 
     /**
      * The timezone the user has configured for their account or


### PR DESCRIPTION
This updates the `bundle.meta` types with clearer docs, deprecation markings, and support for the new `timezone` and `withSearch` fields.

I've followed the [Core Docs](https://docs.zapier.com/platform/build-cli/core#bundle-meta) on this subject, but if anything is not strictly correct with the platform's behaviour I'll be happy to adjust.

- Deprecated `meta.zap`, and all of the inner `id`, `user`, and `user.timezone` properties
- Deprecated `isTestingAuth`, because the docs say "Legacy property".
- Added `withSearch: string | undefined`. Docs unclear if this is always set and will be `string | undefined`, or _if_ the key is present it will be a valid string, meaning `withSearch?: string` would be better.
- Added `timezone: string | null`. Same as above.
- `isBulkRead`: Unchanged, but curious if it should be marked deprecated or internal only too.

