### PR TITLE
PDE-5641: feat(core) capture CLI arguments in analytics safely

### DIFF
--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -21,6 +21,24 @@ const shouldSkipAnalytics = (mode) =>
   process.env.DISABLE_ZAPIER_ANALYTICS ||
   mode === ANALYTICS_MODES.disabled;
 
+const cleanArgs = (args) => {
+  // Do not record "arguments" for following commands
+  const BLACKLISTED_ARGS = [
+    'key-value pairs...',
+    'keys...',
+    'path',
+    'email',
+    'message',
+  ];
+  const cleanedArgs = Object.keys(args)
+    .filter((key) => !BLACKLISTED_ARGS.includes(key))
+    .reduce((obj, key) => {
+      obj[key] = args[key];
+      return obj;
+    }, {});
+  return cleanedArgs;
+};
+
 const recordAnalytics = async (command, isValidCommand, args, flags) => {
   const analyticsMode = await currentAnalyticsMode();
 
@@ -28,6 +46,9 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     debug('skipping analytics');
     return;
   }
+  debug('args...', args);
+  const cleanedArgs = cleanArgs(args);
+  debug('cleaned args...', cleanedArgs);
   const argKeys = Object.keys(args);
 
   const shouldRecordAnonymously = analyticsMode === ANALYTICS_MODES.anonymous;

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -21,27 +21,6 @@ const shouldSkipAnalytics = (mode) =>
   process.env.DISABLE_ZAPIER_ANALYTICS ||
   mode === ANALYTICS_MODES.disabled;
 
-const cleanValues = (args) => {
-  // List of arguments we don't want to record.
-  const doNotRecord = [
-    'key-value pairs...',
-    'keys...',
-    'path',
-    'email',
-    'message',
-    'user',
-    'account',
-    'redirect-uri',
-    'inputData',
-  ];
-  return Object.keys(args)
-    .filter((key) => !doNotRecord.includes(key))
-    .reduce((obj, key) => {
-      obj[key] = args[key];
-      return obj;
-    }, {});
-};
-
 const recordAnalytics = async (command, isValidCommand, args, flags) => {
   const analyticsMode = await currentAnalyticsMode();
 
@@ -49,10 +28,8 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     debug('skipping analytics');
     return;
   }
-  const cleanedArgs = cleanValues(args);
-  const cleanedFlags = cleanValues(flags);
   const argKeys = Object.keys(args);
-
+  const flagKeys = Object.keys(flags);
   const shouldRecordAnonymously = analyticsMode === ANALYTICS_MODES.anonymous;
 
   const integrationIDKey = argKeys.find(
@@ -74,10 +51,10 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     numArgs: argKeys.length,
     appId: linkedAppId,
     flags: {
-      ...cleanedFlags,
+      ...flagKeys,
       ...(command === 'help' ? { helpCommand: argKeys[0] } : {}), // include the beginning of args so we know what they want help on
     },
-    args: shouldRecordAnonymously ? undefined : cleanedArgs,
+    argsKeys: argKeys,
     cliVersion: pkg.version,
     os: shouldRecordAnonymously ? undefined : process.platform,
   };

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -50,10 +50,6 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     isValidCommand,
     numArgs: argKeys.length,
     appId: linkedAppId,
-    flags: {
-      ...flags,
-      ...(command === 'help' ? { helpCommand: argKeys[0] } : {}), // include the beginning of args so we know what they want help on
-    },
     argsKeys: argKeys,
     flagKeys: flagKeys,
     cliVersion: pkg.version,

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -51,10 +51,11 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     numArgs: argKeys.length,
     appId: linkedAppId,
     flags: {
-      ...flagKeys,
+      ...flags,
       ...(command === 'help' ? { helpCommand: argKeys[0] } : {}), // include the beginning of args so we know what they want help on
     },
     argsKeys: argKeys,
+    flagKeys: flagKeys,
     cliVersion: pkg.version,
     os: shouldRecordAnonymously ? undefined : process.platform,
   };


### PR DESCRIPTION
Capture the argument + flags keys ( no values ) that are being used

Related MR: https://gitlab.com/zapier/zapier/-/merge_requests/60772

<img width="861" alt="Screenshot 2025-01-08 at 11 58 46 AM" src="https://github.com/user-attachments/assets/76f75433-5051-4611-8fbf-1688a87823ef" />


<img width="937" alt="Screenshot 2025-01-08 at 11 59 06 AM" src="https://github.com/user-attachments/assets/b64a9062-04fa-48b5-907d-e16f87559348" />

