### PR TITLE
fix(cli) - Fix invoke auth label 

### DIFF
--- a/packages/cli/src/oclif/commands/invoke.js
+++ b/packages/cli/src/oclif/commands/invoke.js
@@ -259,7 +259,7 @@ const getAuthLabel = async (labelTemplate, authData, meta, zcacheTestObj) => {
   const testResult = await testAuth(authData, meta, zcacheTestObj);
   labelTemplate = labelTemplate.replace('__', '.');
   const tpl = _.template(labelTemplate, { interpolate: /{{([\s\S]+?)}}/g });
-  return tpl({ bundle: { authData, inputData: testResult } });
+  return tpl({ ...testResult, bundle: { authData, inputData: testResult } });
 };
 
 const getLabelForDynamicDropdown = (obj, preferredKey, fallbackKey) => {

--- a/packages/cli/src/oclif/commands/invoke.js
+++ b/packages/cli/src/oclif/commands/invoke.js
@@ -259,7 +259,7 @@ const getAuthLabel = async (labelTemplate, authData, meta, zcacheTestObj) => {
   const testResult = await testAuth(authData, meta, zcacheTestObj);
   labelTemplate = labelTemplate.replace('__', '.');
   const tpl = _.template(labelTemplate, { interpolate: /{{([\s\S]+?)}}/g });
-  return tpl(testResult);
+  return tpl({ bundle: { authData, inputData: testResult } });
 };
 
 const getLabelForDynamicDropdown = (obj, preferredKey, fallbackKey) => {


### PR DESCRIPTION
For string `connectionLabel`, running `zapier invoke auth test` prints the output of the `Authentication.test` results. 
For `zapier invoke auth label`, this returns an error: `Error: bundle is not defined`. While the two are similar, in that calls `testAuth`, the `label` option has additional template rendering where it looks for `bundle` and the `testResult` value does not. 
To fix, wrap the data in a bundle object. 