### PR TITLE
PDE-5956: revert(cli): revert `zapier migrate --action` feature

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -605,7 +605,6 @@ You cannot pass both `--user` and `--account`.
 **Flags**
 * `--user` | Migrates all of a users' Private Zaps within all accounts for which the specified user is a member
 * `--account` | Migrates all of a users' Zaps, Private & Shared, within all accounts for which the specified user is a member
-* `-a, --action` | When specified, the command will only migrate users' Zaps that use the specified action(s). Specify an action in the format of "{action_type}/{action_key}", where {action_type} can be "trigger", "create", "search", "bulkRead", or "searchOrCreate". You can specify multiple actions like `-a trigger/new_recipe -a create/add_recipe`.
 * `-y, --yes` | Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.
 * `-d, --debug` | Show extra debugging output.
 
@@ -614,8 +613,6 @@ You cannot pass both `--user` and `--account`.
 * `zapier migrate 1.0.1 2.0.0 10`
 * `zapier migrate 2.0.0 2.0.1 --user=user@example.com`
 * `zapier migrate 2.0.0 2.0.1 --account=account@example.com`
-* `zapier migrate 2.0.0 2.0.1 --action trigger/new_recipe`
-* `zapier migrate 2.0.0 2.0.1 -a trigger/new_recipe -a create/add_recipe -a search/find_recipe`
 
 
 ## promote

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -8,38 +8,6 @@ const PromoteCommand = require('./promote');
 const { callAPI } = require('../../utils/api');
 const { buildFlags } = require('../buildFlags');
 
-const ACTION_TYPES = [
-  'trigger',
-  'create',
-  'search',
-  'searchOrCreate',
-  'bulkRead',
-];
-
-const validateActions = (actions) => {
-  return actions.map((action) => {
-    if (!action.includes('/')) {
-      throw new Error(
-        `Invalid action format: "${action}". Expected format is "{action_type}/{action_key}".`,
-      );
-    }
-
-    const [actionType, actionKey] = action.split('/');
-    if (!ACTION_TYPES.includes(actionType)) {
-      throw new Error(
-        `Invalid action type "${actionType}" in "${action}". Valid types are: ${ACTION_TYPES.join(
-          ', ',
-        )}.`,
-      );
-    }
-
-    return {
-      type: actionType,
-      key: actionKey,
-    };
-  });
-};
-
 class MigrateCommand extends BaseCommand {
   async run_require_confirmation_pre_checks(app, requestBody) {
     const assumeYes = 'yes' in this.flags;
@@ -115,11 +83,6 @@ class MigrateCommand extends BaseCommand {
       );
     }
 
-    let actions;
-    if (this.flags.action) {
-      actions = validateActions(this.flags.action);
-    }
-
     const app = await this.getWritableApp();
 
     let promoteFirst = false;
@@ -127,7 +90,6 @@ class MigrateCommand extends BaseCommand {
       percent === 100 &&
       !user &&
       !account &&
-      !actions?.length &&
       (app.public || app.public_ish) &&
       toVersion !== app.latest_version
     ) {
@@ -152,7 +114,6 @@ class MigrateCommand extends BaseCommand {
         to_version: toVersion,
         email: user || account,
         email_type: flagType,
-        actions,
       },
     };
 
@@ -163,11 +124,6 @@ class MigrateCommand extends BaseCommand {
       message = `Requesting migration from ${fromVersion} to ${toVersion} for ${user || account}`;
     } else {
       message = `Requesting migration from ${fromVersion} to ${toVersion} for ${percent}%`;
-    }
-
-    if (actions?.length) {
-      const actionsInStr = actions.map((a) => `${a.type}/${a.key}`).join(', ');
-      message += ` with ${actionsInStr}`;
     }
 
     this.startSpinner(message);
@@ -202,12 +158,6 @@ MigrateCommand.flags = buildFlags({
       description:
         "Migrates all of a users' Zaps, Private & Shared, within all accounts for which the specified user is a member",
     }),
-    action: Flags.string({
-      char: 'a',
-      description:
-        'When specified, the command will only migrate users\' Zaps that use the specified action(s). Specify an action in the format of "{action_type}/{action_key}", where {action_type} can be "trigger", "create", "search", "bulkRead", or "searchOrCreate". You can specify multiple actions like `-a trigger/new_recipe -a create/add_recipe`.',
-      multiple: true,
-    }),
     yes: Flags.boolean({
       char: 'y',
       description:
@@ -238,8 +188,6 @@ MigrateCommand.examples = [
   'zapier migrate 1.0.1 2.0.0 10',
   'zapier migrate 2.0.0 2.0.1 --user=user@example.com',
   'zapier migrate 2.0.0 2.0.1 --account=account@example.com',
-  'zapier migrate 2.0.0 2.0.1 --action trigger/new_recipe',
-  'zapier migrate 2.0.0 2.0.1 -a trigger/new_recipe -a create/add_recipe -a search/find_recipe',
 ];
 MigrateCommand.description = `Migrate a percentage of users or a single user from one version of your integration to another.
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Reverts the "migrate by action" feature via `zapier migrate --action` (#1126) but keeps some of the minor changes.