### PR TITLE
PDE-6289 - Add user and account filters to canary

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -55,11 +55,11 @@ This command is typically followed by `zapier upload`.
 
 Only one canary can be active at the same time. You can run `zapier canary:list` to check. If you would like to create a new canary with different parameters, you can wait for the canary to finish, or delete it using `zapier canary:delete a.b.c x.y.z`.
 
-For migrating a specific user, you can pass in the --user flag. 
+To canary traffic for a specific user, use the --user flag.
 
-For migrating a specific user within a specific account, you can pass in the --user flag with the --accountId flag.
+To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
 
-For migrating a specific account, you can pass in the --accountId flag with an --owner flag. This is the only use case for the --owner flag, as it helps isolate the account filter.
+To canary traffic for an entire account, use both --accountId and --owner flags. The --owner flag is only used with --accountId to isolate the account filter.
 
 Note: this is similar to `zapier migrate` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
@@ -72,17 +72,16 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 **Flags**
 * (required) `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
-* `-u, --user` | Canary this user across all accounts, unless account_id is specified.
-* `-o, --owner` | Canary the account_id. Only used when account_id is also used.
-* `-a, --accountId` | The account id to target. If owner is specified, Canary applies to all traffic for the account. If user is specified, only canary the user within this account.
+* `-u, --user` | Canary this user across all accounts, unless `accountId` is specified.
+* `-o, --owner` | Canary the accountId. Only used when `--accountId` is also used.
+* `-a, --accountId` | The account ID to target. If owner is specified, canary applies to all traffic for the account. If user is specified, only canary the user within this account.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**
-* `zapier canary:create 1.0.0 1.1.0 -p 25 -d 720`
-* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300`
-* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --user user@example.com`
-* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --account_id 123 --owner admin@example.com`
-* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --account_id 123 --user user@example.com`
+* `zapier canary:create 1.0.0 1.1.0 -p 10 -d 3600`
+* `zapier canary:create 2.0.0 2.1.0 --percent 25 --duration 1800 --user user@example.com`
+* `zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345 -u user@example.com`
+* `zapier canary:create 2.0.0 2.1.0 -p 50 -d 600 -a 12345 -o admin@example.com`
 
 
 ## canary:delete

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -72,8 +72,8 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 **Flags**
 * (required) `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
-* `-u, --user` | Canary this user across all accounts, unless `accountId` is specified.
-* `-o, --owner` | Canary the accountId. Only used when `--accountId` is also used.
+* `-u, --user` | Canary this user (email) across all accounts, unless `accountId` is specified.
+* `-o, --owner` | The owner (email) of the account to target. This canaries all traffic for the specified account. Only used when `--accountId` is also used. This differs from the `user` flag, which targets specific users within an account.
 * `-a, --accountId` | The account ID to target. If owner is specified, canary applies to all traffic for the account. If user is specified, only canary the user within this account.
 * `-d, --debug` | Show extra debugging output.
 

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -55,6 +55,12 @@ This command is typically followed by `zapier upload`.
 
 Only one canary can be active at the same time. You can run `zapier canary:list` to check. If you would like to create a new canary with different parameters, you can wait for the canary to finish, or delete it using `zapier canary:delete a.b.c x.y.z`.
 
+For migrating a specific user, you can pass in the --user flag. 
+
+For migrating a specific user within a specific account, you can pass in the --user flag with the --accountId flag.
+
+For migrating a specific account, you can pass in the --accountId flag with an --owner flag. This is the only use case for the --owner flag, as it helps isolate the account filter.
+
 Note: this is similar to `zapier migrate` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
 **Only use this command to canary traffic between non-breaking versions!**
@@ -66,9 +72,9 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 **Flags**
 * (required) `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
-* `--user` | Canary this user across all accounts, unless account_id is specified.
-* `--owner` | Canary the account_id. Only used when account_id is also used.
-* `--accountId` | The account id to target. If owner is specified, Canary applies to all traffic for the account. If user is specified, only canary the user within this account.
+* `-u, --user` | Canary this user across all accounts, unless account_id is specified.
+* `-o, --owner` | Canary the account_id. Only used when account_id is also used.
+* `-a, --accountId` | The account id to target. If owner is specified, Canary applies to all traffic for the account. If user is specified, only canary the user within this account.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -74,6 +74,7 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 * (required) `-d, --duration` | Duration of the canary in seconds
 * `-u, --user` | Canary this user (email) across all accounts, unless `account-id` is specified.
 * `-a, --account-id` | The account ID to target. If user is specified, only canary the user within this account. If user is not specified, then this argument is only permitted for Zapier staff.
+* `-f, --force-include-all` | Overrides any default filters the canary system imposes. This argument is only permitted for Zapier staff.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -64,8 +64,11 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 * (required) `versionTo` | Version to canary traffic to
 
 **Flags**
-* (required) `-p, --percent` | Percent of traffic to route to new version
+* `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
+* `--user` | Specify a user within all accounts to canary
+* `--account` | Canary all accounts for which the specified user is a member
+* `--includeEnterprise` | Include enterprise accounts
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -57,9 +57,9 @@ Only one canary can be active at the same time. You can run `zapier canary:list`
 
 To canary traffic for a specific user, use the --user flag.
 
