### PR TITLE
feat(core) PDE-6079: add middleware to fetch stashed bundle

### DIFF
--- a/packages/core/src/app-middlewares/before/fetch-stashed-bundle.js
+++ b/packages/core/src/app-middlewares/before/fetch-stashed-bundle.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fetch = require('node-fetch');
+const rpc = require('../../tools/rpc');
+const _ = require('lodash');
+
+const withRetry = async (fn, retries = 3, delay = 100, attempt = 0) => {
+  try {
+    return await fn();
+  } catch (error) {
+    if (attempt >= retries) {
+      throw error;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return withRetry(fn, retries, delay, attempt + 1);
+  }
+};
+
+const fetchStashedBundle = async (input) => {
+  const stashedBundleKey = _.get(input, '_zapier.event.stashedBundleKey', {});
+
+  if (stashedBundleKey) {
+    // Use the RPC to get a presigned URL for downloading the data
+    const s3Url = await rpc(
+      'generate_presigned_download_url',
+      stashedBundleKey,
+    );
+    const response = await withRetry(() => fetch(s3Url));
+    if (!response.ok) {
+      throw new Error('Failed to fetch stashed bundle from S3.');
+    }
+    try {
+      const stashedBundle = await response.json();
+      // Get the existing bundle
+      // Try to set it to stashed bundle
+      // If errors then use the existing bundle
+      // Set the bundle to the stashedBundle value
+      _.set(input, '_zapier.event.bundle', stashedBundle);
+    } catch (error) {
+      throw new Error('Failed to read stashed bundle from S3 response.');
+    }
+  }
+  return input;
+};
+
+module.exports = fetchStashedBundle;

--- a/packages/core/src/create-app.js
+++ b/packages/core/src/create-app.js
@@ -7,6 +7,7 @@ const schemaTools = require('./tools/schema');
 // before middles
 const injectZObject = require('./app-middlewares/before/z-object');
 const addAppContext = require('./app-middlewares/before/add-app-context');
+const fetchStashedBundle = require('./app-middlewares/before/fetch-stashed-bundle');
 
 // after middles
 const checkOutput = require('./app-middlewares/after/checks');
@@ -29,6 +30,7 @@ const createApp = (appRaw) => {
   const befores = [
     addAppContext,
     injectZObject,
+    fetchStashedBundle,
     ...ensureArray(frozenCompiledApp.beforeApp),
   ];
 

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -29,10 +29,12 @@ const createAppWithCustomBefores = (appRaw, customBefores) => {
   const waitForPromises = require('zapier-platform-core/src/app-middlewares/after/wait-for-promises');
   const createCommandHandler = require('zapier-platform-core/src/create-command-handler');
   const applyMiddleware = require('zapier-platform-core/src/middleware');
-
+  const fetchStashedBundle = require('zapier-platform-core/src/app-middlewares/before/fetch-stashed-bundle');
   const frozenCompiledApp = schemaTools.prepareApp(appRaw);
 
-  const befores = [addAppContext, injectZObject].concat(customBefores || []);
+  const befores = [addAppContext, injectZObject, fetchStashedBundle].concat(
+    customBefores || [],
+  );
   const afters = [checkOutput, largeResponseCachePointer, waitForPromises];
 
   const app = createCommandHandler(frozenCompiledApp);


### PR DESCRIPTION
Add new app before middleware that gets a stashed key from the inputs, if present if will attempt to fetch the stashed bundle and inject it into the app. 

Note: Meant to be released after v17

**New File Added**:
`app-middlewares/before/fetch-stashed-bundle.js`:  the new middleware for fetching stashed bundles and injecting it back into the app

**Modifications**:
`src/create-app.js`: Add the new middleware as a "before" middlware.
`legacy-scripting-runner/test/integration-test.js`: Update tests to include new middleware