### PR TITLE
fix(cli): Make sure `loadAppRawUsingRequire` also works with Windows [PDE-6136]

### DIFF
--- a/packages/cli/src/utils/local.js
+++ b/packages/cli/src/utils/local.js
@@ -254,7 +254,8 @@ const loadAppRawUsingImport = async (
 };
 
 const loadAppRawUsingRequire = (appDir) => {
-  let appRaw = require(appDir);
+  const normalizedPath = path.resolve(appDir);
+  let appRaw = require(normalizedPath);
   if (appRaw && appRaw.default) {
     // Node.js 22+ supports using require() to import ESM.
     // For Node.js < 20.17.0, require() will throw an error on ESM.


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

We should also make sure using `require()` works with Windows!

This fix is slightly different from the `import()` fix because:

- `path.resolve()` is able to handle Windows paths
-  `require()` can handle Windows paths (docs: https://nodejs.org/api/modules.html#requireid) including forward and back-slashes, so we don't have to replace them like we do for `import()`