-To canary traffic for an entire account, use the --accountId. Note: this scenario is only permitted for Zapier staff.
+To canary traffic for an entire account, use the --account-id. Note: this scenario is only permitted for Zapier staff.
 
-To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
+To canary traffic for a specific user within a specific account, use both --user and --account-id flags.
 
 Note: this is similar to `zapier migrate` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
@@ -72,8 +72,8 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 **Flags**
 * (required) `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
-* `-u, --user` | Canary this user (email) across all accounts, unless `accountId` is specified.
-* `-a, --accountId` | The account ID to target. If user is specified, only canary the user within this account.
+* `-u, --user` | Canary this user (email) across all accounts, unless `account-id` is specified.
+* `-a, --account-id` | The account ID to target. If user is specified, only canary the user within this account. If user is not specified, then this argument is only permitted for Zapier staff.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -64,16 +64,19 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 * (required) `versionTo` | Version to canary traffic to
 
 **Flags**
-* `-p, --percent` | Percent of traffic to route to new version
+* (required) `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
-* `--user` | Specify a user within all accounts to canary
-* `--account` | Canary all accounts for which the specified user is a member
-* `--includeEnterprise` | Include enterprise accounts
+* `--user` | Canary this user across all accounts, unless account_id is specified.
+* `--owner` | Canary the account_id. Only used when account_id is also used.
+* `--accountId` | The account id to target. If owner is specified, Canary applies to all traffic for the account. If user is specified, only canary the user within this account.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**
 * `zapier canary:create 1.0.0 1.1.0 -p 25 -d 720`
 * `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300`
+* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --user user@example.com`
+* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --account_id 123 --owner admin@example.com`
+* `zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --account_id 123 --user user@example.com`
 
 
 ## canary:delete

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -57,9 +57,9 @@ Only one canary can be active at the same time. You can run `zapier canary:list`
 
 To canary traffic for a specific user, use the --user flag.
 
-To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
+To canary traffic for an entire account, use the --accountId. Note: this scenario is only permitted for Zapier staff.
 
-To canary traffic for an entire account, use both --accountId and --owner flags. The --owner flag is only used with --accountId to isolate the account filter.
+To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
 
 Note: this is similar to `zapier migrate` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
@@ -73,15 +73,14 @@ Note: this is similar to `zapier migrate` but different in that this is temporar
 * (required) `-p, --percent` | Percent of traffic to route to new version
 * (required) `-d, --duration` | Duration of the canary in seconds
 * `-u, --user` | Canary this user (email) across all accounts, unless `accountId` is specified.
-* `-o, --owner` | The owner (email) of the account to target. This canaries all traffic for the specified account. Only used when `--accountId` is also used. This differs from the `user` flag, which targets specific users within an account.
-* `-a, --accountId` | The account ID to target. If owner is specified, canary applies to all traffic for the account. If user is specified, only canary the user within this account.
+* `-a, --accountId` | The account ID to target. If user is specified, only canary the user within this account.
 * `-d, --debug` | Show extra debugging output.
 
 **Examples**
 * `zapier canary:create 1.0.0 1.1.0 -p 10 -d 3600`
 * `zapier canary:create 2.0.0 2.1.0 --percent 25 --duration 1800 --user user@example.com`
 * `zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345 -u user@example.com`
