### PR TITLE
PDE-6313 fix(cli): `zapier build` fails with "Configuration property is not defined"

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -331,7 +331,10 @@ const writeBuildZipSmartly = async (workingDir, zip) => {
 
   if (workspaceRoot !== workingDir) {
     const appDirRelPath = path.relative(workspaceRoot, workingDir);
-    const linkNames = ['zapierwrapper.js', 'index.js'];
+    const linkNames = ['zapierwrapper.js', 'index.js', 'config'];
+    // zapierwrapper.js and index.js are entry points.
+    // 'config' is the default directory that the 'config' npm package expects
+    // to find config files at the root directory.
     for (const name of linkNames) {
       if (fs.existsSync(path.join(workingDir, name))) {
         zip.symlink(name, path.join(appDirRelPath, name), 0o644);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Fixes a bug where `zapier build --skip-npm-install` may fail with this error:

```
zapier-dev build --skip-npm-install --skip-validation
✔ Running _zapier-build script
✔ Applying entry point files
✔ Building app definition.json
✔ Zipping project and dependencies
✔ Cleaning up temp files
✖ Testing build
 ›   Error: WARNING: No configurations found in configuration directory:/private/var/folders/d2/mgr1_yd518n0ygmzycx94hv40000gn/T/zapier-9c80fccc/config
 ›   WARNING: To disable this warning set SUPPRESS_NO_CONFIG_WARNING in the environment.
 ›   WARNING: No configurations found in configuration directory:/private/var/folders/d2/mgr1_yd518n0ygmzycx94hv40000gn/T/zapier-9c80fccc/config
 ›   WARNING: To disable this warning set SUPPRESS_NO_CONFIG_WARNING in the environment.
 ›   /private/var/folders/d2/mgr1_yd518n0ygmzycx94hv40000gn/T/zapier-9c80fccc/apps/myapp/node_modules/config/lib/config.js:181
 ›       throw new Error('Configuration property "' + property + '" is not defined');
 ›       ^
 ›
 ›   Error: Configuration property "API.BASE_URL" is not defined
 ›       at Config.get (/private/var/folders/d2/mgr1_yd518n0ygmzycx94hv40000gn/T/zapier-9c80fccc/apps/myapp/node_modules/config/lib/config.js:181:11)
 ›       <redacted>...
```

The root cause is that the `config` package looks for config files in `<cwd>/config` by default. Suppose we have a monorepo:

```
(project root)
  package.json
  index.js
  apps/
    app-1/
      package.json
      index.js
      config/
        default.js
      node_modules/
        ...
```

**Before** this PR, running `zapier build --skip-npm-install` in `apps/app-1` would create a build.zip like this:

```
(zip root)
  package.json      (copied from apps/app-1/package.json)
  index.js -> apps/app-1/index.js
  zapierwrapper.js -> apps/app-1/index.js
  definition.json   (copied from apps/app-1/definition.json)
  apps/
    app-1/
      package.json
      index.js
      zapierwrapper.js   (auto-generated)
      definition.json    (auto-generated)
      config/
        default.js
      node_modules/
        ...
```

**Afer** this PR, the build.zip file will have an additional symlink `config`:

```
(zip root)
  config -> apps/app-1/config
  ... the rest are the same ...
```