### PR TITLE
chore(cli): Update `zapier pull` description to clarify it pulls production version, not latest, for public integrations (PDE-6517)

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -649,11 +649,11 @@ Check `zapier jobs` to track the status of the promotion. Or use `zapier history
 
 ## pull
 
-> Retrieve and update your local integration files with the latest version.
+> Retrieve and update your local integration files with the promoted version (or latest version if not public).
 
 **Usage**: `zapier pull`
 
-This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
+This command updates your local integration files with the promoted version (or latest version if not public). You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
 
 Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running `zapier pull`:
 

--- a/packages/cli/src/oclif/commands/pull.js
+++ b/packages/cli/src/oclif/commands/pull.js
@@ -53,9 +53,9 @@ class PullCommand extends ZapierBaseCommand {
 }
 
 PullCommand.flags = buildFlags();
-PullCommand.description = `Retrieve and update your local integration files with the latest version.
+PullCommand.description = `Retrieve and update your local integration files with the promoted version (or latest version if not public).
 
-This command updates your local integration files with the latest version. You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
+This command updates your local integration files with the promoted version (or latest version if not public). You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
 
 Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running \`zapier pull\`:
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

The description for `zapier pull` is unclear - it indicates it will pull down the latest version, but that is not the case for public apps. Instead, for those, it will pull the production version.