### PR TITLE
fix(core): Provide named esm exports of zpc objects

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -75,4 +75,10 @@ module.exports = [{
     rules: {
         "no-unused-vars": 0,
     },
+}, {
+    files: ['packages/core/**.mjs'],
+    languageOptions: {
+      ecmaVersion: 2025,
+      sourceType: 'module',
+},
 }];

--- a/packages/core/index.mjs
+++ b/packages/core/index.mjs
@@ -1,5 +1,9 @@
 import zapier from './src/index.js';
-
+import packageJson from './package.json' with { type: 'json' };
+import _tools from './src/tools/exported.js';
+zapier.version = packageJson.version;
+zapier.tools = _tools;
+// Allows `import { ... } from 'zapier-platform-core'`
 export const {
   createAppHandler,
   createAppTester,
@@ -10,4 +14,8 @@ export const {
   defineSearch,
   defineTrigger,
   integrationTestHandler,
+  tools,
+  version,
 } = zapier;
+// Allows `import zapier from 'zapier-platform-core'`
+export default zapier;

--- a/packages/core/index.mjs
+++ b/packages/core/index.mjs
@@ -1,0 +1,13 @@
+import zapier from './src/index.js';
+
+export const {
+  createAppHandler,
+  createAppTester,
+  defineApp,
+  defineCreate,
+  defineInputField,
+  defineInputFields,
+  defineSearch,
+  defineTrigger,
+  integrationTestHandler,
+} = zapier;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
   "files": [
     "/include/",
     "/index.js",
+    "/index.mjs",
     "/src/",
     "/types/"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,9 +8,14 @@
   "license": "SEE LICENSE IN LICENSE",
   "types": "types/index.d.ts",
   "exports": {
-    "require": "./index.js",
-    "import": "./index.mjs",
-    "types": "./types/index.d.ts"
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs",
+      "types": "./types/index.d.ts"
+    },
+    "./src/*": {
+      "require": "./src/*.js"
+    }
   },
   "files": [
     "/include/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,8 +6,12 @@
   "homepage": "https://platform.zapier.com/",
   "author": "Zapier Engineering <contact@zapier.com>",
   "license": "SEE LICENSE IN LICENSE",
-  "main": "index.js",
   "types": "types/index.d.ts",
+  "exports": {
+    "require": "./index.js",
+    "import": "./index.mjs",
+    "types": "./types/index.d.ts"
+  },
   "files": [
     "/include/",
     "/index.js",


### PR DESCRIPTION
This fixes issues where downstream apps can't access members of the zapier library via deconstructed import statements.

V17 can cause issues with the combination of trying to use destructured imports (i.e. `import {name} from 'zapier-platform-core`), from esm modules, while zapier-platform-core remains a CJS library. This adds a shim ES interface to the module, and updates package.json to use it when being consumed by ES modules.

```shell
$ zapier init ts-esm-test --template typescript -m esm
$ cd ts-esm-test && npm install
$ zapier build
```