### PR TITLE
[PDE-5602] feat(cli): Add support for running pre-checks via API before promotion and migration

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -514,6 +514,7 @@ You cannot pass both `--user` and `--account`.
 **Flags**
 * `--user` | Migrates all of a users' Private Zaps within all accounts for which the specified user is a member
 * `--account` | Migrates all of a users' Zaps, Private & Shared, within all accounts for which the specified user is a member
+* `-y, --yes` | Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const debug = require('debug')('zapier:migrate');
 const { Args, Flags } = require('@oclif/core');
 
 const BaseCommand = require('../ZapierBaseCommand');
@@ -23,7 +24,7 @@ class MigrateCommand extends BaseCommand {
         true,
       );
     } catch (response) {
-      this.stopSpinner();
+      this.stopSpinner({ success: false });
 
       // 409 from the backend specifically signals pre-checks failed
       if (response.status === 409) {
@@ -44,6 +45,8 @@ class MigrateCommand extends BaseCommand {
         if (!shouldContinuePreChecks) {
           this.error('Cancelled migration.');
         }
+      } else {
+        debug('Soft pre-checks before migration failed:', response.errText);
       }
     } finally {
       this.stopSpinner();

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -27,7 +27,7 @@ class MigrateCommand extends BaseCommand {
 
       // 409 from the backend specifically signals pre-checks failed
       if (response.status === 409) {
-        const softCheckErrors = _.get(response, 'json.errors');
+        const softCheckErrors = _.get(response, 'json.errors', []);
         const formattedErrors = softCheckErrors.map((e) => `* ${e}`).join('\n');
 
         this.log();

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -134,19 +134,6 @@ class MigrateCommand extends BaseCommand {
 
     try {
       await callAPI(url, { method: 'POST', body });
-    } catch (errorResponse) {
-      // Verify if this error is something we can retry with confirmation
-      const requiresConfirmation = errorResponse.status === 409;
-      if (requiresConfirmation) {
-        this.stopSpinner();
-
-        this.log('');
-
-        this.log();
-      } else {
-        // Unhandled error
-        throw errorResponse;
-      }
     } finally {
       this.stopSpinner();
     }

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -62,7 +62,7 @@ class PromoteCommand extends BaseCommand {
       this.stopSpinner();
       // 409 from the backend specifically signals pre-checks failed
       if (response.status === 409) {
-        const softCheckErrors = _.get(response, 'json.errors');
+        const softCheckErrors = _.get(response, 'json.errors', []);
         const formattedErrors = softCheckErrors.map((e) => `* ${e}`).join('\n');
 
         this.log();

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const debug = require('debug')('zapier:promote');
 const colors = require('colors/safe');
 const { Args, Flags } = require('@oclif/core');
 
@@ -59,7 +60,7 @@ class PromoteCommand extends BaseCommand {
         true,
       );
     } catch (response) {
-      this.stopSpinner();
+      this.stopSpinner({ success: false });
       // 409 from the backend specifically signals pre-checks failed
       if (response.status === 409) {
         const softCheckErrors = _.get(response, 'json.errors', []);
@@ -81,6 +82,8 @@ class PromoteCommand extends BaseCommand {
         if (!shouldContinuePreChecks) {
           this.error('Cancelled promote.');
         }
+      } else {
+        debug('Soft pre-checks before promotion failed:', response.errText);
       }
     } finally {
       this.stopSpinner();


### PR DESCRIPTION
This PR adds logic to run soft-checks before promote/migration via a new backend endpoint. Upon receiving an `HTTP 409` from the backend, the CLI will confirm the user's intent before proceeding.

## Migration
![migrate](https://github.com/user-attachments/assets/764f0ac3-2901-48a4-86b2-c8dcc4b0c4be)


## Promote
![promote](https://github.com/user-attachments/assets/b998b570-483c-4fa1-8368-dab5b34f6374)
