### PR TITLE
chore(core): PDE-6220 bump fernet to latest

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "@zapier/secret-scrubber": "^1.1.2",
     "content-disposition": "0.5.4",
     "dotenv": "16.5.0",
-    "fernet": "^0.4.0",
+    "fernet": "^0.3.3",
     "form-data": "4.0.1",
     "lodash": "4.17.21",
     "mime-types": "2.1.35",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,10 +4850,10 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@~3.1.2-1:
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.8.tgz#715f070bf6014f2ae992a98b3929258b713f08d5"
-  integrity sha512-4E+PJNbUbBrzQLB9Vw86eaF5xZ8MB6dw4aaZ67YhLNduTmqJ5AziuLrYikPWHJkC59DYZp+cyj+qg3vBE8OnOQ==
+crypto-js@~4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^2.0.0:
   version "2.0.0"
@@ -6096,12 +6096,12 @@ fdir@^6.4.4:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
   integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
 
-fernet@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/fernet/-/fernet-0.4.0.tgz#95d10a3660bf1ccfb4964687508ec2e2ba5eda25"
-  integrity sha512-FJgmKoMeG4eoM+bEbMyTzPx9US4W+sw4D0i6jSWSKHFYlFZv92UIWi6a/w6MEf2JNSO+Mth/T+u+d/ye1zwN9A==
+fernet@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/fernet/-/fernet-0.3.3.tgz#23f31a45aa55c08152bb40ea9102e5711cb6ecf9"
+  integrity sha512-DvvqouVhv3VCor83wkQbSycekYUKDRQ1IKqcInaF5n5BSKgWBVfYLbSf7RRxojwQO0DZySiz5MlM2vO4MG3SUg==
   dependencies:
-    crypto-js "~3.1.2-1"
+    crypto-js "~4.2.0"
     urlsafe-base64 "1.0.0"
 
 figures@3.2.0, figures@^3.0.0:


### PR DESCRIPTION
Bump to [latest fernet](https://www.npmjs.com/package/fernet) to resolve
```
node_modules/crypto-js
  fernet  <=0.3.1 || >=0.4.0
  Depends on vulnerable versions of crypto-js
  node_modules/fernet
    zapier-platform-core  >=17.2.0
    Depends on vulnerable versions of fernet
    node_modules/zapier-platform-core 
```
