### PR TITLE
[PDE-5716] feat(cli): Require `--overwrite-partner-changes` flag when a `zapier push` from staff could impact partner changes

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-cli",
-  "version": "16.2.0",
+  "version": "16.3.0",
   "description": "The CLI for managing integrations in Zapier Developer Platform.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-cli",
-  "version": "16.3.0",
+  "version": "16.2.0",
   "description": "The CLI for managing integrations in Zapier Developer Platform.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -1,10 +1,10 @@
 const ZapierBaseCommand = require('../ZapierBaseCommand');
+const { BUILD_PATH, SOURCE_PATH } = require('../../constants');
 const { Flags } = require('@oclif/core');
 
 const BuildCommand = require('./build');
 
 const { buildAndOrUpload } = require('../../utils/build');
-const { BUILD_PATH, SOURCE_PATH } = require('../../constants');
 
 class PushCommand extends ZapierBaseCommand {
   async perform() {
@@ -25,7 +25,7 @@ class PushCommand extends ZapierBaseCommand {
 
 PushCommand.flags = {
   ...BuildCommand.flags,
-  overwritePartnerChanges: Flags.boolean({
+  'overwrite-partner-changes': Flags.boolean({
     description:
       '(Internal Use Only) Allows Zapier Staff to push changes to integrations in certain situations.',
     hidden: true,

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -1,9 +1,10 @@
 const ZapierBaseCommand = require('../ZapierBaseCommand');
-const { BUILD_PATH, SOURCE_PATH } = require('../../constants');
+const { Flags } = require('@oclif/core');
 
 const BuildCommand = require('./build');
 
 const { buildAndOrUpload } = require('../../utils/build');
+const { BUILD_PATH, SOURCE_PATH } = require('../../constants');
 
 class PushCommand extends ZapierBaseCommand {
   async perform() {
@@ -13,6 +14,7 @@ class PushCommand extends ZapierBaseCommand {
         skipNpmInstall: this.flags['skip-npm-install'],
         disableDependencyDetection: this.flags['disable-dependency-detection'],
         skipValidation: this.flags['skip-validation'],
+        overwritePartnerChanges: this.flags['overwrite-partner-changes'],
       },
     );
     this.log(
@@ -21,7 +23,14 @@ class PushCommand extends ZapierBaseCommand {
   }
 }
 
-PushCommand.flags = BuildCommand.flags;
+PushCommand.flags = {
+  ...BuildCommand.flags,
+  overwritePartnerChanges: Flags.boolean({
+    description:
+      '(Internal Use Only) Allows Zapier Staff to push changes to integrations in certain situations.',
+    hidden: true,
+  }),
+};
 PushCommand.description = `Build and upload the current integration.
 
 This command is the same as running \`zapier build\` and \`zapier upload\` in sequence. See those for more info.`;

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -483,8 +483,8 @@ const upload = async (
       );
     }
 
-    // Don't ignore other errors, re-throw them
-    throw err;
+    // Don't ignore other errors, re-throw them with a user-friendly message
+    throw new Error(err.errText);
   } finally {
     endSpinner();
   }

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -475,7 +475,7 @@ const upload = async (
   } catch (err) {
     endSpinner({ success: false });
     // 409 from the backend specifically signals that the last changes were from a partner
-    // and this is a staff user which is likely
+    // and this is a staff user which could unintentionally overwrite those changes
     if (err.status === 409) {
       throw new Error(
         `The latest integration changes appear to be from a partner. OK to overwrite?` +

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -459,15 +459,19 @@ const upload = async (
 
   startSpinner(`Uploading version ${definition.version}`);
   try {
-    await callAPI(`/apps/${app.id}/versions/${definition.version}`, {
-      method: 'PUT',
-      body: {
-        zip_file: buffer,
-        source_zip_file: sourceBuffer,
-        skip_validation: skipValidation,
+    await callAPI(
+      `/apps/${app.id}/versions/${definition.version}`,
+      {
+        method: 'PUT',
+        body: {
+          zip_file: buffer,
+          source_zip_file: sourceBuffer,
+          skip_validation: skipValidation,
+        },
+        extraHeaders: headers,
       },
-      extraHeaders: headers,
-    });
+      true,
+    );
   } catch (err) {
     endSpinner({ success: false });
     // 409 from the backend specifically signals that the last changes were from a partner

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -422,7 +422,10 @@ const downloadSourceZip = async (dst) => {
   }
 };
 
-const upload = async (app, { skipValidation = false } = {}) => {
+const upload = async (
+  app,
+  { skipValidation = false, overwritePartnerChanges = false } = {},
+) => {
   const zipPath = constants.BUILD_PATH;
   const sourceZipPath = constants.SOURCE_PATH;
   const appDir = process.cwd();
@@ -449,17 +452,38 @@ const upload = async (app, { skipValidation = false } = {}) => {
   const binarySourceZip = fs.readFileSync(fullSourceZipPath);
   const sourceBuffer = Buffer.from(binarySourceZip).toString('base64');
 
-  startSpinner(`Uploading version ${definition.version}`);
-  await callAPI(`/apps/${app.id}/versions/${definition.version}`, {
-    method: 'PUT',
-    body: {
-      zip_file: buffer,
-      source_zip_file: sourceBuffer,
-      skip_validation: skipValidation,
-    },
-  });
+  const headers = {};
+  if (overwritePartnerChanges) {
+    headers['X-Overwrite-Partner-Changes'] = 'true';
+  }
 
-  endSpinner();
+  startSpinner(`Uploading version ${definition.version}`);
+  try {
+    await callAPI(`/apps/${app.id}/versions/${definition.version}`, {
+      method: 'PUT',
+      body: {
+        zip_file: buffer,
+        source_zip_file: sourceBuffer,
+        skip_validation: skipValidation,
+      },
+      extraHeaders: headers,
+    });
+  } catch (err) {
+    endSpinner({ success: false });
+    // 409 from the backend specifically signals that the last changes were from a partner
+    // and this is a staff user which is likely
+    if (err.status === 409) {
+      throw new Error(
+        `The latest integration changes appear to be from a partner. OK to overwrite?` +
+          ` If so, run this command again using the '--overwrite-partner-changes' flag.`,
+      );
+    }
+
+    // Don't ignore other errors, re-throw them
+    throw err;
+  } finally {
+    endSpinner();
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
This PR is similar to https://github.com/zapier/zapier-platform/pull/942, where we added a `--force` option to `env:set` and `env:unset`. 

In this MR, we add a `--overwrite-partner-changes` flag to force a `zapier push` to skip a new check when the user is a Zapier staff and the latest integration version contains partner-pushed code ("clobbering" protection).

![Screen Shot 2025-01-29 at 4 09 09 PM](https://github.com/user-attachments/assets/55054c97-5e6c-47fd-8b77-9c00a63bbdd2)
