### PR TITLE
PDE-5551 fix(core): sometimes `request_data` is `<unsupported format>` in logs even when `content-type` is json

### DIFF
--- a/packages/core/src/tools/create-http-patch.js
+++ b/packages/core/src/tools/create-http-patch.js
@@ -59,6 +59,9 @@ const createHttpPatch = (event) => {
 
         // Only include request or response data for specific content types
         // which we are able to read in logs and which are not typically too large
+        // Limitation: This doesn't capture the request content-type if it's set afterwards, like:
+        //   const req = https.request(options, callback);
+        //   req.setHeader('Content-Type', 'text/plain');
         const requestContentType = getContentType(options.headers || {});
         const responseContentType = getContentType(response.headers || {});
 

--- a/packages/core/src/tools/http.js
+++ b/packages/core/src/tools/http.js
@@ -25,19 +25,17 @@ const ALLOWED_HTTP_DATA_CONTENT_TYPES = new Set([
 ]);
 
 const getContentType = (headers) => {
-  const headerKeys = Object.keys(headers);
-  let foundKey = '';
-
-  _.each(headerKeys, (key) => {
+  for (const [key, value] of Object.entries(headers)) {
     if (key.toLowerCase() === 'content-type') {
-      foundKey = key;
-      return false;
+      if (Array.isArray(value) && value.length > 0) {
+        return value[0];
+      } else if (typeof value === 'string') {
+        return value;
+      }
+      return null;
     }
-
-    return true;
-  });
-
-  return _.get(headers, foundKey, '');
+  }
+  return null;
 };
 
 // This function splits a comma-separated string described by RFC 2068 Section 2.

--- a/packages/core/test/tools/create-http-patch.js
+++ b/packages/core/test/tools/create-http-patch.js
@@ -109,56 +109,6 @@ describe('create http patch', () => {
     ]);
   });
 
-  it('should log request/response data for allowlisted content-types', () => {
-    // Arrange
-    const fakeHttpModule = {
-      request: (options, callback) => {
-        const res = new EventEmitter();
-
-        // Response data
-        res.statusCode = 200;
-        res.headers = { 'content-type': XML_TYPE }; // XML type should be supported
-        callback(res);
-        res.emit('data', Buffer.from('<foo>bar</foo>'));
-        res.emit('end');
-      },
-    };
-
-    const logBuffer = [];
-
-    const stubLogger = (_, data) => {
-      logBuffer.push(data);
-    };
-
-    const httpPatch = createHttpPatch({});
-    httpPatch(fakeHttpModule, stubLogger);
-
-    // Act
-    fakeHttpModule.request({
-      url: 'https://fake.zapier.com/foo',
-      body: JSON.stringify({ input: 'data' }),
-      headers: { 'content-type': JSON_TYPE }, // JSON type should be supported
-    });
-
-    // Assert
-    should(logBuffer).deepEqual([
-      {
-        log_type: 'http',
-        request_data: '{"input":"data"}',
-        request_headers: { 'content-type': JSON_TYPE },
-        request_method: 'GET',
-        request_type: 'patched-devplatform-outbound',
-        request_url: 'https://fake.zapier.com/foo',
-        request_via_client: false,
-        response_content: '<foo>bar</foo>',
-        response_headers: {
-          'content-type': 'application/xml',
-        },
-        response_status_code: 200,
-      },
-    ]);
-  });
-
   it('should log request/response data when content-type header is array', () => {
     // Arrange
     const fakeHttpModule = {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes a bug where sometimes `request_data` displays as `<unsupported format>` in logs even when the request `content-type` is `application/json` or some other loggable types.