### PR TITLE
[PDE-5913] fix(schema): Update schema doc url template to reference GitHub markdown

### DIFF
--- a/packages/schema/lib/constants.js
+++ b/packages/schema/lib/constants.js
@@ -2,7 +2,7 @@ module.exports = {
   ROOT_GITHUB: 'https://github.com/zapier/zapier-platform',
   DOCS_PATH: 'docs/build/schema.md',
   DOC_URL_TEMPLATE:
-    'https://platform.zapier.com/cli_docs/schema<%= anchor %>@<%= version %>',
+    'https://github.com/zapier/zapier-platform/blob/zapier-platform-cli%40<%= version %>/packages/schema/docs/build/schema.md<%= anchor %>',
   SKIP_KEY: '_skipTest',
   // the following pairs of keys can't be used together in FieldSchema
   // they're stored here because they're used in a few places

--- a/packages/schema/test/readability.js
+++ b/packages/schema/test/readability.js
@@ -146,7 +146,6 @@ describe('readability', () => {
     results.errors[0].property.should.eql(
       'instance.operation.inputFields[0].choices',
     );
-    console.log(results.errors[0].docLinks[0]);
     should(
       results.errors[0].docLinks[0].includes('schema.md#fieldchoicesschema'),
     ).be.true();

--- a/packages/schema/test/readability.js
+++ b/packages/schema/test/readability.js
@@ -146,8 +146,9 @@ describe('readability', () => {
     results.errors[0].property.should.eql(
       'instance.operation.inputFields[0].choices',
     );
+    console.log(results.errors[0].docLinks[0]);
     should(
-      results.errors[0].docLinks[0].includes('schema#fieldchoicesschema'),
+      results.errors[0].docLinks[0].includes('schema.md#fieldchoicesschema'),
     ).be.true();
     should(results.errors[0].property.endsWith('instance')).be.false();
   });


### PR DESCRIPTION
This PR is similar to https://github.com/zapier/zapier-platform/pull/947 in terms of fixing doc URL and anchor tags, but here we target the schema validation error link.

```js
const { makeDocLink } = require('./lib/utils/links')
makeDocLink('fieldschema')

'https://github.com/zapier/zapier-platform/blob/zapier-platform-cli%4016.3.1/packages/schema/docs/build/schema.md#fieldschema'
```

The new docs on https://docs.zapier.com/ don't host the schema reference. It instead links out to the GitHub schema page. So this PR also modifies the URL to now reference the GitHub source.