### PR TITLE
fix(cli): prevent .cmd on custom binaries

### DIFF
--- a/packages/cli/src/utils/misc.js
+++ b/packages/cli/src/utils/misc.js
@@ -32,7 +32,10 @@ const runCommand = (command, args, options) => {
   options = options || {};
 
   if (isWindows()) {
-    command += '.cmd';
+    const needsCmdShim = ['npm', 'npx', 'yarn'].includes(command.toLowerCase())
+    if (needsCmdShim) {
+      command += '.cmd'
+    }
 
     // See CVE-2024-27980
     options.shell = true;


### PR DESCRIPTION
Prevents .cmd from being added to anything like node, node.exe, or custom binaries.

// Copilots thoughts:
This pull request updates the `runCommand` utility function to improve compatibility and security when executing commands on Windows systems.

### Compatibility improvements:
* Updated the `runCommand` function in `packages/cli/src/utils/misc.js` to append `.cmd` only for specific commands (`npm`, `npx`, `yarn`) by introducing a conditional check. This ensures better compatibility and avoids unnecessary modifications for other commands.
