### PR TITLE
PDE-6125 docs: move ESM import bug fix from 17.0.1 to 17.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ _released `2025-05-19`_
 
 ### core
 
-None!
+- :bug: ESM apps can't import `define` helpers from `zapier-platform-core` ([#1018](https://github.com/zapier/zapier-platform/pull/1018))
 
 ### schema
 
@@ -27,7 +27,6 @@ _released `2025-05-14`_
 ### core
 
 - :bug: `zapier build` (and therefore also `zapier push`) hangs on the `Building app definition.json` step when it's run on an integration with a Core dependency of v17, and run via CLI with a version less than v17 ([#1020](https://github.com/zapier/zapier-platform/pull/1020))
-- :bug: Downstream apps can't access members of the `zapier` library via deconstructed `import` statements ([#1018](https://github.com/zapier/zapier-platform/pull/1018))
 
 ### schema
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

While investigating https://github.com/zapier/zapier-platform/issues/1029, I found the bug fix #1018 was _not_ shipped in v17.0.1—it's in v17.0.2. This PR updates the changelog the reflect that.