### PR TITLE
[PDE-5886] feat(cli): Add warning to `zapier deprecate` command

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -164,7 +164,7 @@ Zapier will immediately send emails warning users of the deprecation if a date l
 
 There are other side effects: they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
 
-Do not use deprecation if you have non-breaking changes, such as:
+Do not use deprecation if you only have non-breaking changes, such as:
 - Fixing help text
 - Adding new triggers/actions
 - Improving existing functionality

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -160,17 +160,22 @@ This only works if there are no users or Zaps on that version. You will probably
 
 Use this when an integration version will not be supported or start breaking at a known date.
 
-Zapier will send an email warning users of the deprecation once a date is set, they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
+Zapier will immediately send emails warning users of the deprecation if a date less than 30 days in the future is set, otherwise the emails will be sent exactly 30 days before the configured deprecation date.
 
-After the deprecation date has passed it will be safe to delete that integration version.
+There are other side effects: they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
 
-Do not use this if you have non-breaking changes, such as fixing help text.
+Do not use deprecation if you have non-breaking changes, such as:
+- Fixing help text
+- Adding new triggers/actions
+- Improving existing functionality
+- other bug fixes that don't break existing automations.
 
 **Arguments**
 * (required) `version` | The version to deprecate.
 * (required) `date` | The date (YYYY-MM-DD) when Zapier will make the specified version unavailable.
 
 **Flags**
+* `-f, --force` | Skip confirmation prompt. Use with caution.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -18,14 +18,15 @@ class DeprecateCommand extends BaseCommand {
         `${colors.yellow('If your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
     );
 
-    const shouldContinue = await this.confirm(
-      'Are you sure you want to deprecate this version? This will notify users that their Zaps or other automations will stop working after the specified date.' +
-        (hasActiveUsers
-          ? `\n\nThis version has ${versionInfo.user_count} active user(s). Strongly consider migrating users to another version before deprecating!`
-          : ''),
-    );
-
-    if (!shouldContinue) {
+    if (
+      !this.flags.force &&
+      !(await this.confirm(
+        'Are you sure you want to deprecate this version? This will notify users that their Zaps or other automations will stop working after the specified date.' +
+          (hasActiveUsers
+            ? `\n\nThis version has ${versionInfo.user_count} active user(s). Strongly consider migrating users to another version before deprecating!`
+            : ''),
+      ))
+    ) {
       this.log('\nDeprecation cancelled.');
       return;
     }

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -15,7 +15,7 @@ class DeprecateCommand extends BaseCommand {
 
     this.log(
       `${colors.yellow('Warning: Deprecation is an irreversible action that will eventually block access to this version.')}\n` +
-        `${colors.yellow('If your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
+        `${colors.yellow('If all your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
     );
 
     if (

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -77,7 +77,7 @@ Zapier will immediately send emails warning users of the deprecation if a date l
 
 There are other side effects: they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
 
-Do not use deprecation if you have non-breaking changes, such as:
+Do not use deprecation if you only have non-breaking changes, such as:
 - Fixing help text
 - Adding new triggers/actions
 - Improving existing functionality

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -1,15 +1,37 @@
 const BaseCommand = require('../ZapierBaseCommand');
-const { Args } = require('@oclif/core');
+const { Args, Flags } = require('@oclif/core');
 const { buildFlags } = require('../buildFlags');
+const colors = require('colors/safe');
 
-const { callAPI } = require('../../utils/api');
+const { callAPI, getSpecificVersionInfo } = require('../../utils/api');
 
 class DeprecateCommand extends BaseCommand {
   async perform() {
     const app = await this.getWritableApp();
     const { version, date } = this.args;
+
+    const versionInfo = await getSpecificVersionInfo(version);
+    const hasActiveUsers = versionInfo.user_count && versionInfo.user_count > 0;
+
     this.log(
-      `Preparing to deprecate version ${version} your app "${app.title}".\n`,
+      `${colors.yellow('Warning: Deprecation is an irreversible action that will eventually block access to this version.')}\n` +
+        `${colors.yellow('If your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
+    );
+
+    const shouldContinue = await this.confirm(
+      'Are you sure you want to deprecate this version? This will notify users that their Zaps or other automations will stop working after the specified date.' +
+        (hasActiveUsers
+          ? `\n\nThis version has ${versionInfo.user_count} active user(s). Strongly consider migrating users to another version before deprecating!`
+          : ''),
+    );
+
+    if (!shouldContinue) {
+      this.log('\nDeprecation cancelled.');
+      return;
+    }
+
+    this.log(
+      `\nPreparing to deprecate version ${version} your app "${app.title}".\n`,
     );
     const url = `/apps/${app.id}/versions/${version}/deprecate`;
     this.startSpinner(`Deprecating ${version}`);
@@ -21,12 +43,19 @@ class DeprecateCommand extends BaseCommand {
     });
     this.stopSpinner();
     this.log(
-      `\nWe'll let users know that this version is no longer recommended and will cease to work on ${date}.`,
+      `\nWe'll let users know that this version will cease to work on ${date}.`,
     );
   }
 }
 
-DeprecateCommand.flags = buildFlags();
+DeprecateCommand.flags = buildFlags({
+  commandFlags: {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt. Use with caution.',
+    }),
+  },
+});
 DeprecateCommand.args = {
   version: Args.string({
     description: 'The version to deprecate.',
@@ -43,11 +72,15 @@ DeprecateCommand.description = `Mark a non-production version of your integratio
 
 Use this when an integration version will not be supported or start breaking at a known date.
 
-Zapier will send an email warning users of the deprecation once a date is set, they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
+Zapier will immediately send emails warning users of the deprecation if a date less than 30 days in the future is set, otherwise the emails will be sent exactly 30 days before the configured deprecation date.
 
-After the deprecation date has passed it will be safe to delete that integration version.
+There are other side effects: they'll start seeing it as "Deprecated" in the UI, and once the deprecation date arrives, if the Zaps weren't updated, they'll be paused and the users will be emailed again explaining what happened.
 
-Do not use this if you have non-breaking changes, such as fixing help text.`;
+Do not use deprecation if you have non-breaking changes, such as:
+- Fixing help text
+- Adding new triggers/actions
+- Improving existing functionality
+- other bug fixes that don't break existing automations.`;
 DeprecateCommand.skipValidInstallCheck = true;
 
 module.exports = DeprecateCommand;

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -293,6 +293,11 @@ const getVersionInfo = () => {
   });
 };
 
+const getSpecificVersionInfo = async (version) => {
+  const app = await getWritableApp();
+  return callAPI(`/apps/${app.id}/versions/${version}`);
+};
+
 // Intended to match logic of https://gitlab.com/zapier/team-developer-platform/dev-platform/-/blob/9fa28d8bacd04ebdad5937bd039c71aede4ede47/web/frontend/assets/app/entities/CliApp/CliApp.ts#L96
 const isPublished = (appStatus) => {
   const publishedStatuses = ['public', 'beta'];
@@ -500,6 +505,7 @@ module.exports = {
   getLinkedAppConfig,
   getWritableApp,
   getVersionInfo,
+  getSpecificVersionInfo,
   isPublished,
   listApps,
   listCanaries,


### PR DESCRIPTION
This MR adds a confirmation step to `zapier deprecate`. It also uses the existing `user_count` property of an app version to highlight to users if a particular app version has any active Zaps which should probably be migrated before deprecation.

CLI Demo running locally:

![Screen Cast 2025-03-25 at 4 41 03 PM](https://github.com/user-attachments/assets/eb469cff-abe9-45f9-8ec3-6adb0ff0c692)
