### PR TITLE
PDE-6135 fix(cli): `typescript` project template OAuth2 doesn't work out of box

### DIFF
--- a/packages/cli/src/generators/templates/typescript/src/authentication.ts
+++ b/packages/cli/src/generators/templates/typescript/src/authentication.ts
@@ -20,7 +20,10 @@ export default {
     getAccessToken: {
       url: `${API_URL}/oauth/access-token`,
       method: 'POST',
-      params: {
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: {
         client_id: '{{process.env.CLIENT_ID}}',
         client_secret: '{{process.env.CLIENT_SECRET}}',
         code: '{{bundle.inputData.code}}',
@@ -31,7 +34,10 @@ export default {
     refreshAccessToken: {
       url: `${API_URL}/oauth/refresh-token`,
       method: 'POST',
-      params: {
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: {
         client_id: '{{process.env.CLIENT_ID}}',
         client_secret: '{{process.env.CLIENT_SECRET}}',
         refresh_token: '{{bundle.authData.refresh_token}}',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

After running `zapier init ts-example -t typescript`, `npm install`, and `zapier push`, we expect the authentication should just work when testing in the Zap editor. But the `getAccessToken` and `refreshAccessToken` methods are implemented incorrectly. This PR fixes it.