### PR TITLE
[PDE-5644] cli(fix): Include "version" column when fetching history logs

### DIFF
--- a/packages/cli/src/oclif/commands/history.js
+++ b/packages/cli/src/oclif/commands/history.js
@@ -15,6 +15,7 @@ class HistoryCommand extends BaseCommand {
         ['What', 'action'],
         ['Message', 'message'],
         ['Who', 'customuser'],
+        ['Version', 'version'],
         ['Timestamp', 'date'],
       ],
       emptyMessage: 'No historical actions found',


### PR DESCRIPTION
This small PR adds a `version` column when running `zapier history`. The main reason being that, for environment variable add/delete actions, we don't display information on which AppVersion was affected which is an important factor when debugging. This does bloat the `"version added"` and `"version changed"` history logs because those already store the version as part of the `"message"` field...


Before:  
<img width="608" alt="Screenshot 2024-12-30 at 10 49 26 AM" src="https://github.com/user-attachments/assets/f61b828e-2f28-41bf-adca-ddbb877a39cc" />


After:  
<img width="616" alt="Screenshot 2024-12-30 at 10 44 31 AM" src="https://github.com/user-attachments/assets/4f29a10a-28a5-4e9c-b18a-b288ba929905" />
