### PR TITLE
PDE-4089 fix(cli): fix command help markdown formatting

### DIFF
--- a/packages/cli/src/oclif/hooks/renderMarkdownHelp.js
+++ b/packages/cli/src/oclif/hooks/renderMarkdownHelp.js
@@ -1,22 +1,22 @@
 const chalk = require('chalk');
 const { marked } = require('marked');
-const TerminalRenderer = require('marked-terminal');
+const { markedTerminal } = require('marked-terminal');
 
-marked.setOptions({
-  renderer: new TerminalRenderer({
+marked.use(
+  markedTerminal({
     tab: 2,
     width: process.stdout.getWindowSize()[0] - 2,
     reflowText: true,
     codespan: chalk.underline.bold,
   }),
-});
+);
 
 module.exports = (options) => {
   const cmdId = options.id === 'help' ? options.argv[0] : options.id;
   const cmd = options.config.findCommand(cmdId);
   if (cmd) {
     if (cmd.description) {
-      cmd.description = marked(cmd.description).trim();
+      cmd.description = marked.parse(cmd.description).trim();
     }
     // TODO: Do the same for flag descriptions?
   }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

The markdown formatting doesn't seem to work in the release-16.0.0 branch. This PR fixes that. The reason is that the new version of marked-terminal changes its interface that we need to adapt.

---

### Before (15.19.0):

![](https://cdn.zappy.app/a2bbeb5792002e84aae98b447064330f.png)

---

### Before (release-16.0.0 branch currently):

![](https://cdn.zappy.app/153b1566a4fd3cfdcca70cf3617bb600.png)

---

### After (this PR):

![](https://cdn.zappy.app/51628a0bbda839acdc6c72c267289f21.png)

---

P.S. I don't like the extra new lines in the EXAMPLES section. Those seems to be [hard-coded](https://github.com/oclif/core/blob/9ed5f726a57f7c9e01ec991ed605340a9dc21151/src/help/command.ts#L146) in the new oclif, so 🤷 .