### PR TITLE
BREAKING CHANGE(core): Return realistic callback URL in tests

### DIFF
--- a/packages/core/src/tools/create-app-tester.js
+++ b/packages/core/src/tools/create-app-tester.js
@@ -62,7 +62,7 @@ const createAppTester = (appRaw, { customStoreKey } = {}) => {
       method,
       bundle,
       storeKey,
-      callback_url: 'https://auth-json-server.zapier-staging.com/echo',
+      callback_url: 'https://hooks.zapier.com/hooks/callback/0193d9fa-4b71-303c-9b8b-6d988174cb4a/pvh_9Em7nK73CXBsUlMvOorzGyU/',
       zcacheTestObj: appTester.zcacheTestObj,
     };
 


### PR DESCRIPTION
Return a realistic callback URL in tests.

This could be breaking if folks have tests that assert the current value.

Even better would for `appTester` to accept a URL to use.