### PR TITLE
[PDE-5660] fix(cli): Use `.status` when catching error response in env:set/env:unset

### DIFF
--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -62,7 +62,7 @@ class SetEnvCommand extends BaseCommand {
       this.log(successMessage(version));
       this.logJSON(payload);
     } catch (e) {
-      if (e.statusCode === 409) {
+      if (e.status === 409) {
         this.error(
           `App version ${version} is the production version. Are you sure you want to set potentially live environment variables?` +
             ` If so, run this command again with the --force flag.`,

--- a/packages/cli/src/oclif/commands/env/unset.js
+++ b/packages/cli/src/oclif/commands/env/unset.js
@@ -56,7 +56,7 @@ class UnsetEnvCommand extends BaseCommand {
     try {
       await callAPI(url, requestOptions);
     } catch (e) {
-      if (e.statusCode === 409) {
+      if (e.status === 409) {
         this.error(
           `App version ${version} is the production version. Are you sure you want to unset potentially live environment variables?` +
             ` If so, run this command again with the --force flag.`,


### PR DESCRIPTION
This PR is a followup bugfix for https://github.com/zapier/zapier-platform/pull/942

Testing locally, `fetch().statusCode` does not work... it should be `.status` 😓 