### PR TITLE
Create copilot-setup-steps.yml

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,10 +17,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BAR: foo
+      JIRA_INSTANCE_URL: https://zapierorg.atlassian.net
+      COPILOT_JIRA_INSTANCE_URL: https://zapierorg.atlassian.net
+      JIRA_USER_EMAIL: fokke.zandbergen@zapier.com
+      COPILOT_JIRA_USER_EMAIL: fokke.zandbergen@zapier.com
+      JIRA_API_KEY: dummy
+      COPILOT_MCP_JIRA_API_KEY: dummy
+      THE_COPILOT_MCP_SEC: ${{ secrets.COPILOT_MCP_SEC }}
+      THE_REPO_SEC: ${{ secrets.REPO_SEC }}
     steps:
       - name: Check variable
         run: |
           echo $COPILOT_MCP_FOO
           echo $FOO
           echo $BAR
-          echo $COPILOT_MCP_JIRA_API_KEY
+          echo $JIRA_INSTANCE_URL
+          echo $COPILOT_JIRA_INSTANCE_URL
+          echo $THE_COPILOT_MCP_SEC
+          echo $THE_REPO_SEC

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,3 +23,4 @@ jobs:
           echo $COPILOT_MCP_FOO
           echo $FOO
           echo $BAR
+          echo $COPILOT_MCP_JIRA_API_KEY

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,4 +17,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check variable
-        run: echo $COPILOT_MCP_FOO
+        run: echo $COPILOT_MCP_FOO && echo $FOO

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,20 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check variable
+        run: echo $COPILOT_MCP_FOO

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -15,6 +15,11 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
+    env:
+      BAR: foo
     steps:
       - name: Check variable
-        run: echo $COPILOT_MCP_FOO && echo $FOO
+        run: |
+          echo $COPILOT_MCP_FOO
+          echo $FOO
+          echo $BAR


### PR DESCRIPTION
For some reason, when I follow https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/extend-coding-agent-with-mcp to use https://npmjs.com/jira-mcp, it fails because the environment variables are not set: https://github.com/zapier/zapier-platform/actions/runs/17318298576/job/49165592059 But they are! I hope setting them via the CoPilot environment will work.