### PR TITLE
PDE-5447 fix(core): some authData keys are safe to be logged uncensored

### DIFF
--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -51,7 +51,6 @@ const initSafeAuthDataKeys = () => {
     'environment',
     'location',
     'org',
-    'org',
     'organization',
     'project',
     'region',

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -32,16 +32,69 @@ const LOG_STREAM_BYTES_LIMIT = 15 * 1024 * 1024;
 
 const DEFAULT_LOGGER_TIMEOUT = 200;
 
+// Will be initialized lazily
+const SAFE_AUTH_DATA_KEYS = new Set();
+
 const sleep = promisify(setTimeout);
 
-const isUrl = (url) => {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(url);
-    return true;
-  } catch (e) {
+const initSafeAuthDataKeys = () => {
+  // An authData key in (safePrefixes x safeSuffixes) is considered safe to log
+  // uncensored
+  const safePrefixes = [
+    'account',
+    'bot_user',
+    'cloud',
+    'cloud_site',
+    'company',
+    'domain',
+    'email',
+    'environment',
+    'location',
+    'org',
+    'org',
+    'organization',
+    'project',
+    'region',
+    'scope',
+    'scopes',
+    'site',
+    'subdomain',
+    'team',
+    'token_type',
+    'user',
+    'workspace',
+  ];
+  const safeSuffixes = ['', '_id', '_name', 'id', 'name'];
+  for (const prefix of safePrefixes) {
+    for (const suffix of safeSuffixes) {
+      SAFE_AUTH_DATA_KEYS.add(prefix + suffix);
+    }
+  }
+};
+
+const isUrl = (value) => {
+  if (!value || typeof value !== 'string') {
     return false;
   }
+  const commonProtocols = [
+    'https://',
+    'http://',
+    'ftp://',
+    'ftps://',
+    'file://',
+  ];
+  for (const protocol of commonProtocols) {
+    if (value.startsWith(protocol)) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(value);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+  }
+  return false;
 };
 
 const MAX_LENGTH = 3500;
@@ -136,6 +189,13 @@ const attemptFindSecretsInStr = (s, isGettingNewSecret) => {
   return findSensitiveValues(parsedRespContent);
 };
 
+const isSafeAuthDataKey = (key) => {
+  if (SAFE_AUTH_DATA_KEYS.size === 0) {
+    initSafeAuthDataKeys();
+  }
+  return SAFE_AUTH_DATA_KEYS.has(key.toLowerCase());
+};
+
 const buildSensitiveValues = (event, data) => {
   const bundle = event.bundle || {};
   const authData = bundle.authData || {};
@@ -147,7 +207,9 @@ const buildSensitiveValues = (event, data) => {
     if (isSensitiveKey(key)) {
       return true;
     }
-
+    if (isSafeAuthDataKey(key)) {
+      return false;
+    }
     if (isUrl(value) && !isUrlWithSecrets(value)) {
       return false;
     }

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -631,6 +631,59 @@ describe('logger', () => {
     ]);
   });
 
+  it('should not replace safe keys', async () => {
+    const bundle = {
+      authData: {
+        // The following are keys in authData known to be logged uncensored
+        scope: 'chat:write,chat:read',
+        scopes: 'user.read message.list',
+        teamId: 1234567890,
+        account_id: '983134213',
+        username: 'john_doe_123',
+        subdomain: 'zapier-1',
+        team_name: 'Engineering',
+        org_id: 'zapier-org-1',
+        email: 'johndoe@example.com',
+
+        // The following should be censored
+        access_token: 'a_secret_token',
+        password: 'hunter3456',
+        unknown_field: 'should be censored if unknown',
+      },
+    };
+    const logger = createlogger({ bundle }, options);
+
+    logger('200 POST https://example.com/test', {
+      log_type: 'http',
+      response_content: JSON.stringify(bundle.authData),
+    });
+    const response = await logger.end(2000);
+    response.status.should.eql(200);
+    response.content.token.should.eql(options.token);
+    response.content.logs.should.deepEqual([
+      {
+        message: '200 POST https://example.com/test',
+        data: {
+          log_type: 'http',
+          response_content: JSON.stringify({
+            scope: 'chat:write,chat:read',
+            scopes: 'user.read message.list',
+            teamId: 1234567890,
+            account_id: '983134213',
+            username: 'john_doe_123',
+            subdomain: 'zapier-1',
+            team_name: 'Engineering',
+            org_id: 'zapier-org-1',
+            email: 'johndoe@example.com',
+            access_token: ':censored:14:0f3381cb70:',
+            password: ':censored:10:57c6192e39:',
+            unknown_field: ':censored:29:6803bf6334:',
+          }),
+        },
+      },
+    ]);
+  });
+
   it('should handle nullish values', async () => {
     const bundle = {
       authData: {

--- a/packages/core/test/logger.js
+++ b/packages/core/test/logger.js
@@ -634,7 +634,7 @@ describe('logger', () => {
   it('should not replace safe keys', async () => {
     const bundle = {
       authData: {
-        // The following are keys in authData known to be logged uncensored
+        // The following are keys in authData that can be logged uncensored
         scope: 'chat:write,chat:read',
         scopes: 'user.read message.list',
         teamId: 1234567890,


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Currently, we censor every value appearing in `bundle.authData` in the log unless the value [looks like a URL without a secret](https://github.com/zapier/zapier-platform/blob/0784942e39981c33ba35bbc74bb21d86727c96da/packages/core/src/tools/create-logger.js#L151-L153). However, there are many fields in `bundle.authData` that are known to be safe to log uncensored, such as `scope`, `team_id`, and `account`. Censoring them in logs just makes troubleshooting hard.