### PR TITLE
PDE-6429 fix(core): censor sensitive info in `ResponseError`

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -937,12 +937,14 @@ Run the standard validation routine powered by json-schema that checks your inte
 
 **Flags**
 * `--without-style` | Forgo pinging the Zapier server to run further checks.
+* `--skip-build` | Skip running the _zapier-build script before validation.
 * `-d, --debug` | Show extra debugging output.
 * `-f, --format` | Change the way structured data is presented. If "json" or "raw", you can pipe the output of the command into other tools, such as jq. One of `[plain | json | raw | row | table]`. Defaults to `table`.
 
 **Examples**
 * `zapier validate`
 * `zapier validate --without-style`
+* `zapier validate --skip-build`
 * `zapier validate --format json`
 
 

--- a/packages/cli/src/tests/utils/build.js
+++ b/packages/cli/src/tests/utils/build.js
@@ -115,7 +115,7 @@ describe('build (runs slowly)', function () {
       path.normalize('node_modules/node-fetch/README.md'),
     );
 
-    smartPaths.length.should.be.within(200, 327);
+    smartPaths.length.should.be.within(200, 328);
   });
 
   it('should list all the files', () => {
@@ -1446,7 +1446,7 @@ describe('build ESM (runs slowly)', function () {
     smartPaths.filter((p) => p.endsWith('.ts')).length.should.equal(0);
     smartPaths.should.not.containEql('tsconfig.json');
 
-    smartPaths.length.should.be.within(200, 328);
+    smartPaths.length.should.be.within(200, 329);
   });
 
   it('should list all the files', async () => {

--- a/packages/core/src/http-middlewares/after/prepare-response.js
+++ b/packages/core/src/http-middlewares/after/prepare-response.js
@@ -2,19 +2,44 @@
 
 const _ = require('lodash');
 const querystring = require('querystring');
+
+const { scrub, findSensitiveValues } = require('@zapier/secret-scrubber');
+
 const { replaceHeaders } = require('./middleware-utils');
 const { FORM_TYPE } = require('../../tools/http');
 const errors = require('../../errors');
+const {
+  findSensitiveValuesFromAuthData,
+} = require('../../tools/secret-scrubber');
 
-const _throwForStatus = (response) => {
+const buildSensitiveValues = (bundle) => {
+  const authData = bundle?.authData || {};
+  const result = [
+    ...findSensitiveValuesFromAuthData(authData),
+    ...findSensitiveValues(process.env),
+  ];
+  return [...new Set(result)];
+};
+
+const _throwForStatus = (response, bundle) => {
   // calling this always throws, regardless of the skipThrowForStatus value
   // eslint-disable-next-line yoda
   if (400 <= response.status && response.status < 600) {
+    // Create a cleaned version of the response to avoid sensitive data leaks
+    try {
+      // Find sensitive values from environment variables and bundle authData
+      const sensitiveValues = buildSensitiveValues(bundle);
+      if (sensitiveValues.length > 0 && response?.request?.url) {
+        response.request.url = scrub(response.request.url, sensitiveValues);
+      }
+    } catch (err) {
+      // don't fail the whole request if we can't scrub for some reason
+    }
     throw new errors.ResponseError(response);
   }
 };
 
-const prepareRawResponse = (resp, request) => {
+const prepareRawResponse = (resp, request, bundle) => {
   // TODO: if !2xx should we go ahead and get response.content for them?
   // retain the response signature for raw control
   const extendedResp = {
@@ -24,7 +49,7 @@ const prepareRawResponse = (resp, request) => {
   const outResp = _.extend(resp, extendedResp, replaceHeaders(resp));
 
   outResp.throwForStatus = () => {
-    _throwForStatus(outResp);
+    _throwForStatus(outResp, bundle);
   };
 
   Object.defineProperty(outResp, 'content', {
@@ -39,7 +64,7 @@ const prepareRawResponse = (resp, request) => {
   return outResp;
 };
 
-const prepareContentResponse = async (resp, request) => {
+const prepareContentResponse = async (resp, request, bundle) => {
   // TODO: does it make sense to not trim the signature? more equivalence to raw...
   const content = await resp.text();
 
@@ -67,14 +92,14 @@ const prepareContentResponse = async (resp, request) => {
   } catch (_e) {}
 
   outResp.throwForStatus = () => {
-    _throwForStatus(outResp);
+    _throwForStatus(outResp, bundle);
   };
 
   return outResp;
 };
 
 // Provide a standardized plain JS responseObj for common consumption, or raw response for streaming.
-const prepareResponse = (resp) => {
+const prepareResponse = (resp, z, bundle) => {
   const request = resp.input;
   delete resp.input;
 
@@ -82,7 +107,7 @@ const prepareResponse = (resp) => {
     ? prepareRawResponse
     : prepareContentResponse;
 
-  return responseFunc(resp, request);
+  return responseFunc(resp, request, bundle);
 };
 
 module.exports = prepareResponse;

--- a/packages/core/src/tools/secret-scrubber.js
+++ b/packages/core/src/tools/secret-scrubber.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { recurseExtract } = require('@zapier/secret-scrubber');
+const {
+  isUrlWithSecrets,
+  isSensitiveKey,
+} = require('@zapier/secret-scrubber/lib/convenience');
+
+// Will be initialized lazily
+const SAFE_AUTH_DATA_KEYS = new Set();
+
+const initSafeAuthDataKeys = () => {
+  // An authData key in (safePrefixes x safeSuffixes) is considered safe to log
+  // uncensored
+  const safePrefixes = [
+    'account',
+    'bot_user',
+    'cloud',
+    'cloud_site',
+    'company',
+    'domain',
+    'email',
+    'environment',
+    'location',
+    'org',
+    'organization',
+    'project',
+    'region',
+    'scope',
+    'scopes',
+    'site',
+    'subdomain',
+    'team',
+    'token_type',
+    'user',
+    'workspace',
+  ];
+  const safeSuffixes = ['', '_id', '_name', 'id', 'name'];
+  for (const prefix of safePrefixes) {
+    for (const suffix of safeSuffixes) {
+      SAFE_AUTH_DATA_KEYS.add(prefix + suffix);
+    }
+  }
+};
+
+const isSafeAuthDataKey = (key) => {
+  if (SAFE_AUTH_DATA_KEYS.size === 0) {
+    initSafeAuthDataKeys();
+  }
+  return SAFE_AUTH_DATA_KEYS.has(key.toLowerCase());
+};
+
+const isUrl = (value) => {
+  if (!value || typeof value !== 'string') {
+    return false;
+  }
+  const commonProtocols = [
+    'https://',
+    'http://',
+    'ftp://',
+    'ftps://',
+    'file://',
+  ];
+  for (const protocol of commonProtocols) {
+    if (value.startsWith(protocol)) {
+      try {
+        // eslint-disable-next-line no-new
+        new URL(value);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+  }
+  return false;
+};
+
+const findSensitiveValuesFromAuthData = (authData) =>
+  recurseExtract(authData, (key, value) => {
+    // for the most part, we should censor all the values from authData
+    // the exception is safe urls, which should be filtered out - we want those to be logged
+    // but, we _should_ censor-no-matter-what sensitive keys, even if their value is a safe url
+    // this covers the case where someone's password is a valid url ¯\_(ツ)_/¯
+    if (isSensitiveKey(key)) {
+      return true;
+    }
+    if (isSafeAuthDataKey(key)) {
+      return false;
+    }
+    if (isUrl(value) && !isUrlWithSecrets(value)) {
+      return false;
+    }
+    return true;
+  });
+
+module.exports = {
+  findSensitiveValuesFromAuthData,
+};


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

To reproduce, use this example trigger and `beforeRequest` middleware:

```js
// Trigger definition
{
  key: "recipe",
  operation: {
    perform: {
      url: "https://httpbin.zapier-tooling.com/status/400",
    },
  },
  // ...
}
```

```js
// beforeRequest middleware
const includeAccessToken = (request, z, bundle) => {
  if (bundle.authData.access_token) {
    request.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
    request.params.access_token = bundle.authData.access_token;
  }
  return request;
};
```

Then run it with `zapier invoke trigger recipe --debug`.

### Before

The value of `access_token` is visible in the response error:

```
(redacted)
 ›   Error: {"status":400,"headers":{"content-type":"text/plain; charset=utf-8","retry-after":null},"content":"","request":{"url":"https://httpbin.zapier-tooling.com/status/400?access_token=a_token"}}
```

(The value of `access_token` is not censored in the response error)

### After

The value of `access_token` is censored in the response error:

```
(redacted)
 ›   Error: {"status":400,"headers":{"content-type":"text/plain; charset=utf-8","retry-after":null},"content":"","request":{"url":"https://httpbin.zapier-tooling.com/status/400?access_token=:censored:7:da1d3a47b7:"}}
```