### PR TITLE
PDE-6124 fix(legacy-scripting-runner): sync `z.request()` should log `request_params`

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.16
+
+- :bug: sync `z.reqeust` should log `request_params` ([#1017](https://github.com/zapier/zapier-platform/pull/1017))
+
 ## 3.8.15
 
 - :hammer: Trim newline and whitespaces from request header ([#1000](https://github.com/zapier/zapier-platform/pull/1000))

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.8.16
 
-- :bug: sync `z.reqeust` should log `request_params` ([#1017](https://github.com/zapier/zapier-platform/pull/1017))
+- :bug: sync `z.request` should log `request_params` ([#1017](https://github.com/zapier/zapier-platform/pull/1017))
 
 ## 3.8.15
 

--- a/packages/legacy-scripting-runner/test/example-app/index.js
+++ b/packages/legacy-scripting-runner/test/example-app/index.js
@@ -131,6 +131,7 @@ const legacyScriptingSource = `
 
       contact_full_poll: function(bundle) {
         bundle.request.url = '${AUTH_JSON_SERVER_URL}/users';
+        bundle.request.params = { id: '2' };
         var response = z.request(bundle.request);
         var contacts = z.JSON.parse(response.content);
         contacts[0].name = 'Patched by KEY_poll!';

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -117,12 +117,12 @@ describe('Integration Test', function () {
       input.bundle.meta = { isTestingAuth: true };
       return app(input).then((output) => {
         const user = output.results;
-        should.equal(user.id, 1);
-        should.equal(user.username, 'Bret');
+        should.equal(user.id, 2);
+        should.equal(user.username, 'Antonette');
       });
     });
 
-    it('authentication.test, core < 8.0.0', () => {
+    it('authentication.test, core < 9.0.0', () => {
       const input = createTestInput(compiledApp, 'authentication.test');
       input.bundle.authData = {
         key1: 'sec',
@@ -131,8 +131,8 @@ describe('Integration Test', function () {
       input.bundle.meta = { standard_poll: false, test_poll: true };
       return app(input).then((output) => {
         const user = output.results;
-        should.equal(user.id, 1);
-        should.equal(user.username, 'Bret');
+        should.equal(user.id, 2);
+        should.equal(user.username, 'Antonette');
       });
     });
   });

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -756,7 +756,7 @@ describe('Integration Test', function () {
         zap: { name: 'My Awesome Zap' },
       };
       return app(input).then((output) => {
-        output.results.length.should.greaterThan(1);
+        should.equal(output.results.length, 1);
 
         const firstContact = output.results[0];
         should.equal(firstContact.name, 'Patched by KEY_poll!');
@@ -775,6 +775,7 @@ describe('Integration Test', function () {
             'Content-Type': 'application/json; charset=utf-8',
             'X-Api-Key': 'secret',
           },
+          request_params: { id: '2' },
           response_status_code: 200,
           response_headers: {
             'content-type': 'application/json; charset=utf-8',
@@ -782,8 +783,11 @@ describe('Integration Test', function () {
         });
 
         const loggedResponseData = JSON.parse(logs[0].response_content);
-        loggedResponseData.length.should.greaterThan(1);
-        loggedResponseData[0].should.containEql({ id: 1, username: 'Bret' });
+        loggedResponseData.length.should.eql(1);
+        loggedResponseData[0].should.containEql({
+          id: 2,
+          username: 'Antonette',
+        });
 
         // bundle log
         logs[1].should.containDeep({
@@ -795,7 +799,9 @@ describe('Integration Test', function () {
             },
             auth_fields: { api_key: 'secret' },
           },
-          output: [{ id: 1, username: 'Bret', name: 'Patched by KEY_poll!' }],
+          output: [
+            { id: 2, username: 'Antonette', name: 'Patched by KEY_poll!' },
+          ],
         });
       });
     });

--- a/packages/legacy-scripting-runner/zfactory.js
+++ b/packages/legacy-scripting-runner/zfactory.js
@@ -110,6 +110,7 @@ const zfactory = (zcli, app, logger) => {
       request_url: url,
       request_method: method,
       request_headers: req.headers,
+      request_params: req.qs,
       request_data: req.data,
       request_via_client: false,
       response_status_code: res.status_code,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

In legacy scripting, if you write:

```
KEY_poll: function(bundle) {
  bundle.request.url = 'https://httpbin.org/get';
  bundle.request.params = { foo: 'bar' };
  var response = z.request(bundle.request);
  var data = z.JSON.parse(response.content);
  return [data];
},
```

The expected behavior should be you see an HTTP log with `request_params` being set:

```jsonc
{
  "message": "200 GET https://httpbin.org/get",
  // ...
  "request_params": { "foo": "bar" },
  // ...
}
```

But in the current behavior the log doesn't have `request_params`.