### PR TITLE
fix(cli): PDE-6346 remove empty array at the end of zapier versions -f json

### DIFF
--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -1,4 +1,3 @@
-const colors = require('colors/safe');
 const { Flags } = require('@oclif/core');
 const BaseCommand = require('../ZapierBaseCommand');
 const { buildFlags } = require('../buildFlags');
@@ -10,15 +9,6 @@ class VersionCommand extends BaseCommand {
     this.startSpinner('Loading versions');
     const { versions } = await listVersions();
     this.stopSpinner();
-
-    // Helper function to format text based on output format
-    const formatText = (text) => {
-      // JSON escapes ANSI codes as \u001b[1m and \u001b[22m so
-      // we don't apply bold to them
-      const isJsonFormat = this.flags.format === 'json';
-      return isJsonFormat ? text : colors.bold(text);
-    };
-
     const rows = versions.map((v) => ({
       ...v,
       state: v.lifecycle.status,
@@ -41,32 +31,6 @@ class VersionCommand extends BaseCommand {
       ],
       emptyMessage:
         'No versions to show. Try adding one with the `zapier push` command',
-    });
-
-    this.logTable({
-      headers: [
-        ['ErrorType', 'version'],
-        ['Description', 'platform_version'],
-      ],
-      rows: [
-        {
-          version: `- ${formatText('Errors')}`,
-          platform_version:
-            'Issues that will prevent your integration from functioning properly. They block you from pushing.',
-        },
-        {
-          version: `- ${formatText('Publishing Tasks')}`,
-          platform_version:
-            'To-dos that must be addressed before your integration can be included in the App Directory. They block you from promoting and publishing.',
-        },
-        {
-          version: `- ${formatText('Warnings')}`,
-          platform_version:
-            "Issues and recommendations that need human reviews by Zapier before publishing your integration. They don't block.",
-        },
-      ],
-      hasBorder: false,
-      style: { head: [], 'padding-left': 0, 'padding-right': 0 },
     });
 
     if (versions.map((v) => v.user_count).filter((c) => c === null).length) {

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -15,8 +15,7 @@ class VersionCommand extends BaseCommand {
     const formatText = (text) => {
       // JSON escapes ANSI codes as \u001b[1m and \u001b[22m so
       // we don't apply bold to them
-      const isJsonFormat =
-        this.flags.format === 'json' || this.flags.format === 'raw';
+      const isJsonFormat = this.flags.format === 'json';
       return isJsonFormat ? text : colors.bold(text);
     };
 

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -10,6 +10,16 @@ class VersionCommand extends BaseCommand {
     this.startSpinner('Loading versions');
     const { versions } = await listVersions();
     this.stopSpinner();
+
+    // Helper function to format text based on output format
+    const formatText = (text) => {
+      // JSON escapes ANSI codes as \u001b[1m and \u001b[22m so
+      // we don't apply bold to them
+      const isJsonFormat =
+        this.flags.format === 'json' || this.flags.format === 'raw';
+      return isJsonFormat ? text : colors.bold(text);
+    };
+
     const rows = versions.map((v) => ({
       ...v,
       state: v.lifecycle.status,
@@ -35,20 +45,23 @@ class VersionCommand extends BaseCommand {
     });
 
     this.logTable({
-      headers: [],
+      headers: [
+        ['ErrorType', 'version'],
+        ['Description', 'platform_version'],
+      ],
       rows: [
         {
-          version: `- ${colors.bold('Errors')}`,
+          version: `- ${formatText('Errors')}`,
           platform_version:
             'Issues that will prevent your integration from functioning properly. They block you from pushing.',
         },
         {
-          version: `- ${colors.bold('Publishing Tasks')}`,
+          version: `- ${formatText('Publishing Tasks')}`,
           platform_version:
             'To-dos that must be addressed before your integration can be included in the App Directory. They block you from promoting and publishing.',
         },
         {
-          version: `- ${colors.bold('Warnings')}`,
+          version: `- ${formatText('Warnings')}`,
           platform_version:
             "Issues and recommendations that need human reviews by Zapier before publishing your integration. They don't block.",
         },


### PR DESCRIPTION
https://zapierorg.atlassian.net/browse/PDE-6346

`zapier versions -f json` returns an extra array with three objects, this fixes it so they show what was intended ( error types ). I am questioning if we should remove them all together though? 

```
➜  ZapierWebhookAppCopy zapier versions -f json 
✔ Loading versions
[
  {
    "Version": "1.0.19",
    "Platform": "17.2.0",
    "Zap Users": "0",
    "State": "private",
    "Legacy Date": "",
    "Deprecation Date": "null",
    "Timestamp": "2025-05-19T13:19:26+00:00"
  }
]
[
  {},
  {},
  {}
]
```

Looks like this after this PR ![](https://cdn.zappy.app/13a167469e9bdbb0f798fd352f20c824.png)

