### PR TITLE
PDE-5244 fix(cli,core): make zapierwrapper.mjs statically analyzable, more test cases

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -55,6 +55,7 @@ const requiredFiles = async ({ cwd, entryPoints }) => {
 
   const result = await esbuild.build({
     entryPoints,
+    outdir: './build',
     bundle: true,
     platform: 'node',
     metafile: true,
@@ -158,10 +159,15 @@ const writeZipFromPaths = (dir, zipPath, paths) => {
 };
 
 const makeZip = async (dir, zipPath, disableDependencyDetection) => {
-  const entryPoints = [
-    path.resolve(dir, 'zapierwrapper.js'),
-    path.resolve(dir, 'index.js'), // For CommonJS integration
-  ];
+  const entryPoints = [path.resolve(dir, 'zapierwrapper.js')];
+
+  const indexPath = path.resolve(dir, 'index.js');
+  if (fs.existsSync(indexPath)) {
+    // Necessary for CommonJS integrations. The zapierwrapper they use require()
+    // the index.js file using a variable. esbuild can't detect it, so we need
+    // to add it here specifically.
+    entryPoints.push(indexPath);
+  }
 
   let paths;
 

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -19,13 +19,7 @@ const {
 
 const constants = require('../constants');
 
-const {
-  writeFile,
-  readFile,
-  copyDir,
-  ensureDir,
-  removeDir,
-} = require('./files');
+const { writeFile, copyDir, ensureDir, removeDir } = require('./files');
 
 const {
   prettyJSONstringify,
@@ -40,6 +34,8 @@ const {
   upload: _uploadFunc,
   validateApp,
 } = require('./api');
+
+const { copyZapierWrapper } = require('./zapierwrapper');
 
 const checkMissingAppInfo = require('./check-missing-app-info');
 
@@ -279,12 +275,6 @@ const listWorkspaces = (workspaceRoot) => {
   );
 };
 
-const isESM = (cwd) => {
-  // Any other ways that the package can be an ESM package?
-  const pJson = require(path.resolve(cwd, 'package.json'));
-  return pJson.type === 'module';
-};
-
 const _buildFunc = async ({
   skipNpmInstall = false,
   disableDependencyDetection = false,
@@ -388,22 +378,7 @@ const _buildFunc = async ({
     startSpinner('Applying entry point files');
   }
 
-  const wrapperFilename = isESM(tmpDir)
-    ? 'zapierwrapper.mjs'
-    : 'zapierwrapper.js';
-  const zapierWrapperBuf = await readFile(
-    path.join(
-      tmpDir,
-      'node_modules',
-      constants.PLATFORM_PACKAGE,
-      'include',
-      wrapperFilename,
-    ),
-  );
-  await writeFile(
-    path.join(tmpDir, 'zapierwrapper.js'),
-    zapierWrapperBuf.toString(),
-  );
+  await copyZapierWrapper(corePath, tmpDir);
 
   if (printProgress) {
     endSpinner();

--- a/packages/cli/src/utils/local.js
+++ b/packages/cli/src/utils/local.js
@@ -1,9 +1,9 @@
 const { findCorePackageDir, runCommand } = require('./misc');
 const { copyZapierWrapper, deleteZapierWrapper } = require('./zapierwrapper');
 
-const getLocalAppHandler = async () => {
+const getLocalAppHandler = async (appDir, shouldDeleteWrapper) => {
+  appDir = appDir || process.cwd();
   const corePackageDir = findCorePackageDir();
-  const appDir = process.cwd();
   const wrapperPath = await copyZapierWrapper(corePackageDir, appDir);
 
   let app;
@@ -22,7 +22,9 @@ const getLocalAppHandler = async () => {
     }
     throw err;
   } finally {
-    await deleteZapierWrapper(appDir);
+    if (shouldDeleteWrapper) {
+      await deleteZapierWrapper(appDir);
+    }
   }
 
   return (event, ctx, callback) => {
@@ -35,8 +37,8 @@ const getLocalAppHandler = async () => {
 };
 
 // Runs a local app command (./index.js) like {command: 'validate'};
-const localAppCommand = async (event) => {
-  const handler = await getLocalAppHandler();
+const localAppCommand = async (event, appDir, shouldDeleteWrapper = false) => {
+  const handler = await getLocalAppHandler(appDir, shouldDeleteWrapper);
   return new Promise((resolve, reject) => {
     handler(event, {}, (err, resp) => {
       if (err) {

--- a/packages/cli/src/utils/zapierwrapper.js
+++ b/packages/cli/src/utils/zapierwrapper.js
@@ -1,0 +1,46 @@
+// Utility functions that helps you copy and delete the Lambda function entry
+// point zapierwrapper.mjs or zapierwrapper.js to the integration directory.
+
+const { readFile, writeFile, rm } = require('node:fs/promises');
+const { join } = require('node:path');
+
+// We have two different versions of zapierwrapper: the .mjs one for ESM and the
+// .js one for CommonJS. To copy the right one, we check the module type in the
+// integration's package.json.
+//
+// For esbuild to perform static analysis, zapierwrapper.mjs can only
+// import('packageName') where the packageName must be a static string literal.
+// It can't import(packageName) where packageName is a variable. So in
+// zapierwrapper.mjs, there's a placeholder {REPLACE_ME_PACKAGE_NAME} that
+// we'll replace with the actual package name.
+const copyZapierWrapper = async (corePackageDir, appDir) => {
+  const appPackageJson = require(join(appDir, 'package.json'));
+  let wrapperFilename;
+  if (appPackageJson.type === 'module') {
+    wrapperFilename = 'zapierwrapper.mjs';
+  } else {
+    wrapperFilename = 'zapierwrapper.js';
+  }
+  const wrapperPath = join(corePackageDir, 'include', wrapperFilename);
+  const wrapperText = (await readFile(wrapperPath, 'utf8')).replace(
+    '{REPLACE_ME_PACKAGE_NAME}',
+    appPackageJson.name,
+  );
+  const wrapperDest = join(appDir, 'zapierwrapper.js');
+  await writeFile(wrapperDest, wrapperText);
+  return wrapperDest;
+};
+
+const deleteZapierWrapper = async (appDir) => {
+  const wrapperPath = join(appDir, 'zapierwrapper.js');
+  try {
+    await rm(wrapperPath);
+  } catch (err) {
+    // ignore
+  }
+};
+
+module.exports = {
+  copyZapierWrapper,
+  deleteZapierWrapper,
+};

--- a/packages/core/include/zapierwrapper.mjs
+++ b/packages/core/include/zapierwrapper.mjs
@@ -1,12 +1,20 @@
 // not intended to be loaded via require() or import() - copied during build step
 import zapier from 'zapier-platform-core';
-import { promises as fs } from 'fs';
-import path from 'node:path';
 
-const packageJsonPath = path.resolve(process.cwd(), 'package.json');
-const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
-const packageName = packageJson.name;
+let appRaw;
+try {
+  appRaw = await import('{REPLACE_ME_PACKAGE_NAME}');
+} catch (err) {
+  if (err.code === 'ERR_MODULE_NOT_FOUND') {
+    err.message +=
+      '\nMake sure you specify a valid entry point using `exports` in package.json.';
+  }
+  throw err;
+}
 
-// https://nodejs.org/docs/latest-v22.x/api/all.html#all_packages_self-referencing-a-package-using-its-name
-const appRaw = (await import(packageName)).default;
+// Allows a developer to use named exports or default export in entry point
+if (appRaw && appRaw.default) {
+  appRaw = appRaw.default;
+}
+
 export const handler = zapier.createAppHandler(appRaw);

--- a/packages/core/test/zapierwrapper.js
+++ b/packages/core/test/zapierwrapper.js
@@ -1,0 +1,191 @@
+const assert = require('node:assert/strict');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+const {
+  mkdtemp,
+  rm,
+  writeFile,
+  readFile,
+  copyFile,
+  mkdir,
+  realpath,
+} = require('node:fs/promises');
+
+describe('zapierwrapper.js in CommonJS', () => {
+  let tempDir;
+  beforeEach(async () => {
+    // realpath is needed to resolve symlinks. Not sure why macOS returns a
+    // symlink /var instead of /private/var for tmpdir()
+    tempDir = await realpath(await mkdtemp(join(tmpdir(), 'zapier-test-')));
+
+    await writeFile(join(tempDir, 'index.js'), `module.exports = {} }`);
+
+    const wrapperPath = resolve(__dirname, '../include/zapierwrapper.js');
+    await copyFile(wrapperPath, join(tempDir, 'zapierwrapper.js'));
+
+    // Make a fake zapier-platform-core
+    const coreDir = join(tempDir, 'node_modules', 'zapier-platform-core');
+    await mkdir(coreDir, { recursive: true });
+    await writeFile(
+      join(coreDir, 'package.json'),
+      JSON.stringify({
+        name: 'zapier-platform-core',
+        version: '1.0.0',
+        main: 'index.js',
+      }),
+    );
+    // This fake Lambda handler just returns a function that returns the input
+    await writeFile(
+      join(coreDir, 'index.js'),
+      'module.exports = { createAppHandler: (appPath) => function() { return appPath; } };',
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true });
+  });
+
+  it('should load index.js without `main` or `exports` in package.json', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+      }),
+    );
+
+    const wrapper = require(join(tempDir, 'zapierwrapper.js'));
+    assert.equal(wrapper.handler(), join(tempDir, 'index.js'));
+  });
+
+  it('should load always index.js, ignoring `main` in package.json', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+        // Maybe someday we'll want to respect `main` for CommonJS
+        main: 'app.js',
+      }),
+    );
+
+    const wrapper = require(join(tempDir, 'zapierwrapper.js'));
+    assert.equal(wrapper.handler(), join(tempDir, 'index.js'));
+  });
+});
+
+describe('zapierwrapper.mjs in ESM', () => {
+  let tempDir;
+  beforeEach(async () => {
+    // realpath is needed to resolve symlinks. Not sure why macOS returns a
+    // symlink /var instead of /private/var for tmpdir()
+    tempDir = await realpath(await mkdtemp(join(tmpdir(), 'zapier-test-')));
+
+    const wrapperPath = resolve(__dirname, '../include/zapierwrapper.mjs');
+    const wrapperText = (await readFile(wrapperPath, 'utf8')).replace(
+      '{REPLACE_ME_PACKAGE_NAME}',
+      'test-app',
+    );
+    await writeFile(join(tempDir, 'zapierwrapper.js'), wrapperText);
+
+    // Make a fake zapier-platform-core
+    const coreDir = join(tempDir, 'node_modules', 'zapier-platform-core');
+    await mkdir(coreDir, { recursive: true });
+    await writeFile(
+      join(coreDir, 'package.json'),
+      JSON.stringify({
+        name: 'zapier-platform-core',
+        version: '1.0.0',
+        main: 'index.js',
+      }),
+    );
+    // This fake Lambda handler just returns a function that returns the input
+    await writeFile(
+      join(coreDir, 'index.js'),
+      'module.exports = { createAppHandler: (appRaw) => function() { return appRaw; } };',
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true });
+  });
+
+  it('should error if no `exports` in package.json', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+        main: 'index.js',
+        type: 'module',
+      }),
+    );
+
+    await assert.rejects(async () => {
+      await import(join(tempDir, 'zapierwrapper.js'));
+    }, /specify a valid entry point using `exports`/);
+  });
+
+  it('should load default export', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+        exports: './index.js',
+        type: 'module',
+      }),
+    );
+    await writeFile(
+      join(tempDir, 'index.js'),
+      "export default { name: 'i-am-index' };",
+    );
+
+    const wrapper = await import(join(tempDir, 'zapierwrapper.js'));
+    assert.deepEqual(wrapper.handler(), { name: 'i-am-index' });
+  });
+
+  it('should load named exports', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+        exports: './index.js',
+        type: 'module',
+      }),
+    );
+    await writeFile(
+      join(tempDir, 'index.js'),
+      "export const name = 'i-am-index';\n" +
+        "export const platformVersion = '1.2.3';",
+    );
+
+    const wrapper = await import(join(tempDir, 'zapierwrapper.js'));
+    const exported = wrapper.handler();
+    assert.equal(exported.name, 'i-am-index');
+    assert.equal(exported.platformVersion, '1.2.3');
+  });
+
+  it('should load conditional exports', async () => {
+    await writeFile(
+      join(tempDir, 'package.json'),
+      JSON.stringify({
+        name: 'test-app',
+        version: '1.0.0',
+        exports: {
+          require: './app.cjs',
+          import: './app.mjs',
+        },
+        type: 'module',
+      }),
+    );
+    await writeFile(
+      join(tempDir, 'app.mjs'),
+      "export default { name: 'i-am-app-mjs' };",
+    );
+
+    const wrapper = await import(join(tempDir, 'zapierwrapper.js'));
+    assert.deepEqual(wrapper.handler(), { name: 'i-am-app-mjs' });
+  });
+});


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Summary:

