### PR TITLE
[PDE-6175] request-worker added to bundle while require.resolve warning suppressed

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -70,6 +70,7 @@ const findRequiredFiles = async (workingDir, entryPoints) => {
     external: [
       '../test/userapp',
       'zapier-platform-core/src/http-middlewares/before/sanatize-headers', // appears in zapier-platform-legacy-scripting-runner/index.js
+      './xhr-sync-worker.js', // appears in jsdom/living/xmlhttprequest.js
     ],
     format,
     // Setting conditions to an empty array to exclude 'module' condition,

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -64,11 +64,12 @@ const findRequiredFiles = async (workingDir, entryPoints) => {
     platform: 'node',
     metafile: true,
     logLevel: 'warning',
+    logOverride: {
+      'require-resolve-not-external': 'silent',
+    },
     external: [
       '../test/userapp',
       'zapier-platform-core/src/http-middlewares/before/sanatize-headers', // appears in zapier-platform-legacy-scripting-runner/index.js
-      './request-worker', // appears in zapier-platform-legacy-scripting-runner/zfactory.js
-      './xhr-sync-worker.js', // appears in jsdom/living/xmlhttprequest.js
     ],
     format,
     // Setting conditions to an empty array to exclude 'module' condition,


### PR DESCRIPTION
This PR re-adds `request-worker` to the bundle built by ESBuild while the warning of `require.resolve` suppressed.