### PR TITLE
feat(cli) - PDE-6172 - Prompt user for deprecation reason during deprecate

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -101,6 +101,28 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 * `zapier canary:list`
 
 
+## canary:status
+
+> Show detailed status and metrics for active canary deployments
+
+**Usage**: `zapier canary:status`
+
+**Flags**
+* `-d, --debug` | Show extra debugging output.
+* `-f, --format` | Change the way structured data is presented. If "json" or "raw", you can pipe the output of the command into other tools, such as jq. One of `[plain | json | raw | row | table]`. Defaults to `table`.
+* `-w, --window` | Time window for metrics One of `[5m | 15m | 30m | 1h]`. Defaults to `15m`.
+* `--watch` | Watch mode - continuously refresh the status
+* `-i, --interval` | Refresh interval in seconds (minimum 5)  Defaults to `30`.
+
+**Examples**
+* `zapier canary:status`
+* `zapier canary:status my-app-id`
+* `zapier canary:status --window 30m`
+* `zapier canary:status --watch`
+* `zapier canary:status --watch --interval 10`
+* `zapier canary:status --format json`
+
+
 ## convert
 
 > Convert a Visual Builder integration to a CLI integration.
@@ -161,11 +183,10 @@ This only works if there are no users or Zaps on that version. You will probably
 Use this when an integration version will not be supported or start breaking at a known date.
 
 When deprecating a version, you must provide a reason for the deprecation. You can either specify the reason using the --reason flag or you will be prompted to select from the following options:
-- API shutdown
+- API endpoint deprecated
 - Security vulnerability
 - Critical bug
 - Legal requirement
-- Breaking change
 - Other
 
 Zapier will immediately send emails warning users of the deprecation if a date less than 30 days in the future is set, otherwise the emails will be sent exactly 30 days before the configured deprecation date.
@@ -184,7 +205,7 @@ Do not use deprecation if you only have non-breaking changes, such as:
 
 **Flags**
 * `-f, --force` | Skip confirmation prompt. Use with caution.
-* `-r, --reason` | Reason for deprecation. One of `[api shutdown | security vulnerability | critical bug | legal requirement | breaking change | other]`.
+* `-r, --reason` | Reason for deprecation. One of `[api endpoint deprecated | security vulnerability | critical bug | legal requirement | other]`.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -6,11 +6,10 @@ const colors = require('colors/safe');
 const { callAPI, getSpecificVersionInfo } = require('../../utils/api');
 
 const DEPRECATION_REASONS = [
-  { name: 'API shutdown', value: 'api shutdown' },
+  { name: 'API endpoint deprecated', value: 'api endpoint deprecated' },
   { name: 'Security vulnerability', value: 'security vulnerability' },
   { name: 'Critical bug', value: 'critical bug' },
   { name: 'Legal requirement', value: 'legal requirement' },
-  { name: 'Breaking change', value: 'breaking change' },
   { name: 'Other', value: 'other' },
 ];
 


### PR DESCRIPTION
When a user deprecates an app version, we can prompt the user for the reason and pass this along to the deprecation API. 

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
