### PR TITLE
PDE-6347 fix(cli): Fix error 'The "path" argument must be of type string' on `zapier build`

### DIFF
--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -386,12 +386,12 @@ const writeBuildZipSmartly = async (workingDir, zip) => {
     for (const symlink of symlinks) {
       const absPath = path.resolve(
         workingDir,
-        symlink.parentPath || symlink.path,
+        symlink.parentPath,
         symlink.name,
       );
       const nameInZip = path.relative(workspaceRoot, absPath);
       const targetInZip = path.relative(
-        symlink.parentPath || symlink.path,
+        symlink.parentPath,
         fs.realpathSync(absPath),
       );
       zip.symlink(nameInZip, targetInZip, 0o644);

--- a/packages/cli/src/utils/files.js
+++ b/packages/cli/src/utils/files.js
@@ -207,16 +207,13 @@ function* walkDir(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      const subDir = path.join(
-        entry.parentPath || entry.path || dir,
-        entry.name,
-      );
+      const subDir = path.join(dir, entry.name);
       yield* walkDir(subDir);
     } else if (entry.isFile() || entry.isSymbolicLink()) {
       if (!entry.parentPath) {
         // dirent.parentPath is only available since Node.js 18.20, 20.12, and
-        // 21.4, while dirent.path is available since Node.js 18.17.
-        entry.parentPath = entry.path || dir;
+        // 21.4. Re-assigning it so the caller can use dirent.parentPath.
+        entry.parentPath = dir;
       }
       yield entry;
     }
@@ -231,17 +228,14 @@ function* walkDirLimitedLevels(dir, maxLevels, currentLevel = 1) {
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (currentLevel < maxLevels) {
-        const subDir = path.join(
-          entry.parentPath || entry.path || dir,
-          entry.name,
-        );
+        const subDir = path.join(dir, entry.name);
         yield* walkDirLimitedLevels(subDir, maxLevels, currentLevel + 1);
       }
     } else if (entry.isFile() || entry.isSymbolicLink()) {
       if (!entry.parentPath) {
         // dirent.parentPath is only available since Node.js 18.20, 20.12, and
-        // 21.4, while dirent.path is available since Node.js 18.17.
-        entry.parentPath = entry.path || dir;
+        // 21.4. Re-assigning it so the caller can use dirent.parentPath.
+        entry.parentPath = dir;
       }
       yield entry;
     }

--- a/packages/cli/src/utils/files.js
+++ b/packages/cli/src/utils/files.js
@@ -217,8 +217,8 @@ function* walkDir(dir) {
         // dirent.parentPath is only available since Node.js 18.20, 20.12, and
         // 21.4, while dirent.path is available since Node.js 18.17.
         entry.parentPath = entry.path || dir;
-        yield entry;
       }
+      yield entry;
     }
   }
 }

--- a/packages/cli/src/utils/files.js
+++ b/packages/cli/src/utils/files.js
@@ -207,10 +207,18 @@ function* walkDir(dir) {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
-      const subDir = path.join(entry.parentPath, entry.name);
+      const subDir = path.join(
+        entry.parentPath || entry.path || dir,
+        entry.name,
+      );
       yield* walkDir(subDir);
     } else if (entry.isFile() || entry.isSymbolicLink()) {
-      yield entry;
+      if (!entry.parentPath) {
+        // dirent.parentPath is only available since Node.js 18.20, 20.12, and
+        // 21.4, while dirent.path is available since Node.js 18.17.
+        entry.parentPath = entry.path || dir;
+        yield entry;
+      }
     }
   }
 }
@@ -223,10 +231,18 @@ function* walkDirLimitedLevels(dir, maxLevels, currentLevel = 1) {
   for (const entry of entries) {
     if (entry.isDirectory()) {
       if (currentLevel < maxLevels) {
-        const subDir = path.join(entry.parentPath, entry.name);
+        const subDir = path.join(
+          entry.parentPath || entry.path || dir,
+          entry.name,
+        );
         yield* walkDirLimitedLevels(subDir, maxLevels, currentLevel + 1);
       }
     } else if (entry.isFile() || entry.isSymbolicLink()) {
+      if (!entry.parentPath) {
+        // dirent.parentPath is only available since Node.js 18.20, 20.12, and
+        // 21.4, while dirent.path is available since Node.js 18.17.
+        entry.parentPath = entry.path || dir;
+      }
       yield entry;
     }
   }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

## Problem

When using a Node.js version like v18.15.0 to run `zapier build --debug`, an error can happen:

```
✖ Zipping project and dependencies
  oclif:zapier:build TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
  oclif:zapier:build     at new NodeError (node:internal/errors:399:5)
  oclif:zapier:build     at validateString (node:internal/validators:163:11)
  oclif:zapier:build     at Object.join (node:path:1172:7)
  oclif:zapier:build     at shouldInclude (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/build.js:164:26)
  oclif:zapier:build     at iterfilter (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/itertools.js:15:9)
  oclif:zapier:build     at iterfilter.next (<anonymous>)
  oclif:zapier:build     at walkDirWithPatterns (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/build.js:175:10)
  oclif:zapier:build     at walkDirWithPatterns.next (<anonymous>)
  oclif:zapier:build     at itermap (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/itertools.js:31:14)
  oclif:zapier:build     at itermap.next (<anonymous>)
  oclif:zapier:build     at writeBuildZipSmartly (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/build.js:322:10)
  oclif:zapier:build     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  oclif:zapier:build     at async makeBuildZip (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/build.js:416:5)
  oclif:zapier:build     at async _buildFunc (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/build.js:712:3)
  oclif:zapier:build     at async buildAndOrUpload (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/utils/build.js:759:5)
  oclif:zapier:build     at async BuildCommand.perform (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/oclif/commands/build.js:16:5)
  oclif:zapier:build     at async Promise.all (index 1)
  oclif:zapier:build     at async BuildCommand._run (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/node_modules/@oclif/core/lib/command.js:181:22)
  oclif:zapier:build     at async Config.runCommand (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/node_modules/@oclif/core/lib/config/config.js:456:25)
  oclif:zapier:build     at async run (/Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/node_modules/@oclif/core/lib/main.js:96:16)
  oclif:zapier:build     at async /Users/eliang/.asdf/installs/nodejs/18.15.0/lib/node_modules/zapier-platform-cli/src/bin/run:5:3 +3s
 ›   Error: The "path" argument must be of type string. Received undefined
```

## Why

`zapier build` uses [`dirent.parentPath`](https://nodejs.org/docs/latest/api/fs.html#direntparentpath), which isn't available until Node.js v21.4.0, v20.12.0, and v18.20.0:

![](https://cdn.zappy.app/b393ba66b6e3c80d75d9a0b229ee6a71.png)

We can't just rely on the deprecated `dirent.path` property either because it was only added in Node.js v18.17.0:

![](https://cdn.zappy.app/ba4f2534339f80dccdc74e8efa2828b6.png)

When releasing zapier-platform-cli v17.3.0, we assumed `dirent.parentPath` would just work as long as the developer runs it on Node.js >= v18.20.0. But in fact the `dirent.parentPath` property is missing even on Node.js versions like v20.11.0 and v21.3.0. This has caused a bit of friction to some developers when using the CLI.

## Solution

This PR fixes `zapier build` so it works on all versions of v18.x - v22.x by _not_ assuming `dirent.parentPath` or `dirent.path` exist.