### PR TITLE
PDE-5506: fix(cli): move swapi.dev to swapi.info for dynamic-dropdown template

### DIFF
--- a/example-apps/dynamic-dropdown/.gitignore
+++ b/example-apps/dynamic-dropdown/.gitignore
@@ -31,6 +31,7 @@ bower_components
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/
+dist/
 
 # Dependency directories
 node_modules/

--- a/example-apps/dynamic-dropdown/README.md
+++ b/example-apps/dynamic-dropdown/README.md
@@ -25,6 +25,6 @@ Find out more on the latest docs: https://github.com/zapier/zapier-platform/blob
 
 # The "dynamic-dropdown" Template
 
-This example integration uses the [Star Wars API](https://swapi.dev/) to provide a dynamic listing of choices for an `inputField` in a trigger.
+This example integration uses the [Star Wars API](https://swapi.info/) to provide a dynamic listing of choices for an `inputField` in a trigger.
 
 ![](https://cdn.zappy.app/d985065c5098089795d9b60c77791e12.png)

--- a/example-apps/dynamic-dropdown/package.json
+++ b/example-apps/dynamic-dropdown/package.json
@@ -10,7 +10,7 @@
     "zapier-platform-core": "16.0.0"
   },
   "devDependencies": {
-    "jest": "^25.5.3"
+    "jest": "^29.6.0"
   },
   "private": true
 }

--- a/example-apps/dynamic-dropdown/triggers/people.js
+++ b/example-apps/dynamic-dropdown/triggers/people.js
@@ -5,15 +5,20 @@ const perform = async (z, bundle) => {
   // Ideally, we should poll through all the pages of results, but in this
   // example we're going to omit that part. Thus, this trigger only "see" the
   // people in their first page of results.
-  const response = await z.request({ url: 'https://swapi.dev/api/people/' });
-  let peopleArray = response.data.results;
+  const response = await z.request({ url: 'https://swapi.info/api/people/' });
+  let peopleArray = response.data;
 
   if (bundle.inputData.species_id) {
     // The Zap's setup has requested a specific species of person. Since the
     // API/endpoint can't perform the filtering, we'll perform it here, within
     // the integration, and return the matching objects/records back to Zapier.
     peopleArray = peopleArray.filter((person) => {
-      const speciesID = extractID(person.species[0]);
+      let speciesID;
+      if (!person.species || !person.species.length) {
+        speciesID = 1; // Assume human if species is not provided
+      } else {
+        speciesID = extractID(person.species[0]);
+      }
       return speciesID === bundle.inputData.species_id;
     });
   }

--- a/example-apps/dynamic-dropdown/triggers/species.js
+++ b/example-apps/dynamic-dropdown/triggers/species.js
@@ -3,7 +3,7 @@ const { extractID } = require('../utils');
 // Fetches a list of records from the endpoint
 const perform = async (z, bundle) => {
   const request = {
-    url: 'https://swapi.dev/api/species/',
+    url: 'https://swapi.info/api/species/',
     params: {},
   };
 
@@ -13,7 +13,7 @@ const perform = async (z, bundle) => {
   }
 
   const response = await z.request(request);
-  const speciesArray = response.data.results;
+  const speciesArray = response.data;
   return speciesArray.map((species) => {
     species.id = extractID(species.url);
     return species;

--- a/packages/cli/src/generators/templates/dynamic-dropdown/README.md
+++ b/packages/cli/src/generators/templates/dynamic-dropdown/README.md
@@ -1,5 +1,5 @@
 # The "dynamic-dropdown" Template
 
-This example integration uses the [Star Wars API](https://swapi.dev/) to provide a dynamic listing of choices for an `inputField` in a trigger.
+This example integration uses the [Star Wars API](https://swapi.info/) to provide a dynamic listing of choices for an `inputField` in a trigger.
 
 ![](https://cdn.zappy.app/d985065c5098089795d9b60c77791e12.png)

--- a/packages/cli/src/generators/templates/dynamic-dropdown/triggers/people.js
+++ b/packages/cli/src/generators/templates/dynamic-dropdown/triggers/people.js
@@ -5,8 +5,8 @@ const perform = async (z, bundle) => {
   // Ideally, we should poll through all the pages of results, but in this
   // example we're going to omit that part. Thus, this trigger only "see" the
   // people in their first page of results.
-  const response = await z.request({ url: 'https://swapi.dev/api/people/' });
-  let peopleArray = response.data.results;
+  const response = await z.request({ url: 'https://swapi.info/api/people/' });
+  let peopleArray = response.data;
 
   if (bundle.inputData.species_id) {
     // The Zap's setup has requested a specific species of person. Since the

--- a/packages/cli/src/generators/templates/dynamic-dropdown/triggers/species.js
+++ b/packages/cli/src/generators/templates/dynamic-dropdown/triggers/species.js
@@ -3,7 +3,7 @@ const { extractID } = require('../utils');
 // Fetches a list of records from the endpoint
 const perform = async (z, bundle) => {
   const request = {
-    url: 'https://swapi.dev/api/species/',
+    url: 'https://swapi.info/api/species/',
     params: {},
   };
 
@@ -13,7 +13,7 @@ const perform = async (z, bundle) => {
   }
 
   const response = await z.request(request);
-  const speciesArray = response.data.results;
+  const speciesArray = response.data;
   return speciesArray.map((species) => {
     species.id = extractID(species.url);
     return species;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

https://swapi.dev is down. It has been down at least twice as far as I can remember. I found https://swapi.info seems to be a more reliable site. Let's move to that.