### PR TITLE
PDE-6149 fix(legacy-scripting-runner): ensure `z.request()` renders `{{curlies}}` on different core versions

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.8.17
 
-- :hammer: Ensure `z.request` renders `{{curlies}}` on zapier-platform-core v17.1.0 ([#1037](https://github.com/zapier/zapier-platform/pull/1037))
+- :hammer: Ensure `z.request` renders `{{curlies}}` on different zapier-platform-core versions ([#1037](https://github.com/zapier/zapier-platform/pull/1037))
 
 ## 3.8.16
 

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.8.17
 
-- :hammer: Ensure `z.request` renders `{{curlies}}` on different zapier-platform-core versions ([#1037](https://github.com/zapier/zapier-platform/pull/1037))
+- :bug: Ensure `z.request` renders `{{curlies}}` on different zapier-platform-core versions ([#1037](https://github.com/zapier/zapier-platform/pull/1037))
 
 ## 3.8.16
 

--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.8.17
+
+- :hammer: Ensure `z.request` renders `{{curlies}}` on zapier-platform-core v17.1.0 ([#1037](https://github.com/zapier/zapier-platform/pull/1037))
+
 ## 3.8.16
 
 - :bug: sync `z.request` should log `request_params` ([#1017](https://github.com/zapier/zapier-platform/pull/1017))

--- a/packages/legacy-scripting-runner/index.js
+++ b/packages/legacy-scripting-runner/index.js
@@ -11,7 +11,7 @@ const {
 } = require('zapier-platform-core/src/tools/cleaner');
 
 const { flattenPaths } = require('zapier-platform-core/src/tools/data');
-const { REPLACE_CURLIES } = require('zapier-platform-core/src/constants');
+const constants = require('zapier-platform-core/src/constants');
 
 const {
   ErrorException,
@@ -860,7 +860,15 @@ const legacyScriptingRunner = (Zap, zcli, input) => {
         request = {};
       }
 
-      request = { ...bundle.request, ...request, [REPLACE_CURLIES]: true };
+      request = { ...bundle.request, ...request };
+
+      if (constants.REPLACE_CURLIES) {
+        // REPLACE_CURLIES is added in core v17.1.0
+        request[constants.REPLACE_CURLIES] = true;
+      } else {
+        // For core < v17.1.0
+        request.replace = true;
+      }
 
       const isBodyStream = typeof _.get(request, 'body.pipe') === 'function';
       if (!preMethod && !isBodyStream && isAnyFileFieldSet(bundle)) {

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "3.8.16",
+  "version": "3.8.17",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

A quick fix to ensure that, in legacy-scripting-runner 3.8.17 (to be released), `z.request()` will render `{{curlies}}` in different versions of zapier-platform-core.