### PR TITLE
fix(schema): Re-add computed prop to inputFieldSchema [PDE-6056]

### DIFF
--- a/packages/core/types/zapier.generated.d.ts
+++ b/packages/core/types/zapier.generated.d.ts
@@ -742,6 +742,13 @@ export interface PlainInputField {
   altersDynamicFields?: boolean;
 
   /**
+   * Is this field automatically populated (and hidden from the user)?
+   * Note: Only OAuth, Session Auth, and certain internal use cases
+   * support fields with this key.
+   */
+  computed?: boolean;
+
+  /**
    * Useful when you expect the input to be part of a longer string.
    * Put "{{input}}" in place of the user's input (IE:
    * "https://{{input}}.yourdomain.com").

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -1330,6 +1330,7 @@ Key | Required | Type | Description
 `choices` | no | [/FieldChoicesSchema](#fieldchoicesschema) | An object of machine keys and human values to populate a static dropdown.
 `placeholder` | no | `string` | An example value that is not saved.
 `altersDynamicFields` | no | `boolean` | Does the value of this field affect the definitions of other fields in the set?
+`computed` | no | `boolean` | Is this field automatically populated (and hidden from the user)? Note: Only OAuth, Session Auth, and certain internal use cases support fields with this key.
 `inputFormat` | no | `string` | Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user's input (IE: "https://{{input}}.yourdomain.com").
 `meta` | no | [/FieldMetaSchema](#fieldmetaschema) | Allows for additional metadata to be stored on the field. Supports simple key-values only (no sub-objects or arrays).
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -763,6 +763,10 @@
           "description": "Does the value of this field affect the definitions of other fields in the set?",
           "type": "boolean"
         },
+        "computed": {
+          "description": "Is this field automatically populated (and hidden from the user)? Note: Only OAuth, Session Auth, and certain internal use cases support fields with this key.",
+          "type": "boolean"
+        },
         "inputFormat": {
           "description": "Useful when you expect the input to be part of a longer string. Put \"{{input}}\" in place of the user's input (IE: \"https://{{input}}.yourdomain.com\").",
           "type": "string",

--- a/packages/schema/lib/schemas/PlainInputFieldSchema.js
+++ b/packages/schema/lib/schemas/PlainInputFieldSchema.js
@@ -59,6 +59,11 @@ module.exports = makeSchema(
           'Does the value of this field affect the definitions of other fields in the set?',
         type: 'boolean',
       },
+      computed: {
+        description:
+          'Is this field automatically populated (and hidden from the user)? Note: Only OAuth, Session Auth, and certain internal use cases support fields with this key.',
+        type: 'boolean',
+      },
       inputFormat: {
         description:
           'Useful when you expect the input to be part of a longer string. Put "{{input}}" in place of the user\'s input (IE: "https://{{input}}.yourdomain.com").',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

The `computed` property was removed from `PlainInputFieldSchema` [in this PR](https://github.com/zapier/zapier-platform/pull/957/files/dc34ca28b552760fc96ec59a027005bc0311eb95#r1935694769). However, after some testing, we've identified that it is actually a valid option for certain internal use cases for input fields, and needs to be added back in order for these to continue working. More context [in the ticket](https://zapierorg.atlassian.net/browse/PDE-6056).