### PR TITLE
PDE-5550 fix(core): native fetch patch should not reuse logger instance across Lambda calls

### DIFF
--- a/packages/core/test/tools/fetch-logger.js
+++ b/packages/core/test/tools/fetch-logger.js
@@ -204,4 +204,27 @@ describe('wrap fetch with logger', () => {
     // No logs should be created
     assert.equal(logs.length, 0);
   });
+
+  it('should not reuse logger between calls', async () => {
+    const otherLogs = [];
+    const anotherLogger = (message, data) => {
+      otherLogs.push({ message, data });
+    };
+    const evenNewerFetch = wrapFetchWithLogger(newFetch, anotherLogger);
+
+    const url = `${HTTPBIN_URL}/get`;
+    const response = await evenNewerFetch(url);
+
+    assert.equal(response.status, 200);
+    assert.equal(logs.length, 0);
+
+    assert.equal(otherLogs.length, 1);
+
+    const log = otherLogs[0];
+    assert.equal(log.message, `200 GET ${url}`);
+    assert.equal(log.data.request_url, url);
+    assert.equal(log.data.request_method, 'GET');
+    assert.equal(log.data.request_data, '');
+    assert.equal(log.data.response_status_code, 200);
+  });
 });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Platform-core creates a logger instance on every Lambda invocation:

https://github.com/zapier/zapier-platform/blob/98fa8a60cd6c4572f3517e58e982368ffeb1e74a/packages/core/src/tools/create-lambda-handler.js#L217-L218

The logger instance should not be reused across Lambda invocations. The logger instance is bound to an event, the input payload of a Lambda invocation. And the event contains the log extra fields, including `execution_id`, `invocation_id`, `zap_id`, etc. If the logger instance is unfortunately reused, the log can use old values for those fields from a previous Lambda invocation. This is what happened to Webflow, which [uses native fetch](https://github.com/webflow/js-webflow-api/blob/472bac9a5d43b9a15c96b9d7bb96ebe36341b738/src/core/fetcher/getFetchFn.ts#L9) in its [SDK](https://github.com/webflow/js-webflow-api).

This PR fixes that by doing something similar to the `http/https` module patch:

https://github.com/zapier/zapier-platform/blob/98fa8a60cd6c4572f3517e58e982368ffeb1e74a/packages/core/src/tools/create-http-patch.js#L14

By assigning the logger to the patched fetch function:

https://github.com/zapier/zapier-platform/blob/4a711f85113c686dd22ad1f56012ae5917340b93/packages/core/src/tools/fetch-logger.js#L76-L79

we make sure we use the new logger instance on every Lambda invocation.