### PR TITLE
PDE-6397: add text back to authfields

### DIFF
--- a/packages/core/types/schemas.generated.d.ts
+++ b/packages/core/types/schemas.generated.d.ts
@@ -711,7 +711,8 @@ export interface AuthField {
     | 'datetime'
     | 'copy'
     | 'password'
-    | 'integer';
+    | 'integer'
+    | 'text';
 
   /** If this value is required or not. This defaults to `true`. */
   required?: boolean;

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -174,7 +174,7 @@ Key | Required | Type | Description
 --- | -------- | ---- | -----------
 `key` | **yes** | `string` | A unique machine readable key for this value (IE: "fname").
 `label` | no | `string` | A human readable label for this value (IE: "First Name").
-`type` | no | `string` in (`'string'`, `'number'`, `'boolean'`, `'datetime'`, `'copy'`, `'password'`, `'integer'`) | The type of this value used to be.
+`type` | no | `string` in (`'string'`, `'number'`, `'boolean'`, `'datetime'`, `'copy'`, `'password'`, `'integer'`, `'text'`) | The type of this value used to be.
 `required` | no | `boolean` | If this value is required or not. This defaults to `true`.
 `default` | no | `string` | A default value that is saved the first time a Zap is created.
 `list` | no | `boolean` | Acts differently when used in inputFields vs. when used in outputFields. In inputFields: Can a user provide multiples of this field? In outputFields: Does this field return an array of items of type `type`?

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -309,7 +309,8 @@
             "datetime",
             "copy",
             "password",
-            "integer"
+            "integer",
+            "text"
           ]
         },
         "required": {

--- a/packages/schema/lib/schemas/AuthFieldSchema.js
+++ b/packages/schema/lib/schemas/AuthFieldSchema.js
@@ -37,6 +37,7 @@ module.exports = makeSchema(
           'copy',
           'password',
           'integer',
+          'text',
         ],
       },
       required: {


### PR DESCRIPTION
https://zapierorg.atlassian.net/browse/PDE-6397

We split FieldSchema into InputFieldSchema, OutputFieldSchema, and AuthFieldSchema in [v17](https://github.com/zapier/zapier-platform/pull/957/files#diff-371ea404c5803792816e705c11005ffbb6ae594ca64857876e31775c31030370R25) and inadvertently removed the "text" type from AuthFieldSchema, this PR adds it back.
