### PR TITLE
improvement(cli): `zapier validate` runs `_zapier-build` before validation (PDE-6246)

### DIFF
--- a/packages/cli/src/oclif/commands/validate.js
+++ b/packages/cli/src/oclif/commands/validate.js
@@ -6,9 +6,14 @@ const { buildFlags } = require('../buildFlags');
 const { flattenCheckResult } = require('../../utils/display');
 const { localAppCommand } = require('../../utils/local');
 const { validateApp } = require('../../utils/api');
+const { maybeRunBuildScript } = require('../../utils/build');
 
 class ValidateCommand extends BaseCommand {
   async perform() {
+    if (!this.flags['skip-build']) {
+      await maybeRunBuildScript({ printProgress: true });
+    }
+
     this.log('Validating project locally');
 
     const errors = await localAppCommand({ command: 'validate' });
@@ -121,6 +126,9 @@ ValidateCommand.flags = buildFlags({
     'without-style': Flags.boolean({
       description: 'Forgo pinging the Zapier server to run further checks.',
     }),
+    'skip-build': Flags.boolean({
+      description: 'Skip running the _zapier-build script before validation.',
+    }),
   },
   opts: {
     format: true,
@@ -130,6 +138,7 @@ ValidateCommand.flags = buildFlags({
 ValidateCommand.examples = [
   'zapier validate',
   'zapier validate --without-style',
+  'zapier validate --skip-build',
   'zapier validate --format json',
 ];
 ValidateCommand.description = `Validate your integration.


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

[The `_zapier-build` script](https://docs.zapier.com/platform/build-cli/overview#using-transpilers) in `package.json` is how developers can configure `tsc` to transpile TypeScript to JavaScript. Currently, it's run like a "pre-build" step as part of the `zapier build` command.

This PR adds it to `zapier validate` as well. When `_zapier-build` is defined in `package.json`, `zapier validate` will run it before validation. If a developer wants to skip `_zapier-build` for any reason, they can use the `--skip-build` option: `zapier validate --skip-build`.