### PR TITLE
feat(cli): Only allow standard (non-labeled) versions to be migrated or promoted to [PDE-6496]

### DIFF
--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -7,6 +7,7 @@ const BaseCommand = require('../ZapierBaseCommand');
 const PromoteCommand = require('./promote');
 const { callAPI } = require('../../utils/api');
 const { buildFlags } = require('../buildFlags');
+const { validateStandardVersion } = require('../../utils/misc');
 
 class MigrateCommand extends BaseCommand {
   async run_require_confirmation_pre_checks(app, requestBody) {
@@ -65,6 +66,9 @@ class MigrateCommand extends BaseCommand {
 
     const fromVersion = this.args.fromVersion;
     const toVersion = this.args.toVersion;
+
+    // Validate that toVersion follows standard version format
+    validateStandardVersion(toVersion);
     let flagType;
 
     if (user || account) {

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -9,6 +9,7 @@ const { callAPI } = require('../../utils/api');
 const { flattenCheckResult } = require('../../utils/display');
 const { getVersionChangelog } = require('../../utils/changelog');
 const checkMissingAppInfo = require('../../utils/check-missing-app-info');
+const { validateStandardVersion } = require('../../utils/misc');
 const { EXAMPLE_CHANGELOG } = require('../../constants');
 
 const ACTION_TYPE_MAPPING = {
@@ -96,6 +97,10 @@ class PromoteCommand extends BaseCommand {
     checkMissingAppInfo(app);
 
     const version = this.args.version;
+
+    // Validate that version follows standard version format
+    validateStandardVersion(version);
+
     const assumeYes = 'yes' in this.flags;
 
     let shouldContinueChangelog;

--- a/packages/cli/src/tests/utils/misc.js
+++ b/packages/cli/src/tests/utils/misc.js
@@ -10,4 +10,28 @@ describe('misc utils', () => {
       misc.isValidNodeVersion('v1.2.3').should.equal(false);
     });
   });
+
+  describe('validateStandardVersion', () => {
+    it('should not throw for valid standard versions', () => {
+      (() => misc.validateStandardVersion('1.0.0')).should.not.throw();
+      (() => misc.validateStandardVersion('10.25.3')).should.not.throw();
+      (() => misc.validateStandardVersion('0.0.1')).should.not.throw();
+      (() => misc.validateStandardVersion('999.999.999')).should.not.throw();
+    });
+
+    it('should throw for versions with labels', () => {
+      (() => misc.validateStandardVersion('1.0.0-beta')).should.throw(
+        /must contain numbers only/,
+      );
+      (() => misc.validateStandardVersion('999.999.999-alpha.1')).should.throw(
+        /must contain numbers only/,
+      );
+    });
+
+    it('should include the invalid version in error message', () => {
+      (() => misc.validateStandardVersion('1.0.0-beta')).should.throw(
+        /Version "1\.0\.0-beta"/,
+      );
+    });
+  });
 });

--- a/packages/cli/src/utils/misc.js
+++ b/packages/cli/src/utils/misc.js
@@ -81,6 +81,15 @@ const runCommand = (command, args, options) => {
 const isValidNodeVersion = (version = process.version) =>
   semver.satisfies(version, NODE_VERSION_CLI_REQUIRES);
 
+const validateStandardVersion = (version) => {
+  const standardVersionRegex = /^\d+\.\d+\.\d+$/;
+  if (!standardVersionRegex.test(version)) {
+    throw new Error(
+      `Version "${version}" must contain numbers only and not be a labeled version. Use format like "1.0.0" instead.`,
+    );
+  }
+};
+
 const findCorePackageDir = (workingDir) => {
   let baseDir = workingDir || process.cwd();
   // 500 is just an arbitrary number to prevent infinite loops
@@ -242,4 +251,5 @@ module.exports = {
   promiseDoWhile,
   runCommand,
   snakeCase,
+  validateStandardVersion,
 };


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

This other PR: https://github.com/zapier/zapier-platform/pull/1093 adds support for labeled versions, i.e. `2.1.3-beta`. However, we only want to allow those during development - actual production versions or versions that users will use should be standard numbers-only versions, i.e. `2.1.3`.

This PR adds a small utility function that checks the version format when `zapier promote` or `zapier migrate` is run, and throws an error if the version being migrated/promoted to is not numbers-only.