### PR TITLE
chore(CI): PDE-6379 update security scanning

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "example-apps/**"


### PR DESCRIPTION
Follow [docs](https://docs.github.com/en/code-security/secret-scanning/using-advanced-secret-scanning-and-push-protection-features/excluding-folders-and-files-from-secret-scanning#excluding-directories-from-secret-scanning-alerts-for-users) to exclude `example-apps` which are not deployed in production/staging environments since they serve as stand alone examples. We are already [ignoring the /example-app/ updates](https://github.com/zapier/zapier-platform/security) so this just reduces noise 
