### PR TITLE
fix(core): Fix CLI v16 and Core v17 incompatibility [PDE-6131] 

### DIFF
--- a/packages/cli/src/version-store.js
+++ b/packages/cli/src/version-store.js
@@ -18,4 +18,5 @@ module.exports = [
   { nodeVersion: '16', npmVersion: '>=5.6.0' }, // 13.x
   { nodeVersion: '18', npmVersion: '>=5.6.0' }, // 15.x
   { nodeVersion: '18', npmVersion: '>=10.7.0' }, // 16.x
+  { nodeVersion: '18', npmVersion: '>=10.7.0' }, // 17.x
 ];


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

We discovered a bug where `zapier build` (and therefore `zapier push`) hangs indefinitely on the `Building app definition.json` step if:

- The user is running `zapier-platform-cli` on v16.5.1 or lower (basically, anything lower than v17)
- The integration's `zapier-platform-core` dependency has been updated to v17.0.0

These versions can be verified by running `zapier --version` within an integration directory.

**An intermediate fix is to update the CLI to v17 by running `npm install -g zapier-platform-cli@latest` to upgrade to CLI v17.** 

## Why is this happening?

Older versions of the Zapier Platform CLI rely on providing a callback to `app.handler`, e.g. [in this code block](https://github.com/zapier/zapier-platform/blob/2e24fda659f2e62fff037d13da6b6de3be10b447/packages/cli/src/utils/build.js#L237-L253). This handler function is defined in Zapier Platform Core. With v17, the `app.handler` function in Zapier Platform Core no longer expects to receive and therefore no longer calls a callback.

## What is the fix?

This PR adds back in the ability for `app.handler` to receive a callback, and checks whether it does or doesn't receive one. Then it either calls the callback if it's received, or runs and returns the Promise logic that we added in v17. This Core update allows the CLI to call `app.handler` and build gracefully regardless of the CLI version being used.

## Other changes

This PR also bundles in a small update to `version-store.js` to indicate that v17 continues to rely on Node v18.