-* `zapier canary:create 2.0.0 2.1.0 -p 50 -d 600 -a 12345 -o admin@example.com`
+* `zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345`
 
 
 ## canary:delete

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -10,6 +10,7 @@ class CanaryCreateCommand extends ZapierBaseCommand {
     const duration = this.flags.duration;
     const user = this.flags.user;
     const accountId = this.flags['account-id'];
+    const forceIncludeAll = this.flags['force-include-all'];
 
     this.validateVersions(versionFrom, versionTo);
     this.validatePercent(percent);
@@ -46,6 +47,11 @@ If you would like to stop this canary now, run \`zapier canary:delete ${existing
     if (accountId) {
       body.account_id = parseInt(accountId);
       createCanaryMessage += `\n    - Account ID: ${accountId}`;
+    }
+
+    if (forceIncludeAll) {
+      body.force_include_all = true;
+      createCanaryMessage += `\n    - Force Include All: true`;
     }
 
     this.startSpinner(createCanaryMessage);
@@ -98,6 +104,11 @@ CanaryCreateCommand.flags = buildFlags({
       char: 'a',
       description:
         'The account ID to target. If user is specified, only canary the user within this account. If user is not specified, then this argument is only permitted for Zapier staff.',
+    }),
+    'force-include-all': Flags.boolean({
+      char: 'f',
+      description:
+        'Overrides any default filters the canary system imposes. This argument is only permitted for Zapier staff.',
     }),
   },
 });

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -9,13 +9,11 @@ class CanaryCreateCommand extends ZapierBaseCommand {
     const percent = this.flags.percent;
     const duration = this.flags.duration;
     const user = this.flags.user;
-    const owner = this.flags.owner;
     const accountId = this.flags.accountId;
 
     this.validateVersions(versionFrom, versionTo);
     this.validatePercent(percent);
     this.validateDuration(duration);
-    this.validateAudienceFilters(accountId, user, owner);
 
     const activeCanaries = await listCanaries();
     if (activeCanaries.objects.length > 0) {
@@ -43,9 +41,6 @@ If you would like to stop this canary now, run \`zapier canary:delete ${existing
     if (user) {
       body.user = user;
       createCanaryMessage += `\n    - User: ${user}`;
-    } else if (owner) {
-      body.owner = owner;
-      createCanaryMessage += `\n    - Owner: ${owner}`;
     }
 
     if (accountId) {
@@ -80,31 +75,6 @@ If you would like to stop this canary now, run \`zapier canary:delete ${existing
       this.error('`--duration` must be a positive number between 30 and 86400');
     }
   }
-
-  /**
-   * // Valid combinations:
-  // 1. No filters (canary all traffic)
-  // 2. user only (canary user across all accounts) 
-  // 3. accountId + user (canary user within specific account)
-  // 4. accountId + owner (canary all traffic for specific account)
-   */
-  validateAudienceFilters(accountId, user, owner) {
-    if (user && owner) {
-      this.error(
-        'Cannot specify both `--user` and `--owner`. Use only one or the other.',
-      );
-    }
-
-    if (owner && !accountId) {
-      this.error('Cannot specify `--owner` without `--accountId`.');
-    }
-
-    if (accountId && !user && !owner) {
-      this.error(
-        'Cannot specify `--accountId` without either `--user` or `--owner`. Specify who to target within the account.',
-      );
-    }
-  }
 }
 
 CanaryCreateCommand.flags = buildFlags({
@@ -124,15 +94,10 @@ CanaryCreateCommand.flags = buildFlags({
       description:
         'Canary this user (email) across all accounts, unless `accountId` is specified.',
     }),
-    owner: Flags.string({
-      char: 'o',
-      description:
-        'The owner (email) of the account to target. This canaries all traffic for the specified account. Only used when `--accountId` is also used. This differs from the `user` flag, which targets specific users within an account.',
-    }),
     accountId: Flags.string({
       char: 'a',
       description:
-        'The account ID to target. If owner is specified, canary applies to all traffic for the account. If user is specified, only canary the user within this account.',
+        'The account ID to target. If user is specified, only canary the user within this account.',
     }),
   },
 });
@@ -154,9 +119,9 @@ Only one canary can be active at the same time. You can run \`zapier canary:list
 
 To canary traffic for a specific user, use the --user flag.
 
-To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
+To canary traffic for an entire account, use the --accountId. Note: this scenario is only permitted for Zapier staff.
 
-To canary traffic for an entire account, use both --accountId and --owner flags. The --owner flag is only used with --accountId to isolate the account filter.
+To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
 
 Note: this is similar to \`zapier migrate\` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
@@ -166,7 +131,7 @@ CanaryCreateCommand.examples = [
   'zapier canary:create 1.0.0 1.1.0 -p 10 -d 3600',
   'zapier canary:create 2.0.0 2.1.0 --percent 25 --duration 1800 --user user@example.com',
   'zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345 -u user@example.com',
-  'zapier canary:create 2.0.0 2.1.0 -p 50 -d 600 -a 12345 -o admin@example.com',
+  'zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345',
 ];
 CanaryCreateCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -9,7 +9,7 @@ class CanaryCreateCommand extends ZapierBaseCommand {
     const percent = this.flags.percent;
     const duration = this.flags.duration;
     const user = this.flags.user;
-    const accountId = this.flags.accountId;
+    const accountId = this.flags['account-id'];
 
     this.validateVersions(versionFrom, versionTo);
     this.validatePercent(percent);
@@ -92,12 +92,12 @@ CanaryCreateCommand.flags = buildFlags({
     user: Flags.string({
       char: 'u',
       description:
-        'Canary this user (email) across all accounts, unless `accountId` is specified.',
+        'Canary this user (email) across all accounts, unless `account-id` is specified.',
     }),
-    accountId: Flags.string({
+    'account-id': Flags.string({
       char: 'a',
       description:
-        'The account ID to target. If user is specified, only canary the user within this account.',
+        'The account ID to target. If user is specified, only canary the user within this account. If user is not specified, then this argument is only permitted for Zapier staff.',
     }),
   },
 });
@@ -119,9 +119,9 @@ Only one canary can be active at the same time. You can run \`zapier canary:list
 
 To canary traffic for a specific user, use the --user flag.
 
-To canary traffic for an entire account, use the --accountId. Note: this scenario is only permitted for Zapier staff.
+To canary traffic for an entire account, use the --account-id. Note: this scenario is only permitted for Zapier staff.
 
-To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
+To canary traffic for a specific user within a specific account, use both --user and --account-id flags.
 
 Note: this is similar to \`zapier migrate\` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -106,14 +106,17 @@ CanaryCreateCommand.flags = buildFlags({
       required: true,
     }),
     user: Flags.string({
+      char: 'u',
       description:
         'Canary this user across all accounts, unless account_id is specified.',
     }),
     owner: Flags.string({
+      char: 'o',
       description:
         'Canary the account_id. Only used when account_id is also used.',
     }),
     accountId: Flags.string({
+      char: 'a',
       description:
         'The account id to target. If owner is specified, Canary applies to all traffic for the account. If user is specified, only canary the user within this account.',
     }),
@@ -134,6 +137,12 @@ CanaryCreateCommand.args = {
 CanaryCreateCommand.description = `Create a new canary deployment, diverting a specified percentage of traffic from one version to another for a specified duration.
 
 Only one canary can be active at the same time. You can run \`zapier canary:list\` to check. If you would like to create a new canary with different parameters, you can wait for the canary to finish, or delete it using \`zapier canary:delete a.b.c x.y.z\`.
+
+For migrating a specific user, you can pass in the --user flag. 
+
+For migrating a specific user within a specific account, you can pass in the --user flag with the --accountId flag.
+
+For migrating a specific account, you can pass in the --accountId flag with an --owner flag. This is the only use case for the --owner flag, as it helps isolate the account filter.
 
 Note: this is similar to \`zapier migrate\` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -44,7 +44,7 @@ If you would like to stop this canary now, run \`zapier canary:delete ${existing
     }
 
     if (accountId) {
-      body.account_id = accountId;
+      body.account_id = parseInt(accountId);
       createCanaryMessage += `\n    - Account ID: ${accountId}`;
     }
 

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -108,17 +108,17 @@ CanaryCreateCommand.flags = buildFlags({
     user: Flags.string({
       char: 'u',
       description:
-        'Canary this user across all accounts, unless account_id is specified.',
+        'Canary this user across all accounts, unless `accountId` is specified.',
     }),
     owner: Flags.string({
       char: 'o',
       description:
-        'Canary the account_id. Only used when account_id is also used.',
+        'Canary the accountId. Only used when `--accountId` is also used.',
     }),
     accountId: Flags.string({
       char: 'a',
       description:
-        'The account id to target. If owner is specified, Canary applies to all traffic for the account. If user is specified, only canary the user within this account.',
+        'The account ID to target. If owner is specified, canary applies to all traffic for the account. If user is specified, only canary the user within this account.',
     }),
   },
 });
@@ -138,22 +138,21 @@ CanaryCreateCommand.description = `Create a new canary deployment, diverting a s
 
 Only one canary can be active at the same time. You can run \`zapier canary:list\` to check. If you would like to create a new canary with different parameters, you can wait for the canary to finish, or delete it using \`zapier canary:delete a.b.c x.y.z\`.
 
-For migrating a specific user, you can pass in the --user flag. 
+To canary traffic for a specific user, use the --user flag.
 
-For migrating a specific user within a specific account, you can pass in the --user flag with the --accountId flag.
+To canary traffic for a specific user within a specific account, use both --user and --accountId flags.
 
-For migrating a specific account, you can pass in the --accountId flag with an --owner flag. This is the only use case for the --owner flag, as it helps isolate the account filter.
+To canary traffic for an entire account, use both --accountId and --owner flags. The --owner flag is only used with --accountId to isolate the account filter.
 
 Note: this is similar to \`zapier migrate\` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
 **Only use this command to canary traffic between non-breaking versions!**`;
 
 CanaryCreateCommand.examples = [
-  'zapier canary:create 1.0.0 1.1.0 -p 25 -d 720',
-  'zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300',
-  'zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --user user@example.com',
-  'zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --account_id 123 --owner admin@example.com',
-  'zapier canary:create 2.0.0 2.1.0 --percent 50 --duration 300 --account_id 123 --user user@example.com',
+  'zapier canary:create 1.0.0 1.1.0 -p 10 -d 3600',
+  'zapier canary:create 2.0.0 2.1.0 --percent 25 --duration 1800 --user user@example.com',
+  'zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345 -u user@example.com',
+  'zapier canary:create 2.0.0 2.1.0 -p 50 -d 600 -a 12345 -o admin@example.com',
 ];
 CanaryCreateCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -108,12 +108,12 @@ CanaryCreateCommand.flags = buildFlags({
     user: Flags.string({
       char: 'u',
       description:
-        'Canary this user across all accounts, unless `accountId` is specified.',
+        'Canary this user (email) across all accounts, unless `accountId` is specified.',
     }),
     owner: Flags.string({
       char: 'o',
       description:
-        'Canary the accountId. Only used when `--accountId` is also used.',
+        'The owner (email) of the account to target. This canaries all traffic for the specified account. Only used when `--accountId` is also used. This differs from the `user` flag, which targets specific users within an account.',
     }),
     accountId: Flags.string({
       char: 'a',

--- a/packages/cli/src/oclif/commands/canary/list.js
+++ b/packages/cli/src/oclif/commands/canary/list.js
@@ -12,6 +12,9 @@ class CanaryListCommand extends ZapierBaseCommand {
       to_version: c.to_version,
       percent: c.percent,
       seconds_remaining: c.until_timestamp - Math.floor(Date.now() / 1000),
+      user: c.user,
+      owner: c.owner,
+      account_id: c.account_id,
     }));
 
     this.log(bold('Active Canaries') + '\n');
@@ -22,6 +25,9 @@ class CanaryListCommand extends ZapierBaseCommand {
         ['To Version', 'to_version'],
         ['Traffic Amount', 'percent'],
         ['Seconds Remaining', 'seconds_remaining'],
+        ['User', 'user'],
+        ['Owner', 'owner'],
+        ['Account ID', 'account_id'],
       ],
       emptyMessage: grey(`No active canary deployments found.`),
     });

--- a/packages/cli/src/oclif/commands/canary/list.js
+++ b/packages/cli/src/oclif/commands/canary/list.js
@@ -13,7 +13,6 @@ class CanaryListCommand extends ZapierBaseCommand {
       percent: c.percent,
       seconds_remaining: c.until_timestamp - Math.floor(Date.now() / 1000),
       user: c.user,
-      owner: c.owner,
       account_id: c.account_id,
     }));
 
