### PR TITLE
chore(core): Allow overriding `id` requirement in polling triggers

### DIFF
--- a/packages/core/types/functions.d.ts
+++ b/packages/core/types/functions.d.ts
@@ -2,9 +2,16 @@ import type { Bundle, ZObject } from './custom';
 
 type DefaultInputData = Record<string, unknown>;
 
+/**
+ * Wraps a `perform` function that is used to poll for data from an API.
+ * By default must return an array of objects with an `id` field, but
+ * when one or more output fields have `primary:true` set on them, this
+ * can be overridden by setting the second type parameter to a type with
+ * those keys.
+ */
 export type PollingTriggerPerform<
   $InputData extends DefaultInputData = DefaultInputData,
-  $Return extends { id: string } = { id: string }, // Primary key stuff later?
+  $Return extends {} = { id: string },
 > = (z: ZObject, bundle: Bundle<$InputData>) => $Return[] | Promise<$Return[]>;
 
 /**

--- a/packages/core/types/functions.test-d.ts
+++ b/packages/core/types/functions.test-d.ts
@@ -1,0 +1,18 @@
+import { expectAssignable } from 'tsd';
+import type { PollingTriggerPerform } from './functions';
+
+const simplePerform = (async (z, bundle) => {
+  return [{ id: '1', name: 'test' }];
+}) satisfies PollingTriggerPerform;
+
+expectAssignable<PollingTriggerPerform<{}, { id: string; name: string }>>(
+  simplePerform,
+);
+
+const primaryKeyOverridePerform = (async (z, bundle) => {
+  return [{ itemId: 123, name: 'test' }];
+}) satisfies PollingTriggerPerform<{}, { itemId: number; name: string }>;
+
+expectAssignable<PollingTriggerPerform<{}, { itemId: number; name: string }>>(
+  primaryKeyOverridePerform,
+);


### PR DESCRIPTION
By default, polling triggers require an `id` field in the array items they (promise to) return. This restriction can now be overridden by the second type argument to the `PollingTriggerPerform` type, in the case they are not using an `id` field and have specified `primary:true` on one or more output fields.

For example:

```ts
// Good: includes ID.
const perform1 = (async (z, bundle) => {
  return [{ id: '1', name: 'test' }];
}) satisfies PollingTriggerPerform;

// Bad, id not returned by default
const perform2 = (async (z, bundle) => {
  return [{ itemId: 1, name: 'test' }];
}) satisfies PollingTriggerPerform; // Error!

// Good, non-id return specified with return override.
const perform2 = (async (z, bundle) => {
  return [{ itemId: 1, name: 'test' }];
}) satisfies PollingTriggerPerform<B, {itemId: number, name: string}>; 
// B is the normal bundle inputs, omitted here.
```

It will be the developer's responsibility to make these return types correspond with the `primary` properties of the `outputfields`. 