### PR TITLE
PDE-6249 fix(core): log `text/xml` response content, not just `application/xml`

### DIFF
--- a/packages/core/src/tools/http.js
+++ b/packages/core/src/tools/http.js
@@ -9,7 +9,7 @@ const HTML_TYPE = 'text/html';
 const TEXT_TYPE = 'text/plain';
 const TEXT_TYPE_UTF8 = 'text/plain; charset=utf-8';
 const YAML_TYPE = 'application/yaml';
-const XML_TYPE = 'application/xml';
+const XML_TYPE = 'text/xml';
 const JSONAPI_TYPE = 'application/vnd.api+json';
 
 const ALLOWED_HTTP_DATA_CONTENT_TYPES = new Set([

--- a/packages/core/src/tools/http.js
+++ b/packages/core/src/tools/http.js
@@ -9,7 +9,8 @@ const HTML_TYPE = 'text/html';
 const TEXT_TYPE = 'text/plain';
 const TEXT_TYPE_UTF8 = 'text/plain; charset=utf-8';
 const YAML_TYPE = 'application/yaml';
-const XML_TYPE = 'text/xml';
+const XML_TEXT_TYPE = 'text/xml';
+const XML_APPLICATION_TYPE = 'application/xml';
 const JSONAPI_TYPE = 'application/vnd.api+json';
 
 const ALLOWED_HTTP_DATA_CONTENT_TYPES = new Set([
@@ -20,7 +21,8 @@ const ALLOWED_HTTP_DATA_CONTENT_TYPES = new Set([
   TEXT_TYPE,
   TEXT_TYPE_UTF8,
   YAML_TYPE,
-  XML_TYPE,
+  XML_TEXT_TYPE,
+  XML_APPLICATION_TYPE,
   JSONAPI_TYPE,
 ]);
 
@@ -122,7 +124,8 @@ module.exports = {
   HTML_TYPE,
   TEXT_TYPE,
   YAML_TYPE,
-  XML_TYPE,
+  XML_TEXT_TYPE,
+  XML_APPLICATION_TYPE,
   JSONAPI_TYPE,
   ALLOWED_HTTP_DATA_CONTENT_TYPES,
   getContentType,

--- a/packages/core/test/tools/create-http-patch.js
+++ b/packages/core/test/tools/create-http-patch.js
@@ -9,6 +9,7 @@ const {
   BINARY_TYPE,
   JSON_TYPE,
   TEXT_TYPE,
+  XML_APPLICATION_TYPE,
   XML_TEXT_TYPE,
 } = require('../../src/tools/http');
 const createAppTester = require('../../src/tools/create-app-tester');
@@ -102,7 +103,7 @@ describe('create http patch', () => {
         request_via_client: false,
         response_content: '<foo>bar</foo>',
         response_headers: {
-          'content-type': 'application/xml',
+          'content-type': 'text/xml',
         },
         response_status_code: 200,
       },
@@ -117,7 +118,7 @@ describe('create http patch', () => {
 
         // Response data
         res.statusCode = 200;
-        res.headers = { 'content-type': [XML_TEXT_TYPE] }; // XML type should be supported
+        res.headers = { 'content-type': [XML_APPLICATION_TYPE] }; // XML type should be supported
         callback(res);
         res.emit('data', Buffer.from('<foo>bar</foo>'));
         res.emit('end');

--- a/packages/core/test/tools/create-http-patch.js
+++ b/packages/core/test/tools/create-http-patch.js
@@ -9,7 +9,7 @@ const {
   BINARY_TYPE,
   JSON_TYPE,
   TEXT_TYPE,
-  XML_TYPE,
+  XML_TEXT_TYPE,
 } = require('../../src/tools/http');
 const createAppTester = require('../../src/tools/create-app-tester');
 const createHttpPatch = require('../../src/tools/create-http-patch');
@@ -67,7 +67,7 @@ describe('create http patch', () => {
 
         // Response data
         res.statusCode = 200;
-        res.headers = { 'content-type': XML_TYPE }; // XML type should be supported
+        res.headers = { 'content-type': XML_TEXT_TYPE }; // XML type should be supported
         callback(res);
         res.emit('data', Buffer.from('<foo>bar</foo>'));
         res.emit('end');
@@ -117,7 +117,7 @@ describe('create http patch', () => {
 
         // Response data
         res.statusCode = 200;
-        res.headers = { 'content-type': [XML_TYPE] }; // XML type should be supported
+        res.headers = { 'content-type': [XML_TEXT_TYPE] }; // XML type should be supported
         callback(res);
         res.emit('data', Buffer.from('<foo>bar</foo>'));
         res.emit('end');


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes a bug where `text/xml` response content should be logged. We're already logging `application/xml`, but both `text/xml` and `application/xml` should be allowed.