### PR TITLE
feat(cli): Make ESM the default for `zapier init` if the template supports it [PDE-6134]

### DIFF
--- a/packages/cli/src/generators/index.js
+++ b/packages/cli/src/generators/index.js
@@ -290,9 +290,9 @@ class ProjectGenerator extends Generator {
         {
           type: 'list',
           name: 'module',
-          choices: ['commonjs', 'esm'],
+          choices: ['esm', 'commonjs'],
           message: 'Choose module type:',
-          default: 'commonjs',
+          default: 'esm',
         },
       ]);
       this.options.module = this.answers.module;


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Now that we have ESM support for the Minimal and Typescript templates, ESM should be the default module type for those templates. This PR updates the default accordingly.