* Make `zapierwrapper.mjs` statically analyzable
* Add unit tests for `zapierwrapper.js` and `zapierwrapper.mjs`
* Remove the hard-coded `index.js` from `getLocalAppHandler()`

### Make `zapierwrapper.mjs` statically analyzable

I found that `zapier build` produced bad `build.zip`. It could miss the entry point specified in the `exports` field in the integration's `package.json`.

Why? `zapierwrapper.mjs` previously passed a variable to `import()` that couldn't be [statically analyzed](https://esbuild.github.io/api/#non-analyzable-imports) by esbuild. This PR updates it to use a placeholder string (`{REPLACE_ME_PACKAGE_NAME}`) that gets replaced with the integration package name during the build process. This allows for proper static analysis by esbuild.

### Add unit tests for `zapierwrapper.js` and `zapierwrapper.mjs`

This PR adds test coverage for both `zapierwrapper.js` and `zapierwrapper.mjs`. The tests verify that the wrappers correctly handle different `package.json` configurations, including various export patterns (conditional exports, default exports, and named exports).

### Remove the hard-coded `index.js` from `getLocalAppHandler()`

The local app handler powers some CLI commands such as `zapier describe` and `zapier validate`. Previously, it assumed that `index.js` was always the entry point. This PR removes this assumption, respecting the `exports` field specified in `package.json`.

How? Before running the CLI command, we copy the corresponding `zapierwrapper` file to the integration directory. Then `getLocalAppHandler()` can just `import('./zapierwrapper.js')`, letting `zapierwrapper.js` find out the entry point of the integration. When the CLI command finishes, we delete `zapierwrapper.js` from the integration directory.