### PR TITLE
PDE-6176 fix(core): unexpected line break in logged response content

### DIFF
--- a/packages/core/src/tools/create-http-patch.js
+++ b/packages/core/src/tools/create-http-patch.js
@@ -110,7 +110,7 @@ const createHttpPatch = (event) => {
           } else {
             const responseBody = _.map(chunks, (chunk) =>
               chunk.toString(),
-            ).join('\n');
+            ).join('');
             sendToLogger(responseBody);
           }
         };

--- a/packages/core/test/tools/create-http-patch.js
+++ b/packages/core/test/tools/create-http-patch.js
@@ -272,8 +272,11 @@ describe('create http patch', () => {
                 response_status_code: 200,
               });
 
+              // We've seen httpbin put a line break in the middle of a JSON
+              // object, so we need to remove it before parsing.
+              const responseContent = log.response_content.replaceAll('\n', '');
               const loggedIds = Array.from(
-                log.response_content.matchAll(/"id":(\d+)/g),
+                responseContent.matchAll(/"id":(\d+)/g),
                 (m) => m[1],
               );
               should(loggedIds).have.length(50);

--- a/packages/core/test/tools/create-http-patch.js
+++ b/packages/core/test/tools/create-http-patch.js
@@ -272,11 +272,8 @@ describe('create http patch', () => {
                 response_status_code: 200,
               });
 
-              // We've seen httpbin put a line break in the middle of a JSON
-              // object, so we need to remove it before parsing.
-              const responseContent = log.response_content.replaceAll('\n', '');
               const loggedIds = Array.from(
-                responseContent.matchAll(/"id":(\d+)/g),
+                log.response_content.matchAll(/"id":(\d+)/g),
                 (m) => m[1],
               );
               should(loggedIds).have.length(50);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes a bug where logged response content sometimes have an unexpected line break.

I found this bug because the test case [`should not cause missing bytes for late listener`](https://github.com/zapier/zapier-platform/blob/542da96acc5a305e6aed786d67d1d953f7615327/packages/core/test/tools/create-http-patch.js#L211) occasionally fails with this error message:

```
1) create http patch
       should not cause missing bytes for late listener:

      Uncaught AssertionError: expected 4 to equal 46
      + expected - actual

      -4
      +46
      
      at Assertion.fail (/.../zapier-platform/node_modules/should/cjs/should.js:275:17)
      at Assertion.value (/.../zapier-platform/node_modules/should/cjs/should.js:356:19)
      at IncomingMessage.<anonymous> (test/tools/create-http-patch.js:294:28)
      at IncomingMessage.emit (node:events:530:35)
      at IncomingMessage.emit (node:domain:489:12)
      at response.emit (src/tools/create-http-patch.js:124:31)
      at endReadableNT (node:internal/streams/readable:1698:12)
      at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
```

The failure is caused by a line break inserted in the middle of a JSON object, due to the logger joining content chunks with line breaks. For example, when the test failed, the logger put together the response content like this:

```
...
{"id":4
6,"args":{"chunk_size":["100"]},"headers":{"Accept":["*/*"],"Host":["httpbin.zapier-tooling.com"],"User-Agent":["curl/8.7.1"],"X-Forwarded-For":["10.101.11.2"],"X-Forwarded-Host":["httpbin.zapier-tooling.com"],"X-Forwarded-Port":["443"],"X-Forwarded-Proto":["https"],"X-Forwarded-Scheme":["https"],"X-Real-Ip":["10.101.11.2"],"X-Request-Id":["b107ea8a07f575d5d93a33708c567546"],"X-Scheme":["https"]},"origin":"10.101.11.2","url":"https://httpbin.zapier-tooling.com/stream/50?chunk_size=100"}
{"id":47,"args":{"chunk_size":["100"]},"headers":{"Accept":["*/*"],"Host":["httpbin.zapier-tooling.com"],"User-Agent":["curl/8.7.1"],"X-Forwarded-For":["10.101.11.2"],"X-Forwarded-Host":["httpbin.zapier-tooling.com"],"X-Forwarded-Port":["443"],"X-Forwarded-Proto":["https"],"X-Forwarded-Scheme":["https"],"X-Real-Ip":["10.101.11.2"],"X-Request-Id":["b107ea8a07f575d5d93a33708c567546"],"X-Scheme":["https"]},"origin":"10.101.11.2","url":"https://httpbin.zapier-tooling.com/stream/50?chunk_size=100"}
...
```

The line break between `4` and `6` caused the test to fail.