### PR TITLE
PDE-6145 fix(core): `{{curlies}}` in `requestTemplate` should be replaced

### DIFF
--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -148,33 +148,44 @@ const prepareRequest = function (req) {
 
   req = sugarBody(req);
 
-  // apply app requestTemplate to request
-  if (req.merge) {
-    const requestTemplate = (input._zapier?.app || {}).requestTemplate;
-    req = requestMerge(requestTemplate, req);
-  }
-
-  const replaceable = {
-    url: req.url,
-    headers: req.headers,
-    params: req.params,
-    body: req.body,
-  };
-
-  if (req[REPLACE_CURLIES]) {
-    // replace {{curlies}} in the request
+  if (req[REPLACE_CURLIES] || req.merge) {
     const bank = createBundleBank(
-      input._zapier.app,
-      input._zapier.event,
+      input?._zapier?.event || {},
       req.serializeValueForCurlies,
     );
-    req = {
-      ...req,
-      ...recurseReplaceBank(replaceable, bank),
+
+    const replaceable = {
+      url: req.url,
+      headers: req.headers,
+      params: req.params,
+      body: req.body,
     };
-  } else {
-    // throw if there's {{curlies}} in the request
-    throwForCurlies(replaceable);
+    if (req[REPLACE_CURLIES]) {
+      // replace {{curlies}} in the request
+      req = {
+        ...req,
+        ...recurseReplaceBank(replaceable, bank),
+      };
+    } else {
+      // throw if there's {{curlies}} in the request
+      throwForCurlies(replaceable);
+    }
+
+    if (req.merge) {
+      // Always replace {{curlies}} in reqeustTemplate regardless of
+      // req[REPLACE_CURLIES]
+      const requestTemplate = input._zapier?.app?.requestTemplate || {};
+      const replaceable = {
+        url: requestTemplate.url,
+        headers: requestTemplate.headers,
+        params: requestTemplate.params,
+        body: requestTemplate.body,
+      };
+      const renderedTemplate = recurseReplaceBank(replaceable, bank);
+
+      // Apply app.requestTemplate to request
+      req = requestMerge(renderedTemplate, req);
+    }
   }
 
   req = coerceBody(req);

--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -154,7 +154,7 @@ const prepareRequest = function (req) {
       req.serializeValueForCurlies,
     );
 
-    const replaceable = {
+    const requestReplaceable = {
       url: req.url,
       headers: req.headers,
       params: req.params,
@@ -164,24 +164,24 @@ const prepareRequest = function (req) {
       // replace {{curlies}} in the request
       req = {
         ...req,
-        ...recurseReplaceBank(replaceable, bank),
+        ...recurseReplaceBank(requestReplaceable, bank),
       };
     } else {
       // throw if there's {{curlies}} in the request
-      throwForCurlies(replaceable);
+      throwForCurlies(requestReplaceable);
     }
 
     if (req.merge) {
       // Always replace {{curlies}} in reqeustTemplate regardless of
       // req[REPLACE_CURLIES]
       const requestTemplate = input._zapier?.app?.requestTemplate || {};
-      const replaceable = {
+      const templateReplaceable = {
         url: requestTemplate.url,
         headers: requestTemplate.headers,
         params: requestTemplate.params,
         body: requestTemplate.body,
       };
-      const renderedTemplate = recurseReplaceBank(replaceable, bank);
+      const renderedTemplate = recurseReplaceBank(templateReplaceable, bank);
 
       // Apply app.requestTemplate to request
       req = requestMerge(renderedTemplate, req);

--- a/packages/core/src/tools/cleaner.js
+++ b/packages/core/src/tools/cleaner.js
@@ -143,7 +143,7 @@ const finalizeBundle = pipe(
 );
 
 // Takes a raw app and bundle and composes a bank of {{key}}->val
-const createBundleBank = (appRaw, event = {}, serializeFunc = (x) => x) => {
+const createBundleBank = (event = {}, serializeFunc = (x) => x) => {
   const bank = {
     bundle: finalizeBundle(event.bundle),
     process: {

--- a/packages/core/test/constants.js
+++ b/packages/core/test/constants.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const AUTH_JSON_SERVER = 'https://auth-json-server.zapier-staging.com';
 const HTTPBIN_URL = 'https://httpbin.zapier-tooling.com';
 
 module.exports = {
+  AUTH_JSON_SERVER,
   HTTPBIN_URL,
 };

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -478,6 +478,55 @@ describe('http prepareRequest', () => {
     });
     should(request.body).eql('{"name":""}');
   });
+
+  it('should handle two curlies in a string', async () => {
+    const request = prepareRequest({
+      [REPLACE_CURLIES]: true,
+      url: 'https://example.com/post',
+      method: 'POST',
+      body: {
+        full_name:
+          '{{bundle.inputData.first_name}} {{bundle.inputData.last_name}}',
+      },
+      input: {
+        _zapier: {
+          event: {
+            bundle: {
+              inputData: {
+                first_name: 'Michael',
+                last_name: 'Jordan',
+              },
+            },
+          },
+        },
+      },
+    });
+    should(request.body).eql('{"full_name":"Michael Jordan"}');
+  });
+
+  it('should replace no more than 1000 curlies', async () => {
+    const request = prepareRequest({
+      [REPLACE_CURLIES]: true,
+      url: 'https://example.com/post',
+      method: 'POST',
+      body: {
+        long: '{{bundle.inputData.answer}} '.repeat(1002) + '!',
+      },
+      input: {
+        _zapier: {
+          event: {
+            bundle: {
+              inputData: {
+                answer: 'no',
+              },
+            },
+          },
+        },
+      },
+    });
+    const { long } = JSON.parse(request.body);
+    should(long).eql('no '.repeat(1000) + '  !');
+  });
 });
 
 describe('http querystring before middleware', () => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

This PR fixes a regression on v17 where `{{curlies}}` in `requestTemplate` (a property in [`AppSchema`](https://github.com/zapier/zapier-platform/blob/2cd98d1a404a7e9acbe1846c25244edb6769f67b/packages/schema/docs/build/schema.md#appschema)) are no longer rendered. For example, an integration may define:

```
{
  requestTemplate: {
    headers: {
      authorization: 'Bearer {{bundle.authData.access_token}}'
    }
  }
}
```

Given `bundle.authData.access_token = 'a_token'`:

Expected behavior: Every `z.request()` call automatically includes the header `authorization: Bearer a_token`.

Current behavior in v17 (>=17.0.0 <=17.0.2): `z.request()` throws an error:

```
z.request() no longer supports {{bundle.*}} or {{process.*}} as of v17
```