### PR TITLE
feat(cli) - Add new zapier legacy command

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -434,6 +434,30 @@ Jobs are returned from oldest to newest.
 * `zapier jobs`
 
 
+## legacy
+
+> Mark a non-production version of your integration as legacy.
+
+**Usage**: `zapier legacy VERSION`
+
+Use this when an integration version is no longer recommended for new users, but you don't want to block existing users from using it.
+
+Reasons why you might want to mark a version as legacy:
+- this version may be discontinued in the future
+- this version has bugs
+- a newer version has been released and you want to encourage users to upgrade
+
+**Arguments**
+* (required) `version` | The version to mark as legacy.
+
+**Flags**
+* `-f, --force` | Skip confirmation prompt. Use with caution.
+* `-d, --debug` | Show extra debugging output.
+
+**Examples**
+* `zapier legacy 1.2.3`
+
+
 ## link
 
 > Link the current directory with an existing integration.

--- a/packages/cli/src/oclif/commands/legacy.js
+++ b/packages/cli/src/oclif/commands/legacy.js
@@ -1,0 +1,67 @@
+const BaseCommand = require('../ZapierBaseCommand');
+const { Args, Flags } = require('@oclif/core');
+const { buildFlags } = require('../buildFlags');
+const colors = require('colors/safe');
+
+const { callAPI } = require('../../utils/api');
+
+class LegacyCommand extends BaseCommand {
+  async perform() {
+    const app = await this.getWritableApp();
+    const { version } = this.args;
+
+    this.log(
+      `${colors.yellow('Warning: .')}\n` +
+        `${colors.yellow('If all your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
+    );
+
+    if (
+      !this.flags.force &&
+      !(await this.confirm(
+        'Are you sure you want to make this version legacy? Existing Zaps and automations will continue to work, but users may not be able to create new Zaps or automations with this version.',
+      ))
+    ) {
+      this.log('\nCancelled, version is not marked as legacy.');
+      return;
+    }
+
+    this.log(
+      `\nPreparing to make version ${version} your app "${app.title}" legacy.\n`,
+    );
+    const url = `/apps/${app.id}/versions/${version}/legacy`;
+    this.startSpinner(`Making ${version} legacy`);
+    await callAPI(url, {
+      method: 'PUT',
+    });
+    this.stopSpinner();
+  }
+}
+
+LegacyCommand.flags = buildFlags({
+  commandFlags: {
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation prompt. Use with caution.',
+    }),
+  },
+});
+LegacyCommand.args = {
+  version: Args.string({
+    description: 'The version to mark as legacy.',
+    required: true,
+  }),
+};
+LegacyCommand.examples = ['zapier legacy 1.2.3'];
+LegacyCommand.description = `Mark a non-production version of your integration as legacy.
+
+Use this when an integration version is no longer recommended for new users, but you don't want to block existing users from using it.
+
+Reasons why you might want to mark a version as legacy:
+- this version may be discontinued in the future
+- this version has bugs
+- a newer version has been released and you want to encourage users to upgrade
+
+`;
+LegacyCommand.skipValidInstallCheck = true;
+
+module.exports = LegacyCommand;

--- a/packages/cli/src/oclif/commands/legacy.js
+++ b/packages/cli/src/oclif/commands/legacy.js
@@ -1,7 +1,6 @@
 const BaseCommand = require('../ZapierBaseCommand');
 const { Args, Flags } = require('@oclif/core');
 const { buildFlags } = require('../buildFlags');
-const colors = require('colors/safe');
 
 const { callAPI } = require('../../utils/api');
 
@@ -10,15 +9,10 @@ class LegacyCommand extends BaseCommand {
     const app = await this.getWritableApp();
     const { version } = this.args;
 
-    this.log(
-      `${colors.yellow('Warning: .')}\n` +
-        `${colors.yellow('If all your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
-    );
-
     if (
       !this.flags.force &&
       !(await this.confirm(
-        'Are you sure you want to make this version legacy? Existing Zaps and automations will continue to work, but users may not be able to create new Zaps or automations with this version.',
+        'Are you sure you want to mark this version as legacy? Existing Zaps and automations will continue to work, but users may not be able to create new Zaps or automations with this version.',
       ))
     ) {
       this.log('\nCancelled, version is not marked as legacy.');
@@ -26,7 +20,7 @@ class LegacyCommand extends BaseCommand {
     }
 
     this.log(
-      `\nPreparing to make version ${version} your app "${app.title}" legacy.\n`,
+      `\nPreparing to mark version ${version} your app "${app.title}" as legacy.\n`,
     );
     const url = `/apps/${app.id}/versions/${version}/legacy`;
     this.startSpinner(`Making ${version} legacy`);

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -18,6 +18,7 @@ class VersionCommand extends BaseCommand {
         ['Platform', 'platform_version'],
         ['Users', 'user_count'],
         ['Deployment', 'deployment'],
+        ['Legacy Date', 'legacy_date'],
         ['Deprecation Date', 'deprecation_date'],
         ['Timestamp', 'date'],
       ],

--- a/packages/cli/src/oclif/oCommands.js
+++ b/packages/cli/src/oclif/oCommands.js
@@ -26,6 +26,7 @@ module.exports = {
   integrations: require('./commands/integrations'),
   invoke: require('./commands/invoke'),
   link: require('./commands/link'),
+  legacy: require('./commands/legacy'),
   login: require('./commands/login'),
   logs: require('./commands/logs'),
   logout: require('./commands/logout'),


### PR DESCRIPTION
`legacy` is a new lifecycle state for app versions we want to support.
Accompanying documentation can be found [here](https://gitlab.com/zapier/public-api/public-api-docs/-/merge_requests/56)