### PR TITLE
[PDE-5714] docs(cli): Update `zapier pull` prompt to clarify complex `ynarxdeiH` options during file conflicts

### DIFF
--- a/packages/cli/src/generators/pull.js
+++ b/packages/cli/src/generators/pull.js
@@ -24,7 +24,10 @@ module.exports = class PullGenerator extends Generator {
         name: 'confirm',
         message: `Warning: You are about to overwrite existing files.
 
-Before proceeding, please make sure you have saved your work. Consider creating a backup or saving your current state in a git branch. During the process, you may abort anytime by pressing 'x'.
+Before proceeding, please make sure you have saved your work. Consider creating a backup or saving your current state in a git branch.
+
+If presented with a series of options ('ynarxdeiH'), you may
+press Enter to view more details about each option. For example, 'x' will abort the process.
 
 Do you want to continue?`,
         default: false,


### PR DESCRIPTION
A point of feedback regarding `zapier pull` is that the `ynarxdeiH` options shown during file conflicts are not user-friendly.

It's not a simple change to modify yeoman-environment's prompts ([source](https://github.com/yeoman/environment/blob/08d00cbbfa15ed12761500292b3038686fbf64fd/lib/util/conflicter.js#L322)) so the next best thing is likely to better document how to expand the options.

Before:

<img width="1090" alt="image" src="https://github.com/user-attachments/assets/b7b68ca2-7e65-4716-98c5-66e9ea4b5be2" />

---

After:

<img width="1063" alt="Screenshot 2025-01-28 at 11 10 27 AM" src="https://github.com/user-attachments/assets/1cab08a6-8e89-498d-b782-53a868d65a30" />

---

When expanding help text by pressing enter:

<img width="1067" alt="Screenshot 2025-01-28 at 11 10 38 AM" src="https://github.com/user-attachments/assets/5382ec6f-9de4-44cc-ab30-2f832fcdffff" />
