### PR TITLE
PDE-6286 fix(cli): `zapier build` misses local package files when building in a lerna monorepo

### DIFF
--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -375,6 +375,10 @@ module.exports = {
   };
 };
 
+describe('build in lerna monorepo', function () {
+  // TODO
+});
+
 describe('build in yarn workspaces', function () {
   let monorepo, origCwd;
 

--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -461,7 +461,7 @@ describe('build in lerna monorepo', function () {
     // lerna@7 removed the bootstrap command, so we use lerna@6.
     // Lerna now actually recommends using the workspace feature from your
     // package manager, so this test suite is more of a regression test.
-    await runCommand('npx', ['lerna@6', 'bootstrap'], {
+    await runCommand('npx', ['lerna@6', 'bootstrap', '--no-ci'], {
       cwd: monorepo.repoDir,
     });
   });

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -223,6 +223,10 @@ const looksLikeWorkspaceRoot = async (dir) => {
     return true;
   }
 
+  if (fs.existsSync(path.join(dir, 'lerna.json'))) {
+    return true;
+  }
+
   const packageJsonPath = path.join(dir, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
     return false;
@@ -238,24 +242,11 @@ const looksLikeWorkspaceRoot = async (dir) => {
   return packageJson?.workspaces != null;
 };
 
-const countStartingDoubleDots = (relPath) => {
-  let count = 0;
-  const parts = relPath.split(path.sep);
-  for (const part of parts) {
-    if (part === '..') {
-      count += 1;
-    } else {
-      break;
-    }
-  }
-  return count;
-};
-
 // Traverses up the directory tree to find the workspace root. The workspace
 // root directory either:
 // - contains pnpm-workspace.yaml
 // - contains a package.json file with a "workspaces" field
-// - contains local packages
+// - contains lerna.json
 // Returns the absolute path to the workspace root directory, or null if not
 // found.
 const findWorkspaceRoot = async (workingDir, relPaths) => {
@@ -269,22 +260,6 @@ const findWorkspaceRoot = async (workingDir, relPaths) => {
     }
     dir = path.dirname(dir);
   }
-
-  // Check if any relPaths match something like '../../common/utils/file.js'
-  let maxNumDoubleDots = 0;
-  for (const relPath of relPaths) {
-    const numDoubleDots = countStartingDoubleDots(relPath);
-    maxNumDoubleDots = Math.max(maxNumDoubleDots, numDoubleDots);
-  }
-
-  if (maxNumDoubleDots > 0) {
-    let rootDir = workingDir;
-    for (let i = 0; i < maxNumDoubleDots; i++) {
-      rootDir = path.dirname(rootDir);
-    }
-    return rootDir;
-  }
-
   return null;
 };
 

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -249,7 +249,7 @@ const looksLikeWorkspaceRoot = async (dir) => {
 // - contains lerna.json
 // Returns the absolute path to the workspace root directory, or null if not
 // found.
-const findWorkspaceRoot = async (workingDir, relPaths) => {
+const findWorkspaceRoot = async (workingDir) => {
   let dir = workingDir;
   for (let i = 0; i < 500; i++) {
     if (await looksLikeWorkspaceRoot(dir)) {
@@ -327,8 +327,7 @@ const writeBuildZipSmartly = async (workingDir, zip) => {
     ]),
   ).sort();
 
-  const workspaceRoot =
-    (await findWorkspaceRoot(workingDir, relPaths)) || workingDir;
+  const workspaceRoot = (await findWorkspaceRoot(workingDir)) || workingDir;
 
   if (workspaceRoot !== workingDir) {
     const appDirRelPath = path.relative(workspaceRoot, workingDir);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes a bug where `zapier build --skip-npm-install` failed to recognize a Lerna monorepo. In which case, it should build the app at the project root rather than the app directory.

For example, for a Lerna monorepo that looks like this:

```
(project root)
  lerna.json
  package.json
  common/
    libary-1/
      package.json
  packages/
    app-1/
      package.json
      ...
```

`zapier build --skip-npm-install` should build at the project root instead of `packages/app-1`. When it builds in `packages/app-1`, like it does currently, `common/library-1` will be missing in the output build.zip file.

The fix is simple. We only need to add a few lines to make `looksLikeWorkspaceRoot()` return true when there's a `lerna.json` file.

While I was there, I added test coverage not only for the Lerna case, but also for yarn and pnpm cases.