### PR TITLE
[PDE-5692] fix(CLI): Integration check reference URL's anchor tags are broken

### DIFF
--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -42,7 +42,7 @@ const PACKAGE_VERSION = packageJson.version;
 const UPDATE_NOTIFICATION_INTERVAL = 1000 * 60 * 60 * 24 * 7; // one week
 
 const CHECK_REF_DOC_LINK =
-  'https://docs.zapier.com/platform/publish/integration-checks-reference#integration-check-reference';
+  'https://docs.zapier.com/platform/publish/integration-checks-reference';
 
 const ISSUES_URL =
   'https://github.com/zapier/zapier-platform/issues/new/choose';


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
