### PR TITLE
PDE-5636 feat(cli): include extra fields for analytics 

### DIFF
--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -346,7 +346,7 @@ class ZapierBaseCommand extends Command {
     if (!this.args) {
       throw new Error('unable to record analytics until args are parsed');
     }
-    return recordAnalytics(this.id, true, Object.keys(this.args), this.flags);
+    return recordAnalytics(this.id, true, Object.values(this.args), this.flags);
   }
 }
 

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -346,7 +346,7 @@ class ZapierBaseCommand extends Command {
     if (!this.args) {
       throw new Error('unable to record analytics until args are parsed');
     }
-    return recordAnalytics(this.id, true, Object.values(this.args), this.flags);
+    return recordAnalytics(this.id, true, Object.keys(this.args), this.flags);
   }
 }
 

--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -346,7 +346,7 @@ class ZapierBaseCommand extends Command {
     if (!this.args) {
       throw new Error('unable to record analytics until args are parsed');
     }
-    return recordAnalytics(this.id, true, Object.keys(this.args), this.flags);
+    return recordAnalytics(this.id, true, this.args, this.flags);
   }
 }
 

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -49,7 +49,7 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     command,
     isValidCommand,
     numArgs: argKeys.length,
-    app_id: linkedAppId,
+    appId: linkedAppId,
     flags: {
       ...flags,
       ...(command === 'help' ? { helpCommand: argKeys[0] } : {}), // include the beginning of args so we know what they want help on

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -21,7 +21,7 @@ const shouldSkipAnalytics = (mode) =>
   process.env.DISABLE_ZAPIER_ANALYTICS ||
   mode === ANALYTICS_MODES.disabled;
 
-const recordAnalytics = async (command, isValidCommand, argValues, flags) => {
+const recordAnalytics = async (command, isValidCommand, argNames, flags) => {
   const analyticsMode = await currentAnalyticsMode();
 
   if (shouldSkipAnalytics(analyticsMode)) {
@@ -35,12 +35,11 @@ const recordAnalytics = async (command, isValidCommand, argValues, flags) => {
   const analyticsBody = {
     command,
     isValidCommand,
-    numArgs: argValues.length,
-    arguments: argValues,
+    numArgs: argNames.length,
     app_id: linkedAppId,
     flags: {
       ...flags,
-      ...(command === 'help' ? { helpCommand: argValues[0] } : {}), // include the beginning of args so we know what they want help on
+      ...(command === 'help' ? { helpCommand: argNames[0] } : {}), // include the beginning of args so we know what they want help on
     },
     cliVersion: pkg.version,
     os: shouldRecordAnonymously ? undefined : process.platform,

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -21,25 +21,38 @@ const shouldSkipAnalytics = (mode) =>
   process.env.DISABLE_ZAPIER_ANALYTICS ||
   mode === ANALYTICS_MODES.disabled;
 
-const recordAnalytics = async (command, isValidCommand, argNames, flags) => {
+const recordAnalytics = async (command, isValidCommand, args, flags) => {
   const analyticsMode = await currentAnalyticsMode();
 
   if (shouldSkipAnalytics(analyticsMode)) {
     debug('skipping analytics');
     return;
   }
+  const argKeys = Object.keys(args);
+
   const shouldRecordAnonymously = analyticsMode === ANALYTICS_MODES.anonymous;
-  // We don't want to "explode" if appID is missing
-  const linkedAppId = (await getLinkedAppConfig(undefined, false))?.id;
+
+  const integrationIDKey = argKeys.find(
+    (key) => key.toLowerCase() === 'integrationid',
+  );
+  const integrationID = integrationIDKey ? args[integrationIDKey] : undefined;
+
+  // Some commands ( like "zapier convert" ) won't have an app directory when called.
+  // Instead, having the app ID in the arguments.
+  // Fallback to using "integrationid" in arguments ( if it's there )
+  // and don't want to "explode" if appID is missing
+  const linkedAppId =
+    (await getLinkedAppConfig(undefined, false))?.id || integrationID;
+
   // to make this more testable, we should split this out into its own function
   const analyticsBody = {
     command,
     isValidCommand,
-    numArgs: argNames.length,
+    numArgs: argKeys.length,
     app_id: linkedAppId,
     flags: {
       ...flags,
-      ...(command === 'help' ? { helpCommand: argNames[0] } : {}), // include the beginning of args so we know what they want help on
+      ...(command === 'help' ? { helpCommand: argKeys[0] } : {}), // include the beginning of args so we know what they want help on
     },
     cliVersion: pkg.version,
     os: shouldRecordAnonymously ? undefined : process.platform,

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -2,6 +2,7 @@ const { callAPI } = require('./api');
 // const { readFile } = require('./files');
 const debug = require('debug')('zapier:analytics');
 const pkg = require('../../package.json');
+const { getLinkedAppConfig } = require('../utils/api');
 const { ANALYTICS_KEY, ANALYTICS_MODES, IS_TESTING } = require('../constants');
 const { readUserConfig, writeUserConfig } = require('./userConfig');
 
@@ -20,24 +21,26 @@ const shouldSkipAnalytics = (mode) =>
   process.env.DISABLE_ZAPIER_ANALYTICS ||
   mode === ANALYTICS_MODES.disabled;
 
-const recordAnalytics = async (command, isValidCommand, argNames, flags) => {
+const recordAnalytics = async (command, isValidCommand, argValues, flags) => {
   const analyticsMode = await currentAnalyticsMode();
 
   if (shouldSkipAnalytics(analyticsMode)) {
     debug('skipping analytics');
     return;
   }
-
   const shouldRecordAnonymously = analyticsMode === ANALYTICS_MODES.anonymous;
-
+  // We don't want to "explode" if appID is missing
+  const linkedAppId = (await getLinkedAppConfig(undefined, false))?.id;
   // to make this more testable, we should split this out into its own function
   const analyticsBody = {
     command,
     isValidCommand,
-    numArgs: argNames.length,
+    numArgs: argValues.length,
+    arguments: argValues,
+    app_id: linkedAppId,
     flags: {
       ...flags,
-      ...(command === 'help' ? { helpCommand: argNames[0] } : {}), // include the beginning of args so we know what they want help on
+      ...(command === 'help' ? { helpCommand: argValues[0] } : {}), // include the beginning of args so we know what they want help on
     },
     cliVersion: pkg.version,
     os: shouldRecordAnonymously ? undefined : process.platform,

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -39,7 +39,7 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
 
   // Some commands ( like "zapier convert" ) won't have an app directory when called.
   // Instead, having the app ID in the arguments.
-  // Fallback to using "integrationid" in arguments ( if it's there )
+  // In this case, we fallback to using "integrationid" in arguments ( if it's there )
   // and don't want to "explode" if appID is missing
   const linkedAppId =
     (await getLinkedAppConfig(undefined, false))?.id || integrationID;

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -95,7 +95,7 @@ const callAPI = async (
     }
   }
 
-  debug(`>> ${requestOptions.method} ${requestOptions.url}`);
+  debug(`>> ${requestOptions.method} ${requestOptions.url || res.url}`);
 
   if (requestOptions.body) {
     const replacementStr = 'raw zip removed in logs';


### PR DESCRIPTION
This pull request expands the analytics functionality in the Zapier CLI by updating the way arguments are recorded and adding additional information to the analytics payload.

#### Changes
- **Updated `analytics.js`**:
  - Included `app_id` in the analytics payload, which is fetched from the linked app configuration OR integrationid" in arguments since some commands ( like "zapier convert" ) won't have a linked app directory when called. 
  
- **Updated `ZapierBaseCommand.js`**:
    - Change `Object.keys(this.args)` to `this.args`. This allows us to later capture app ID argument value based on the name and populate `numArgs` and parts of `flags` . This is not meant to capture `this.args` in analytics as shown in tests below 

#### Impact
The inclusion of app ID will provide better insights into CLI usage patterns. There is another ticket to track work required for adding "arguments" effectively and safely PDE-5641


#### Tests
Tested the changes locally

<img width="1562" alt="Screenshot 2024-12-23 at 9 53 27 AM" src="https://github.com/user-attachments/assets/05a55036-88d8-4a6f-bf87-f68edf921519" />

```
➜  zapier-platform git:(PDE-5636_expand_analyticsBody) ✗ zapier-dev convert 216691 testing5 -v 1.0.0 --debug  
(node:72410) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
⠋ Downloading integration from Zapier  zapier:analytics sending {
  command: 'convert',
  isValidCommand: true,
  numArgs: 2,
  app_id: 216691,
  flags: { version: '1.0.0', debug: true },
  cliVersion: '16.0.0',
  os: 'darwin',
  sendUserId: true
} +0ms
⠙ Downloading integration from Zapier  zapier:api >> POST undefined +0ms
  zapier:api >> {"command":"convert","isValidCommand":true,"numArgs":2,"app_id":216691,"flags":{"version":"1.0.0","debug":true},"cliVersion":"16.0.0","os":"darwin"} +1ms
  zapier:api << 200 +0ms
  zapier:api <<  +0ms
  zapier:api ------------ +0ms
  zapier:analytics success: true +122ms
  zapier:api >> GET undefined +16ms
  zapier:api << 200 +0ms
  zapier:api <<  +0ms
  zapier:api ------------ +0ms
⠹ Downloading integration from Zapier  zapier:api >> GET undefined +56ms
  zapier:api << 200 +0ms
  zapier:api <<  +0ms
  zapier:api ------------ +0ms
✔ Downloading integration from Zapier
✔ Writing .env
✔ Writing package.json
✔ Writing .zapierapprc
✔ Writing index.js
✔ Writing authentication.js
✔ Writing triggers/test_key.js
✔ Writing test/triggers/test_key.test.js
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/.env
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/.gitignore
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/.zapierapprc
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/authentication.js
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/index.js
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/package.json
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/triggers/test_key.js
✔ Copying /Users/natay/src/github.com/zapier-platform/testing5/test/triggers/test_key.test.js
```




