### PR TITLE
PDE-6149 fix(core): internalize flag that enables/disable `{{curlies}}` replacement, disable `{{curlies}}` for Raw Requests

### DIFF
--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -26,7 +26,6 @@ const RENDER_ONLY_METHODS = [
 const REPLACE_CURLIES = Symbol('replaceCurlies');
 
 const REQUEST_OBJECT_SHORTHAND_OPTIONS = {
-  isShorthand: true,
   [REPLACE_CURLIES]: true,
 };
 

--- a/packages/core/src/constants.js
+++ b/packages/core/src/constants.js
@@ -23,7 +23,12 @@ const RENDER_ONLY_METHODS = [
   'authentication.oauth1Config.authorizeUrl',
 ];
 
-const REQUEST_OBJECT_SHORTHAND_OPTIONS = { isShorthand: true, replace: true };
+const REPLACE_CURLIES = Symbol('replaceCurlies');
+
+const REQUEST_OBJECT_SHORTHAND_OPTIONS = {
+  isShorthand: true,
+  [REPLACE_CURLIES]: true,
+};
 
 const DEFAULT_LOGGING_HTTP_ENDPOINT = 'https://httplogger.zapier.com/input';
 const DEFAULT_LOGGING_HTTP_API_KEY = 'R24hzu86v3jntwtX2DtYECeWAB'; // It's ok, this isn't PROD
@@ -65,13 +70,14 @@ module.exports = {
   IS_TESTING,
   KILL_MAX_LIMIT,
   KILL_MIN_LIMIT,
+  NON_STREAM_UPLOAD_MAX_SIZE,
   PACKAGE_NAME,
   PACKAGE_VERSION,
   RENDER_ONLY_METHODS,
+  REPLACE_CURLIES,
   REQUEST_OBJECT_SHORTHAND_OPTIONS,
   RESPONSE_SIZE_LIMIT,
   SAFE_LOG_KEYS,
   STATUSES,
   UPLOAD_MAX_SIZE,
-  NON_STREAM_UPLOAD_MAX_SIZE,
 };

--- a/packages/core/src/execute-request.js
+++ b/packages/core/src/execute-request.js
@@ -10,7 +10,6 @@ const executeRequest = (input) => {
   if (!options.url) {
     throw new Error('Missing url for request');
   }
-  options.replace = true;
   return input.z.request(options).then(responseCleaner);
 };
 

--- a/packages/core/src/execute.js
+++ b/packages/core/src/execute.js
@@ -10,18 +10,15 @@ const prepareRequest = require('./http-middlewares/before/prepare-request');
 const constants = require('./constants');
 
 const executeHttpRequest = (input, options) => {
-  options = _.extend(
-    {},
+  options = {
     // shorthand requests should always throw _unless_ the object specifically opts out
     // this covers godzilla devs who use shorthand requests (most of them) that rely on the throwing behavior
     // when we set the app-wide skip for everyone, we don't want their behavior to change
     // so, this line takes precedence over the global setting, but not the local one (`options`)
-    {
-      skipThrowForStatus: false,
-    },
-    options,
-    constants.REQUEST_OBJECT_SHORTHAND_OPTIONS,
-  );
+    skipThrowForStatus: false,
+    ...options,
+    ...constants.REQUEST_OBJECT_SHORTHAND_OPTIONS,
+  };
   return input.z.request(options).then((response) => {
     if (response.data === undefined) {
       throw new Error(
@@ -83,11 +80,10 @@ const execute = (app, input) => {
   } else if (_.isObject(method) && method.url) {
     const options = method;
     if (isRenderOnly(methodName)) {
-      const requestWithInput = _.extend(
-        {},
-        injectInput(input)(options),
-        constants.REQUEST_OBJECT_SHORTHAND_OPTIONS,
-      );
+      const requestWithInput = {
+        ...injectInput(input)(options),
+        ...constants.REQUEST_OBJECT_SHORTHAND_OPTIONS,
+      };
       const preparedRequest = addQueryParams(prepareRequest(requestWithInput));
       return preparedRequest.url;
     }

--- a/packages/core/src/http-middlewares/before/inject-input.js
+++ b/packages/core/src/http-middlewares/before/inject-input.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /*
    Creates HTTP before middleware that adds some app context
    to HTTP request options, including the app and event.
@@ -9,7 +7,9 @@ const _ = require('lodash');
    Useful for HTTP middlewares that need stuff from the app or event.
  */
 const injectInput = (input) => {
-  return (req) => _.extend({}, req, { input });
+  return (req) => {
+    return { ...req, input };
+  };
 };
 
 module.exports = injectInput;

--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -16,6 +16,8 @@ const {
   JSON_TYPE_UTF8,
 } = require('../../tools/http');
 
+const { REPLACE_CURLIES } = require('../../constants');
+
 const isStream = (obj) => obj instanceof stream.Stream;
 const isPromise = (obj) => obj && typeof obj.then === 'function';
 
@@ -108,8 +110,9 @@ const throwForCurlies = (value, path) => {
     if (/{{\s*(bundle|process)\.[^}]*}}/.test(value)) {
       throw new Error(
         'z.request() no longer supports {{bundle.*}} or {{process.*}} as of v17 ' +
-          "unless it's used in a shorthand request. " +
-          'Use JavaScript template literals instead. ' +
+          "unless it's used in a shorthand request defined by the integration. " +
+          'Zapier Customers: Remove "{{curly braces}}" from your request. ' +
+          'Developers: Use JavaScript template literals instead. ' +
           `Value in violation: "${value}" in attribute "${path.join('.')}".`,
       );
     }
@@ -158,7 +161,7 @@ const prepareRequest = function (req) {
     body: req.body,
   };
 
-  if (req.replace) {
+  if (req[REPLACE_CURLIES]) {
     // replace {{curlies}} in the request
     const bank = createBundleBank(
       input._zapier.app,

--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -43,66 +43,76 @@ const recurseCleanFuncs = (obj, path) => {
   return obj;
 };
 
+const findNextCurlies = (str) => {
+  const start = str.indexOf('{{');
+  if (start < 0) {
+    return {
+      start: -1,
+      end: -1,
+    };
+  }
+
+  const end = str.indexOf('}}', start + 2);
+  if (end < 0) {
+    return {
+      start: -1,
+      end: -1,
+    };
+  }
+
+  return {
+    start,
+    end: end + 2,
+  };
+};
+
 // Recurse a nested object replace all instances of keys->vals in the bank.
 const recurseReplaceBank = (obj, bank = {}) => {
-  const matchesCurlies = /({{.*?}})/;
-  const matchesKeyRegexMap = Object.keys(bank).reduce((acc, key) => {
-    // Escape characters (ex. {{foo}} => \\{\\{foo\\}\\} )
-    acc[key] = new RegExp(key.replace(/[-[\]/{}()\\*+?.^$|]/g, '\\$&'), 'g');
-    return acc;
-  }, {});
-  const replacer = (out) => {
-    if (!['string', 'number'].includes(typeof out)) {
-      return out;
+  const replacer = (input) => {
+    if (!['string', 'number'].includes(typeof input)) {
+      return input;
     }
 
-    // whatever leaves this function replaces values in the calling object
-    // so, we don't want to return a different data type unless it's a censored string
-    const originalValue = out;
-    const originalValueStr = String(out);
-    let maybeChangedString = originalValueStr;
+    const outputStrings = [];
+    let inputString = String(input);
 
-    Object.keys(bank).forEach((key) => {
-      const matchesKey = matchesKeyRegexMap[key];
-      // RegExp.test modifies internal state of the regex object
-      // since we're re-using regexes, we have to reset that state between calls
-      // or the second time in a row that the key should match, it misses instead
-      // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex
-      matchesKey.lastIndex = 0;
-      if (!matchesKey.test(maybeChangedString)) {
-        return;
+    // 1000 iterations is just a static upper bound to make infinite loops
+    // impossible. Who would have 1000 {{curlies}} in a string... right?
+    for (let i = 0; i < 1000; i++) {
+      const { start, end } = findNextCurlies(inputString);
+      if (start < 0) {
+        break;
       }
 
-      const valueParts = maybeChangedString
-        .split(matchesCurlies)
-        .filter(Boolean);
+      const head = inputString.slice(0, start);
+      const key = inputString.slice(start, end);
+      const tail = inputString.slice(end);
+
+      outputStrings.push(head);
+
       const replacementValue = bank[key];
-      const isPartOfString =
-        !matchesCurlies.test(maybeChangedString) || valueParts.length > 1;
-      const shouldThrowTypeError =
-        isPartOfString &&
-        (Array.isArray(replacementValue) || _.isPlainObject(replacementValue));
-
-      if (shouldThrowTypeError) {
-        const bareKey = _.trimEnd(_.trimStart(key, '{'), '}');
-        throw new TypeError(
-          'Cannot reliably interpolate objects or arrays into a string. ' +
-            `Variable \`${bareKey}\` is an ${getObjectType(
-              replacementValue,
-            )}:\n"${replacementValue}"`,
-        );
+      if (replacementValue) {
+        if (
+          Array.isArray(replacementValue) ||
+          _.isPlainObject(replacementValue)
+        ) {
+          throw new TypeError(
+            'Cannot reliably interpolate objects or arrays into a string. ' +
+              `Variable \`${key}\` is an ${getObjectType(
+                replacementValue,
+              )}:\n"${replacementValue}"`,
+          );
+        } else {
+          outputStrings.push(replacementValue);
+        }
+      } else {
+        outputStrings.push('');
       }
 
-      maybeChangedString = isPartOfString
-        ? valueParts.join('').replace(matchesKey, replacementValue)
-        : replacementValue;
-    });
-
-    if (originalValueStr === maybeChangedString) {
-      // we didn't censor or replace the value, so return the original
-      return originalValue;
+      inputString = tail;
     }
-    return maybeChangedString;
+
+    return outputStrings.join('');
   };
   return recurseReplace(obj, replacer);
 };

--- a/packages/core/src/tools/request-merge.js
+++ b/packages/core/src/tools/request-merge.js
@@ -14,6 +14,9 @@ const caseInsensitiveMerge = (requestOne, requestTwo, requestThree) => {
 
   // This is a very quick & efficient merge for all of request's properties
   const mergedRequest = _.merge(requestOne, requestTwo, requestThree);
+
+  // _.merge() ignores symbols. REPLACE_CURLIES is a symbol, so we need to add
+  // it back
   if (requestThree[REPLACE_CURLIES]) {
     mergedRequest[REPLACE_CURLIES] = requestThree[REPLACE_CURLIES];
   }

--- a/packages/core/src/tools/request-merge.js
+++ b/packages/core/src/tools/request-merge.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 
 const requestClean = require('./request-clean');
+const { REPLACE_CURLIES } = require('../constants');
 
 // Do a merge with case-insensitive keys in the .header, and drop empty .header keys
 const caseInsensitiveMerge = (requestOne, requestTwo, requestThree) => {
@@ -13,6 +14,9 @@ const caseInsensitiveMerge = (requestOne, requestTwo, requestThree) => {
 
   // This is a very quick & efficient merge for all of request's properties
   const mergedRequest = _.merge(requestOne, requestTwo, requestThree);
+  if (requestThree[REPLACE_CURLIES]) {
+    mergedRequest[REPLACE_CURLIES] = requestThree[REPLACE_CURLIES];
+  }
 
   // Now to cleanup headers, we start on the last request (the one with priority) and work backwards to add the keys that don't already exist
   // NOTE: This is done "manually" instead of a _.merge or Object.assign() because we need case-insensitivity

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -82,12 +82,19 @@ describe('request client', function () {
     const request = createAppRequestClient(input);
     const response = await request({
       method: 'POST',
-      url: 'https://httpbin.zapier-tooling.com/post',
+      url: `${HTTPBIN_URL}/post`,
       body: request({ url: fileUrl, raw: true }),
     });
     response.status.should.eql(200);
-    const body = JSON.parse(response.content);
-    body.data.should.eql(fileExpectedContent);
+
+    // Current version of httpbin.zapier-tooling.com encodes the input in base64
+    // and returns it, so we need to decode it here.
+    const encodedData = response.data.data;
+    const [header, encodedBody] = encodedData.split(',');
+    header.should.eql('data:application/octet-stream;base64');
+
+    const decodedBody = Buffer.from(encodedBody, 'base64').toString('utf8');
+    decodedBody.should.eql(fileExpectedContent);
   });
 
   it('should handle a buffer upload fine', async () => {
@@ -98,8 +105,15 @@ describe('request client', function () {
       body: Buffer.from('hello world this is a cat (=^..^=)'),
     });
     response.status.should.eql(200);
-    const body = JSON.parse(response.content);
-    body.data.should.eql('hello world this is a cat (=^..^=)');
+
+    // Current version of httpbin.zapier-tooling.com encodes the input in base64
+    // and returns it, so we need to decode it here.
+    const encodedData = response.data.data;
+    const [header, encodedBody] = encodedData.split(',');
+    header.should.eql('data:application/octet-stream;base64');
+
+    const decodedBody = Buffer.from(encodedBody, 'base64').toString('utf8');
+    decodedBody.should.eql('hello world this is a cat (=^..^=)');
   });
 
   it('should handle a stream upload fine', async () => {
@@ -110,8 +124,15 @@ describe('request client', function () {
       body: fs.createReadStream(path.join(__dirname, 'test.txt')),
     });
     response.status.should.eql(200);
-    const body = JSON.parse(response.content);
-    body.data.should.eql('hello world this is a cat (=^..^=)');
+
+    // Current version of httpbin.zapier-tooling.com encodes the input in base64
+    // and returns it, so we need to decode it here.
+    const encodedData = response.data.data;
+    const [header, encodedBody] = encodedData.split(',');
+    header.should.eql('data:application/octet-stream;base64');
+
+    const decodedBody = Buffer.from(encodedBody, 'base64').toString('utf8');
+    decodedBody.should.eql('hello world this is a cat (=^..^=)');
   });
 
   it('should support single url param', async () => {

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 const should = require('should');
 
 const createAppRequestClient = require('../src/tools/create-app-request-client');
+const { REPLACE_CURLIES } = require('../src/constants');
 const createInput = require('../src/tools/create-input');
 const errors = require('../src/errors');
 const { HTTPBIN_URL } = require('./constants');
@@ -385,6 +386,7 @@ describe('request client', function () {
     it('should replace remaining curly params with empty string when set as false', async () => {
       const request = createAppRequestClient(input);
       const response = await request({
+        [REPLACE_CURLIES]: true,
         url: `${HTTPBIN_URL}/get`,
         params: {
           something: '',
@@ -394,8 +396,8 @@ describe('request client', function () {
         removeMissingValuesFrom: {
           params: false,
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       response.data.args.something.should.deepEqual(['']);
@@ -434,8 +436,8 @@ describe('request client', function () {
         removeMissingValuesFrom: {
           params: true,
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       should(response.data.args.something).eql(undefined);
@@ -499,8 +501,8 @@ describe('request client', function () {
           hookUrl: '{{bundle.targetUrl}}',
           zapId: '{{bundle.meta.zap.id}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { hookUrl, zapId } = JSON.parse(response.data.data);
@@ -521,8 +523,8 @@ describe('request client', function () {
         params: {
           id: '{{bundle.subscribeData.id}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { url } = JSON.parse(response.content);
@@ -554,8 +556,8 @@ describe('request client', function () {
           float: '{{bundle.inputData.float}}',
           arr: '{{bundle.inputData.arr}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { json } = response.data;
@@ -593,8 +595,8 @@ describe('request client', function () {
           float: 123.456,
           arr: [1, 2, 3],
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { json } = response.data;
@@ -625,8 +627,8 @@ describe('request client', function () {
         removeMissingValuesFrom: {
           body: true,
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { json } = response.data;
@@ -654,8 +656,8 @@ describe('request client', function () {
             value: 'exists',
           },
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { json } = response.data;
@@ -698,8 +700,8 @@ describe('request client', function () {
         headers: {
           Authorization: 'Bearer {{bundle.authData.access_token}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { json, headers } = response.data;
@@ -723,8 +725,8 @@ describe('request client', function () {
         body: {
           message: 'No arrays, thank you: {{bundle.inputData.badData}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       }).should.be.rejectedWith(
         'Cannot reliably interpolate objects or arrays into a string. ' +
           'Variable `bundle.inputData.badData` is an Array:\n"1,2,3"',
@@ -751,8 +753,8 @@ describe('request client', function () {
           streetAddress: '{{bundle.inputData.address.street}}',
           city: '{{bundle.inputData.address.city}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { json } = response.data;
@@ -789,8 +791,8 @@ describe('request client', function () {
           'x-cool': '{{bundle.authData.access_token}}',
           'x-another': '{{bundle.authData.access_token}}',
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       const { headers } = response.data;
@@ -836,8 +838,8 @@ describe('request client', function () {
           }
           return value;
         },
-        // Set `replace` to true to make it act like a shorthand request
-        replace: true,
+        // Set this internal symbol to true to make it act like a shorthand request
+        [REPLACE_CURLIES]: true,
       });
 
       response.data.json.should.deepEqual({

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -21,6 +21,7 @@ const sanitizeHeaders = require('../src/http-middlewares/before/sanatize-headers
 const applyMiddleware = require('../src/middleware');
 const oauth1SignRequest = require('../src/http-middlewares/before/oauth1-sign-request');
 const { parseDictHeader } = require('../src/tools/http');
+const { REPLACE_CURLIES } = require('../src/constants');
 const { HTTPBIN_URL } = require('./constants');
 
 describe('http requests', () => {
@@ -150,7 +151,6 @@ describe('http prepareRequest', () => {
       params: {
         foo: '{{inputData.foo}}',
       },
-      replace: true,
       body: '123',
       input: {
         _zapier: {
@@ -176,7 +176,7 @@ describe('http prepareRequest', () => {
   it('should force "bundle" prefix when doing replacement', () => {
     const origReq = {
       url: 'https://example.com/{{inputData.foo}}',
-      replace: true,
+      [REPLACE_CURLIES]: true,
       input: {
         _zapier: {
           event: {
@@ -374,7 +374,7 @@ describe('http prepareRequest', () => {
 
   it('should not replace values in input', () => {
     const request = prepareRequest({
-      replace: true,
+      [REPLACE_CURLIES]: true,
       url: 'https://{{bundle.authData.subdomain}}.example.com/recipes',
       method: 'POST',
       body: {

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -679,7 +679,7 @@ describe('http throwForStatus after middleware', () => {
     }).should.be.rejectedWith(errors.ResponseError, {
       name: 'ResponseError',
       doNotContextify: true,
-      message: `{"status":400,"headers":{"content-type":null,"retry-after":null},"content":"","request":{"url":"${HTTPBIN_URL}/status/400"}}`,
+      message: `{"status":400,"headers":{"content-type":"text/plain; charset=utf-8","retry-after":null},"content":"","request":{"url":"${HTTPBIN_URL}/status/400"}}`,
     });
   });
 
@@ -697,6 +697,7 @@ describe('http throwForStatus after middleware', () => {
 
     response.status.should.equal(200);
   });
+
   it('does not throw for 2xx', async () => {
     const testLogger = () => Promise.resolve({});
     const input = createInput({}, {}, testLogger);
@@ -708,16 +709,20 @@ describe('http throwForStatus after middleware', () => {
 
     response.status.should.equal(200);
   });
+
   it('does not throw for >= 600', async () => {
     const testLogger = () => Promise.resolve({});
     const input = createInput({}, {}, testLogger);
     const request = createAppRequestClient(input);
 
+    // httpbin.zapier-tooling.com no longer allows you to set a 600 status code
+    // so we need to mock it
+    const localScope = nock(HTTPBIN_URL).get('/status/600').reply(600, 'error');
     const response = await request({
       url: `${HTTPBIN_URL}/status/600`,
     });
-
     response.status.should.equal(600);
+    localScope.isDone().should.be.true();
   });
 });
 

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -669,6 +669,10 @@ describe('http oauth1SignRequest before middelware', () => {
 });
 
 describe('http throwForStatus after middleware', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   it('throws for 400 <= status < 600', async () => {
     const testLogger = () => Promise.resolve({});
     const input = createInput({}, {}, testLogger);
@@ -717,12 +721,12 @@ describe('http throwForStatus after middleware', () => {
 
     // httpbin.zapier-tooling.com no longer allows you to set a 600 status code
     // so we need to mock it
-    const localScope = nock(HTTPBIN_URL).get('/status/600').reply(600, 'error');
+    const scope = nock(HTTPBIN_URL).get('/status/600').reply(600, 'error');
     const response = await request({
       url: `${HTTPBIN_URL}/status/600`,
     });
     response.status.should.equal(600);
-    localScope.isDone().should.be.true();
+    scope.isDone().should.be.true();
   });
 });
 

--- a/packages/core/types/schemas.generated.d.ts
+++ b/packages/core/types/schemas.generated.d.ts
@@ -4,7 +4,7 @@
  * files, and/or the schema-to-ts tool and run its CLI to regenerate
  * these typings.
  *
- * zapier-platform-schema version: 17.0.1
+ * zapier-platform-schema version: 17.0.2
  *  schema-to-ts compiler version: 0.1.0
  */
 import type {

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -11,6 +11,7 @@ const {
 } = require('zapier-platform-core/src/tools/cleaner');
 
 const { flattenPaths } = require('zapier-platform-core/src/tools/data');
+const { REPLACE_CURLIES } = require('zapier-platform-core/src/constants');
 
 const {
   ErrorException,
@@ -859,7 +860,7 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         request = {};
       }
 
-      request = { ...bundle.request, ...request, replace: true };
+      request = { ...bundle.request, ...request, [REPLACE_CURLIES]: true };
 
       const isBodyStream = typeof _.get(request, 'body.pipe') === 'function';
       if (!preMethod && !isBodyStream && isAnyFileFieldSet(bundle)) {

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -3836,7 +3836,7 @@ describe('Integration Test', function () {
       };
       return app(input).then((output) => {
         const file = output.results.file;
-        should.equal(file.sha1, '04bc9f090eafc29a4ab29b05f0f306365b017857');
+        should.equal(file.sha1, '0b01577e8e0063ec7048ddd8bcf17c06b821b452');
         should.equal(file.mimetype, 'application/json');
         should.equal(file.originalname, 'an example.json');
 
@@ -3866,7 +3866,7 @@ describe('Integration Test', function () {
       };
       return app(input).then((output) => {
         const file = output.results.file;
-        should.equal(file.sha1, 'ebad26f071d502f26ea7afccea320195c1ad7e8e');
+        should.equal(file.sha1, '35c06366ecfbb3c452cf8aa6abf2377f2281cfd9');
         should.equal(file.mimetype, 'application/json');
         should.equal(file.originalname, 'example.json');
 
@@ -3896,7 +3896,7 @@ describe('Integration Test', function () {
       };
       return app(input).then((output) => {
         const file = output.results.file;
-        should.equal(file.sha1, 'd7bd9d0e663a001291d1536715403744cbff054d');
+        should.equal(file.sha1, '69a1677af6e04e993b6b1415a4ba29be7a20388b');
         should.equal(file.mimetype, 'application/json');
         should.equal(file.originalname, '中文.json');
 
@@ -4160,7 +4160,7 @@ describe('Integration Test', function () {
           response.getHeader.should.be.Function();
           should.equal(
             response.getHeader('content-type'),
-            'application/json; encoding=utf-8',
+            'application/json; charset=utf-8',
           );
         });
       });
@@ -4196,7 +4196,7 @@ describe('Integration Test', function () {
           response.getHeader.should.be.Function();
           should.equal(
             response.getHeader('content-type'),
-            'application/json; encoding=utf-8',
+            'application/json; charset=utf-8',
           );
         });
       });
@@ -4235,7 +4235,7 @@ describe('Integration Test', function () {
           response.getHeader.should.be.Function();
           should.equal(
             response.getHeader('content-type'),
-            'application/json; encoding=utf-8',
+            'application/json; charset=utf-8',
           );
         });
       });
@@ -4278,7 +4278,7 @@ describe('Integration Test', function () {
           response.getHeader.should.be.Function();
           should.equal(
             response.getHeader('content-type'),
-            'application/json; encoding=utf-8',
+            'application/json; charset=utf-8',
           );
         });
       });

--- a/packages/legacy-scripting-runner/test/zfactory.js
+++ b/packages/legacy-scripting-runner/test/zfactory.js
@@ -72,9 +72,18 @@ describe('z', () => {
       response.should.have.property('content');
 
       response.status_code.should.eql(200);
+      debugger;
+
       const results = JSON.parse(response.content);
       results.args.should.eql({ hello: ['world'] });
-      results.data.should.eql(bundleRequest.data);
+
+      // Current version of httpbin.zapier-tooling.com encodes the input in
+      // base64 and returns it, so we need to decode it here.
+      const [header, encodedBody] = results.data.split(',');
+      header.should.eql('data:application/octet-stream;base64');
+
+      const decodedBody = Buffer.from(encodedBody, 'base64').toString('utf8');
+      decodedBody.should.eql(bundleRequest.data);
       results.headers.Accept.should.deepEqual(['application/json']);
 
       done();

--- a/packages/legacy-scripting-runner/test/zfactory.js
+++ b/packages/legacy-scripting-runner/test/zfactory.js
@@ -72,7 +72,6 @@ describe('z', () => {
       response.should.have.property('content');
 
       response.status_code.should.eql(200);
-      debugger;
 
       const results = JSON.parse(response.content);
       results.args.should.eql({ hello: ['world'] });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Changes:

- Internalize the flag that enables/disables `{{curlies}}` replacement in `z.request()`.
  - Use a [symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) instead of a property like `req.replace`. This makes it impossible to enable the replacement behavior with `z.request({ replace: true })`.
- Remove `{{curlies}}` support from Raw Requests ([`execute-request.js`](https://github.com/zapier/zapier-platform/blob/2cd98d1a404a7e9acbe1846c25244edb6769f67b/packages/core/src/execute-request.js))
- Disallow multi-pass `{{curlies}}` replacement.
  - See test case `should replace curlies in single pass` for what this change is about.
- legacy-scripting-runner's `z.request()` client still needs to keep `{{curlies}}` replacement for backward compatibility.

This is not a breaking change because:
- `req.replace` is already an internal flag, which this PR is removing.
- The v17.0.0 changelog already declared that `{{curlies}}` are no longer supported for manual requests (i.e. calling `z.request()` in a function).
- Raw Requests already don't support `{{curlies}}`. Currently, `{{curlies}}` are silently removed before the raw request is sent. After this change, it will throw an error.