### PR TITLE
fix(schema): Reference the proper FieldSchema as necessary

### DIFF
--- a/packages/core/types/zapier.generated.d.ts
+++ b/packages/core/types/zapier.generated.d.ts
@@ -361,7 +361,7 @@ export interface AuthField {
    *
    * @minItems 1
    */
-  children?: Field[];
+  children?: AuthField[];
 
   /** Is this field a key/value input? */
   dict?: boolean;
@@ -703,7 +703,7 @@ export interface InputField {
    *
    * @minItems 1
    */
-  children?: Field[];
+  children?: InputField[];
 
   /** Is this field a key/value input? */
   dict?: boolean;
@@ -807,7 +807,7 @@ export interface OutputField {
    *
    * @minItems 1
    */
-  children?: Field[];
+  children?: OutputField[];
 
   /** Is this field a key/value input? */
   dict?: boolean;

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -176,7 +176,7 @@ Key | Required | Type | Description
 `required` | no | `boolean` | If this value is required or not. This defaults to `true`.
 `default` | no | `string` | A default value that is saved the first time a Zap is created.
 `list` | no | `boolean` | Acts differently when used in inputFields vs. when used in outputFields. In inputFields: Can a user provide multiples of this field? In outputFields: Does this field return an array of items of type `type`?
-`children` | no | `array`[undefined] | An array of child fields that define the structure of a sub-object for this field. Usually used for line items.
+`children` | no | `array`[[/AuthFieldSchema](#authfieldschema)] | An array of child fields that define the structure of a sub-object for this field. Usually used for line items.
 `dict` | no | `boolean` | Is this field a key/value input?
 `helpText` | no | `string` | A human readable description of this value (IE: "The first part of a full name."). You can use Markdown.
 `placeholder` | no | `string` | An example value that is not saved.
@@ -1229,7 +1229,7 @@ Key | Required | Type | Description
 `required` | no | `boolean` | If this value is required or not.
 `default` | no | `string` | A default value that is saved the first time a Zap is created.
 `list` | no | `boolean` | Acts differently when used in inputFields vs. when used in outputFields. In inputFields: Can a user provide multiples of this field? In outputFields: Does this field return an array of items of type `type`?
-`children` | no | `array`[undefined] | An array of child fields that define the structure of a sub-object for this field. Usually used for line items.
+`children` | no | `array`[[/InputFieldSchema](#inputfieldschema)] | An array of child fields that define the structure of a sub-object for this field. Usually used for line items.
 `dict` | no | `boolean` | Is this field a key/value input?
 `helpText` | no | `string` | A human readable description of this value (IE: "The first part of a full name."). You can use Markdown.
 `dynamic` | no | [/RefResourceSchema](#refresourceschema) | A reference to a trigger that will power a dynamic dropdown.
@@ -1265,7 +1265,7 @@ Key | Required | Type | Description
 * `{ key: 'abc', choices: [ 3 ] }` - _Invalid value for key: choices (if an array, must be of either string or FieldChoiceWithLabelSchema)_
 * `{ key: 'abc', choices: [ { label: 'Red', value: '#f00' } ] }` - _Invalid value for key: choices (if an array of FieldChoiceWithLabelSchema, must provide key `sample`)_
 * `{ key: 'abc', choices: 'mobile' }` - _Invalid value for key: choices (must be either object or array)_
-* `{ key: 'abc', children: [ '$func$2$f$' ] }` - _Invalid value for key: children (must be array of FieldSchema)_
+* `{ key: 'abc', children: [ '$func$2$f$' ] }` - _Invalid value for key: children (must be array of InputFieldSchema)_
 
 -----
 
@@ -1375,7 +1375,7 @@ Key | Required | Type | Description
 `required` | no | `boolean` | If this value is required or not.
 `default` | no | `string` | A default value that is saved the first time a Zap is created.
 `list` | no | `boolean` | Acts differently when used in inputFields vs. when used in outputFields. In inputFields: Can a user provide multiples of this field? In outputFields: Does this field return an array of items of type `type`?
-`children` | no | `array`[undefined] | An array of child fields that define the structure of a sub-object for this field. Usually used for line items.
+`children` | no | `array`[[/OutputFieldSchema](#outputfieldschema)] | An array of child fields that define the structure of a sub-object for this field. Usually used for line items.
 `dict` | no | `boolean` | Is this field a key/value input?
 `primary` | no | `boolean` | Use this field as part of the primary key for deduplication. You can set multiple fields as "primary", provided they are unique together. If no fields are set, Zapier will default to using the `id` field. `primary` only makes sense for `outputFields`. It only works in static `outputFields`; will not work in custom/dynamic `outputFields`. For more information, see [How deduplication works in Zapier](https://platform.zapier.com/build/deduplication).
 `steadyState` | no | `boolean` | Prevents triggering on new output until all values for fields with this property remain unchanged for 2 polls. It can be used to, e.g., not trigger on a new contact until the contact has completed typing their name. NOTE that this only applies to the `outputFields` of polling triggers.
@@ -1396,7 +1396,7 @@ Key | Required | Type | Description
 * `{ key: 'abc', choices: [ 3 ] }` - _Invalid value for key: choices (if an array, must be of either string or FieldChoiceWithLabelSchema)_
 * `{ key: 'abc', choices: [ { label: 'Red', value: '#f00' } ] }` - _Invalid value for key: choices (if an array of FieldChoiceWithLabelSchema, must provide key `sample`)_
 * `{ key: 'abc', choices: 'mobile' }` - _Invalid value for key: choices (must be either object or array)_
-* `{ key: 'abc', children: [ '$func$2$f$' ] }` - _Invalid value for key: children (must be array of FieldSchema)_
+* `{ key: 'abc', children: [ '$func$2$f$' ] }` - _Invalid value for key: children (must be array of OutputFieldSchema)_
 
 -----
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -320,7 +320,7 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "/FieldSchema"
+            "$ref": "/AuthFieldSchema"
           },
           "description": "An array of child fields that define the structure of a sub-object for this field. Usually used for line items.",
           "minItems": 1
@@ -710,7 +710,7 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "/FieldSchema"
+            "$ref": "/InputFieldSchema"
           },
           "description": "An array of child fields that define the structure of a sub-object for this field. Usually used for line items.",
           "minItems": 1
@@ -802,7 +802,7 @@
         "children": {
           "type": "array",
           "items": {
-            "$ref": "/FieldSchema"
+            "$ref": "/OutputFieldSchema"
           },
           "description": "An array of child fields that define the structure of a sub-object for this field. Usually used for line items.",
           "minItems": 1

--- a/packages/schema/lib/schemas/AuthFieldSchema.js
+++ b/packages/schema/lib/schemas/AuthFieldSchema.js
@@ -12,6 +12,13 @@ module.exports = makeSchema(
     type: 'object',
     properties: {
       ...FieldSchema.schema.properties,
+      children: {
+        type: 'array',
+        items: { $ref: '/AuthFieldSchema' },
+        description:
+          'An array of child fields that define the structure of a sub-object for this field. Usually used for line items.',
+        minItems: 1,
+      },
       helpText: {
         description:
           'A human readable description of this value (IE: "The first part of a full name."). You can use Markdown.',

--- a/packages/schema/lib/schemas/InputFieldSchema.js
+++ b/packages/schema/lib/schemas/InputFieldSchema.js
@@ -14,6 +14,13 @@ module.exports = makeSchema(
     required: ['key'],
     properties: {
       ...FieldSchema.schema.properties,
+      children: {
+        type: 'array',
+        items: { $ref: '/InputFieldSchema' },
+        description:
+          'An array of child fields that define the structure of a sub-object for this field. Usually used for line items.',
+        minItems: 1,
+      },
       helpText: {
         description:
           'A human readable description of this value (IE: "The first part of a full name."). You can use Markdown.',
@@ -115,7 +122,7 @@ module.exports = makeSchema(
       {
         example: { key: 'abc', children: ['$func$2$f$'] },
         reason:
-          'Invalid value for key: children (must be array of FieldSchema)',
+          'Invalid value for key: children (must be array of InputFieldSchema)',
       },
     ],
     additionalProperties: false,

--- a/packages/schema/lib/schemas/OutputFieldSchema.js
+++ b/packages/schema/lib/schemas/OutputFieldSchema.js
@@ -11,6 +11,13 @@ module.exports = makeSchema(
     required: ['key'],
     properties: {
       ...FieldSchema.schema.properties,
+      children: {
+        type: 'array',
+        items: { $ref: '/OutputFieldSchema' },
+        description:
+          'An array of child fields that define the structure of a sub-object for this field. Usually used for line items.',
+        minItems: 1,
+      },
       type: {
         description:
           'The type of this value. Field type of `file` will accept either a file object or a string. If a URL is provided in the string, Zapier will automatically make a GET for that file. Otherwise, a .txt file will be generated.',
@@ -72,7 +79,7 @@ module.exports = makeSchema(
       {
         example: { key: 'abc', children: ['$func$2$f$'] },
         reason:
-          'Invalid value for key: children (must be array of FieldSchema)',
+          'Invalid value for key: children (must be array of OutputFieldSchema)',
       },
     ],
     additionalProperties: false,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
With the /FieldSchema now hidden, its references are displayed `undefined` in https://github.com/zapier/zapier-platform/blob/f59896291048bfe858e967689eabe86c58133c35/packages/schema/docs/build/schema.md#inputfieldschema

![](https://cdn.zappy.app/3f88eb9ded8d76636b9cf496aa91836a.png)
