### PR TITLE
PDE-5774 fix(core): Catch HTTP 500 along with status codes >500 in RPC client

### DIFF
--- a/packages/core/src/tools/create-rpc-client.js
+++ b/packages/core/src/tools/create-rpc-client.js
@@ -108,7 +108,7 @@ const createRpcClient = (event) => {
       try {
         res = await request(req);
 
-        if (res.status > 500) {
+        if (res.status >= 500) {
           throw new Error('Unable to reach the RPC server');
         }
         if (res.content) {

--- a/packages/core/test/tools/mocky.js
+++ b/packages/core/test/tools/mocky.js
@@ -51,10 +51,10 @@ const mockRpcGetPresignedPostCall = (key) => {
     });
 };
 
-const mockRpcFail = (error) => {
+const mockRpcFail = (error, status = 400) => {
   nock(FAKE_ZAPIER_URL)
     .post(RPC_URL_PATH)
-    .reply(400, (uri, requestBody) => {
+    .reply(status, (uri, requestBody) => {
       const id = JSON.parse(requestBody).id;
       return { error, id };
     });

--- a/packages/core/test/tools/mocky.js
+++ b/packages/core/test/tools/mocky.js
@@ -54,7 +54,7 @@ const mockRpcGetPresignedPostCall = (key) => {
 const mockRpcFail = (error) => {
   nock(FAKE_ZAPIER_URL)
     .post(RPC_URL_PATH)
-    .reply(500, (uri, requestBody) => {
+    .reply(400, (uri, requestBody) => {
       const id = JSON.parse(requestBody).id;
       return { error, id };
     });

--- a/packages/core/test/tools/rpc-client.js
+++ b/packages/core/test/tools/rpc-client.js
@@ -16,9 +16,9 @@ describe('rpc client', () => {
 
   it('should handle an explosion', () => {
     // mock 3 explosions due to retry
-    mocky.mockRpcFail('this is an expected explosion');
-    mocky.mockRpcFail('this is an expected explosion');
-    mocky.mockRpcFail('this is an expected explosion');
+    mocky.mockRpcFail('this is an expected explosion', 500);
+    mocky.mockRpcFail('this is an expected explosion', 500);
+    mocky.mockRpcFail('this is an expected explosion', 500);
 
     return rpc('explode')
       .then(() => {
@@ -26,7 +26,7 @@ describe('rpc client', () => {
       })
       .catch((err) => {
         err.message.should.eql(
-          'RPC request failed after 3 attempts: this is an expected explosion',
+          'RPC request failed after 3 attempts: Unable to reach the RPC server',
         );
       });
   });


### PR DESCRIPTION
We see `Got id undefined but expected ID_NUMBER when calling RPC` errors when it comes to RPC endpoints returning a 500 response. Inspecting the code, I believe we should likely catch the error before we check `res.content.id`.


After this change is released, we should update our log stream alarms to ALSO consider the `Unable to reach the RPC server` text instead of just the `Got id ${res.content.id} but expected ${id} when calling RPC` text. Both texts should be viable since we could have apps still running on previous versions.