### PR TITLE
PDE-6151 fix(cli): "Cannot find base config file" tsconfig warning

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -64,6 +64,7 @@ const requiredFiles = async ({ cwd, entryPoints }) => {
     format: 'esm',
     write: false, // no need to write outfile
     absWorkingDir: cwd,
+    tsconfigRaw: '{}',
   });
 
   return Object.keys(result.metafile.inputs).map((path) =>


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes this warning message when running `zapier build`:

![](https://cdn.zappy.app/4766c838bee2674a459afb7ed8e1a75d.png)