@@ -26,7 +25,6 @@ class CanaryListCommand extends ZapierBaseCommand {
         ['Traffic Amount', 'percent'],
         ['Seconds Remaining', 'seconds_remaining'],
         ['User', 'user'],
-        ['Owner', 'owner'],
         ['Account ID', 'account_id'],
       ],
       emptyMessage: grey(`No active canary deployments found.`),

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -154,17 +154,14 @@ const createCredentials = (username, password, totpCode) => {
   );
 };
 
-const createCanary = async (versionFrom, versionTo, percent, duration) => {
+const createCanary = async (versionFrom, versionTo, body) => {
   const linkedAppId = (await getLinkedAppConfig(undefined, true))?.id;
 
   return callAPI(
     `/apps/${linkedAppId}/versions/${versionFrom}/canary-to/${versionTo}`,
     {
       method: 'POST',
-      body: {
-        percent,
-        duration,
-      },
+      body,
     },
   );
 };


### PR DESCRIPTION
To improve the usability of `zapier canary`, I am looking to add several "audience" type target filters to help isolate canary tests.
The general percentage applies the change to all users, with no way to isolate any problematic invocations to test out a bug fix for instance. 
This PR then aims to add the following filters:
- user (email): to filter by user, can be used with accountId
- accountId: to filter by account