### PR TITLE
BREAKING CHANGE (core): PDE-6283 add nodejs22 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
           - ubuntu-latest
           # TODO: Fix tests on Windows
           # - windows-latest
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           cache: yarn
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           cache: yarn
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -83,7 +83,7 @@ jobs:
           - ubuntu-latest
           # TODO: Fix tests on Windows
           # - windows-latest
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -146,7 +146,7 @@ jobs:
           - ubuntu-latest
           # TODO: Fix tests on Windows
           # - windows-latest
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -146,7 +146,7 @@ jobs:
           - ubuntu-latest
           # TODO: Fix tests on Windows
           # - windows-latest
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/packages/cli/src/constants.js
+++ b/packages/cli/src/constants.js
@@ -20,7 +20,7 @@ const BUILD_PATH = `${BUILD_DIR}/build.zip`;
 const SOURCE_PATH = `${BUILD_DIR}/source.zip`;
 const NODE_VERSION = versionStore[versionStore.length - 1].nodeVersion;
 const LAMBDA_VERSION = `v${NODE_VERSION}`;
-const NODE_VERSION_CLI_REQUIRES = '>=18'; // should be the oldest non-ETL version
+const NODE_VERSION_CLI_REQUIRES = '>=22'; // should be the oldest non-ETL version
 const AUTH_KEY = 'deployKey';
 const ANALYTICS_KEY = 'analyticsMode';
 const ANALYTICS_MODES = {

--- a/packages/cli/src/version-store.js
+++ b/packages/cli/src/version-store.js
@@ -19,4 +19,5 @@ module.exports = [
   { nodeVersion: '18', npmVersion: '>=5.6.0' }, // 15.x
   { nodeVersion: '18', npmVersion: '>=10.7.0' }, // 16.x
   { nodeVersion: '18', npmVersion: '>=10.7.0' }, // 17.x
+  { nodeVersion: '22', npmVersion: '>=10.7.0' }, // 18.x
 ];


### PR DESCRIPTION
Add support for nodejs22 in `zapier-platform-cli`, I plan to update dependencies to update any EOL packages in another ticket, https://zapierorg.atlassian.net/browse/PDE-6319

