### PR TITLE
[PDE-5660] fix(cli): Pass in `rawError=true` when catching error response in `env:unset`

### DIFF
--- a/packages/cli/src/oclif/commands/env/unset.js
+++ b/packages/cli/src/oclif/commands/env/unset.js
@@ -54,7 +54,7 @@ class UnsetEnvCommand extends BaseCommand {
     }
 
     try {
-      await callAPI(url, requestOptions);
+      await callAPI(url, requestOptions, true);
     } catch (e) {
       if (e.status === 409) {
         this.error(


### PR DESCRIPTION
Caught another issue when testing locally: the error response for `env:unset` upon hitting an HTTP 409 does not specify how to solve the issue. This is because the third parameter to `callAPI` defaults as `false` ([source](https://github.com/zapier/zapier-platform/blob/575fef5d196410d601dcf23a8a811599ef689a0b/packages/cli/src/utils/api.js#L55), `env:set` has this as `true`) and the error is handled differently.

This is something to merge in before [releasing 16.2.0](https://github.com/zapier/zapier-platform/pull/953) 😅 

Before

![Screen Shot 2025-01-21 at 11 26 07 AM](https://github.com/user-attachments/assets/d34bccc0-6cb5-43f2-8cd6-1a90e4827bb4)

After 

![Screen Shot 2025-01-21 at 11 25 51 AM](https://github.com/user-attachments/assets/5bdb59be-f592-4eb2-8578-a2857e5bb261)
