### PR TITLE
PDE-6084 feat(core): `z.request()` accepts `encodeURIComponent`

### DIFF
--- a/packages/core/src/http-middlewares/before/add-query-params.js
+++ b/packages/core/src/http-middlewares/before/add-query-params.js
@@ -14,7 +14,9 @@ const addQueryParams = (req) => {
 
     normalizeEmptyParamFields(req);
 
-    let stringifiedParams = querystring.stringify(req.params);
+    let stringifiedParams = querystring.stringify(req.params, '&', '=', {
+      encodeURIComponent: req.encodeURIComponent,
+    });
 
     // it goes against spec, but for compatibility, some APIs want certain
     // characters (mostly $) unencoded

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -396,6 +396,22 @@ describe('http querystring before middleware', () => {
     addQueryParams(req);
     should(req.url).eql('https://example.com?cool=%E7%83%8F龜%40$å');
   });
+
+  it('should allow to pass in a custom encodeURIComponent function', () => {
+    const req = {
+      url: 'https://example.com',
+      params: { cool: '!*()[]' },
+      encodeURIComponent: (s) => {
+        return encodeURIComponent(s)
+          .replaceAll('!', '%21')
+          .replaceAll('*', '%2A')
+          .replaceAll('(', '%28')
+          .replaceAll(')', '%29');
+      },
+    };
+    addQueryParams(req);
+    should(req.url).eql('https://example.com?cool=%21%2A%28%29%5B%5D');
+  });
 });
 
 describe('http addBasicAuthHeader before middelware', () => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

This change allows `z.request()` to take an `encodeURIComponent` function that will be used to encode special characters in the request query parameters.

Example:

```js
const response = await z.request({
  url: 'https://httpbin.org/get',
  params: {
    special: '!*()[]',
  },
  encodeURIComponent: (s) => {
    // The built-in encodeURIComponent() function doesn't encode '!*()'
    return encodeURIComponent(s)
      .replaceAll('!', '%21')
      .replaceAll('*', '%2A')
      .replaceAll('(', '%28')
      .replaceAll(')', '%29');
  },
});
```

Internally, `z.request()` [uses `querystring.stringify()`](https://github.com/zapier/zapier-platform/blob/43f0abbf20d08270716cd56904390e551cc162c4/packages/core/src/http-middlewares/before/add-query-params.js#L17) to encode query parameters. It allows you to [pass in an `encodeURIComponent` function](https://nodejs.org/docs/latest-v18.x/api/querystring.html#querystringstringifyobj-sep-eq-options) to customize the encoding behavior.

When the passed `encodeURIComponent` is not a function, `z.request()` will ignore it, matching `querystring.stringify()`'s behavior.