### PR TITLE
refactor(cli) - zapier versions filter out deprecated by default

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -874,5 +874,6 @@ Run the standard validation routine powered by json-schema that checks your inte
 **Usage**: `zapier versions`
 
 **Flags**
+* `--all` | List all versions, including deprecated versions.
 * `-d, --debug` | Show extra debugging output.
 * `-f, --format` | Change the way structured data is presented. If "json" or "raw", you can pipe the output of the command into other tools, such as jq. One of `[plain | json | raw | row | table]`. Defaults to `table`.

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -874,6 +874,6 @@ Run the standard validation routine powered by json-schema that checks your inte
 **Usage**: `zapier versions`
 
 **Flags**
-* `--all` | List all versions, including deprecated versions.
+* `-a, --all` | List all versions, including deprecated versions.
 * `-d, --debug` | Show extra debugging output.
 * `-f, --format` | Change the way structured data is presented. If "json" or "raw", you can pipe the output of the command into other tools, such as jq. One of `[plain | json | raw | row | table]`. Defaults to `table`.

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -87,6 +87,7 @@ VersionCommand.skipValidInstallCheck = true;
 VersionCommand.flags = buildFlags({
   commandFlags: {
     all: Flags.boolean({
+      char: 'a',
       description: `List all versions, including deprecated versions.`,
     }),
   },

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -1,5 +1,5 @@
 const colors = require('colors/safe');
-
+const { Flags } = require('@oclif/core');
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
 
@@ -34,8 +34,12 @@ class VersionCommand extends BaseCommand {
       state: deploymentToLifecycleState(v.lifecycle.status),
     }));
 
+    const visibleVersions = this.flags.all
+      ? rows
+      : rows.filter((v) => v.state !== 'deprecated');
+
     this.logTable({
-      rows,
+      rows: visibleVersions,
       headers: [
         ['Version', 'version'],
         ['Platform', 'platform_version'],
@@ -80,7 +84,14 @@ class VersionCommand extends BaseCommand {
 }
 
 VersionCommand.skipValidInstallCheck = true;
-VersionCommand.flags = buildFlags({ opts: { format: true } });
+VersionCommand.flags = buildFlags({
+  commandFlags: {
+    all: Flags.boolean({
+      description: `List all versions, including deprecated versions.`,
+    }),
+  },
+  opts: { format: true },
+});
 VersionCommand.description = `List the versions of your integration available for use in Zapier automations.`;
 
 module.exports = VersionCommand;

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -5,25 +5,6 @@ const { buildFlags } = require('../buildFlags');
 
 const { listVersions } = require('../../utils/api');
 
-const deploymentToLifecycleState = (deployment) => {
-  switch (deployment) {
-    case 'non-production':
-      return 'private';
-    case 'production':
-      return 'promoted';
-    case 'demoted':
-      return 'available';
-    case 'legacy':
-      return 'legacy';
-    case 'deprecating':
-      return 'deprecating';
-    case 'deprecated':
-      return 'deprecated';
-    default:
-      return deployment;
-  }
-};
-
 class VersionCommand extends BaseCommand {
   async perform() {
     this.startSpinner('Loading versions');
@@ -31,7 +12,7 @@ class VersionCommand extends BaseCommand {
     this.stopSpinner();
     const rows = versions.map((v) => ({
       ...v,
-      state: deploymentToLifecycleState(v.lifecycle.status),
+      state: v.lifecycle.status,
     }));
 
     const visibleVersions = this.flags.all


### PR DESCRIPTION
Deprecated versions are not active versions, and are not actionable. We can remove it from the list of versions to reduce complexity. Optionally, devs can pass in an `--all` flag to list everything