### PR TITLE
fix(core): Remove request body fields using undefined input data curlies for application/x-www-form-urlencoded content-type

### DIFF
--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -52,6 +52,7 @@ const coerceBody = (req) => {
 
   // auto coerce form if header says so
   if (contentType === FORM_TYPE && req.body && !_.isString(req.body)) {
+    normalizeEmptyBodyFields(req);
     req.body = querystring.stringify(req.body).replace(/%20/g, '+');
   }
 

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -527,6 +527,70 @@ describe('http prepareRequest', () => {
     const { long } = JSON.parse(request.body);
     should(long).eql('no '.repeat(1000) + '  !');
   });
+
+  it('should remove body fields using undefined input data curlies', async () => {
+    // With header "Content-Type": "application/json"
+    const requestForJsonBody = prepareRequest({
+      [REPLACE_CURLIES]: true,
+      url: 'https://example.com/post',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: {
+        name: '{{bundle.inputData.username}}',
+        email: '{{bundle.inputData.email}}',
+        language: '{{bundle.inputData.language}}',
+      },
+      removeMissingValuesFrom: {
+        body: true,
+        params: false,
+      },
+      input: {
+        _zapier: {
+          event: {
+            bundle: {
+              inputData: {
+                username: 'franklin',
+                language: 'eng',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    should(requestForJsonBody.body).eql('{"name":"franklin","language":"eng"}');
+
+    // With header "Content-Type": "application/x-www-form-urlencoded"
+    const requestForFormBody = prepareRequest({
+      [REPLACE_CURLIES]: true,
+      url: 'https://example.com/post',
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: {
+        name: '{{bundle.inputData.username}}',
+        email: '{{bundle.inputData.email}}',
+        language: '{{bundle.inputData.language}}',
+      },
+      removeMissingValuesFrom: {
+        body: true,
+        params: false,
+      },
+      input: {
+        _zapier: {
+          event: {
+            bundle: {
+              inputData: {
+                username: 'franklin',
+                language: 'eng',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    should(requestForFormBody.body).eql('name=franklin&language=eng');
+  });
 });
 
 describe('http querystring before middleware', () => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Unlike the requests with the header `Content-Type: application/json`, fields of the request body dependent on an undefined input data curlies are not removed for requests with header `Content-Type: application/x-www-form-urlencoded`. This change fixes that for both cases to ensure the removal.