### PR TITLE
PDE-5888 fix(cli): location of SyntaxError not showing even if --debug is on

### DIFF
--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -18,7 +18,7 @@ class ZapierBaseCommand extends Command {
 
     if (this.flags.debug) {
       this.debug.enabled = true; // enables this.debug on the command
-      require('debug').enable('zapier:*'); // enables all further spawned functions, like API
+      require('debug').enable('zapier:*,oclif:zapier:*'); // enables all further spawned functions, like API
     }
 
     this.debug('argv is', this.argv);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

While working on #982, I noticed `zapier` CLI commands aren't showing the location of a syntax error in the integration code, even if `--debug` is enabled. Example:

```
$ zapier describe --debug
✖ Fetching integration info
 ›   Error: Unexpected identifier 'authentication'
```

This appears to be a regression introduced by #890. The newer version of oclif uses namespace `oclif:` [by default](https://github.com/oclif/core/blob/e788c037920b586b06bb1cd6ccccff87da7784f2/src/logger.ts#L6-L8) for the [`debug`](https://www.npmjs.com/package/debug) package. By adding `oclif:zapier:*` to `require('debug').enable()`, the detailed info is back:

```
$ zapier-dev describe --debug
  oclif:zapier:describe argv is [] +0ms
  oclif:zapier:describe args are {} +0ms
  oclif:zapier:describe flags are { debug: true, format: 'table' } +0ms
  oclif:zapier:describe ------------ +0ms
✖ Fetching integration info
  oclif:zapier:describe /Users/eliang/Projects/zapps/auth-json-server/index.js:8
  oclif:zapier:describe   authentication: authentication.config,
  oclif:zapier:describe   ^^^^^^^^^^^^^^
  oclif:zapier:describe
  oclif:zapier:describe SyntaxError: Unexpected identifier 'authentication'
  oclif:zapier:describe     at wrapSafe (node:internal/modules/cjs/loader:1512:18)
  oclif:zapier:describe     at Module._compile (node:internal/modules/cjs/loader:1534:20)
  oclif:zapier:describe     at Object..js (node:internal/modules/cjs/loader:1699:10)
  oclif:zapier:describe     at Module.load (node:internal/modules/cjs/loader:1313:32)
  oclif:zapier:describe     at Function._load (node:internal/modules/cjs/loader:1123:12)
  oclif:zapier:describe     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
  oclif:zapier:describe     at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
  oclif:zapier:describe     at Module.require (node:internal/modules/cjs/loader:1335:12)
  oclif:zapier:describe     at require (node:internal/modules/helpers:136:16)
  oclif:zapier:describe     at getLocalAppHandler (/Users/eliang/Projects/zapier-platform/packages/cli/src/utils/local.js:20:14)
  oclif:zapier:describe     at localAppCommand (/Users/eliang/Projects/zapier-platform/packages/cli/src/utils/local.js:43:19)
  oclif:zapier:describe     at DescribeCommand.perform (/Users/eliang/Projects/zapier-platform/packages/cli/src/oclif/commands/describe.js:73:7)
  oclif:zapier:describe     at DescribeCommand.run (/Users/eliang/Projects/zapier-platform/packages/cli/src/oclif/ZapierBaseCommand.js:40:12)
  oclif:zapier:describe     at async DescribeCommand._run (/Users/eliang/Projects/zapier-platform/node_modules/@oclif/core/lib/command.js:312:22)
  oclif:zapier:describe     at async Config.runCommand (/Users/eliang/Projects/zapier-platform/node_modules/@oclif/core/lib/config/config.js:435:25)
  oclif:zapier:describe     at async run (/Users/eliang/Projects/zapier-platform/node_modules/@oclif/core/lib/main.js:95:16) +2ms
 ›   Error: Unexpected identifier 'authentication'
```