### PR TITLE
PDE-6136 fix(cli): `zapier build` misses files on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,8 +81,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          # TODO: Fix tests on Windows
-          # - windows-latest
+          - windows-latest
         node-version: [18.x, 20.x]
 
     steps:
@@ -140,8 +139,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          # TODO: Fix tests on Windows
-          # - windows-latest
+          - windows-latest
         node-version: [18.x, 20.x]
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,8 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # TODO: Fix tests on Windows
+          # - windows-latest
         node-version: [18.x, 20.x]
 
     steps:
@@ -139,7 +140,8 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # TODO: Fix tests on Windows
+          # - windows-latest
         node-version: [18.x, 20.x]
 
     steps:

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -63,6 +63,7 @@ const requiredFiles = async ({ cwd, entryPoints }) => {
     external: ['../test/userapp'],
     format: 'esm',
     write: false, // no need to write outfile
+    absWorkingDir: cwd,
   });
 
   return Object.keys(result.metafile.inputs).map((path) =>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
