### PR TITLE
PDE-5232 feat!(core): add `throwforThrottling` middleware (BREAKING CHANGE)

### DIFF
--- a/packages/core/src/http-middlewares/before/prepare-request.js
+++ b/packages/core/src/http-middlewares/before/prepare-request.js
@@ -148,7 +148,7 @@ const prepareRequest = function (req) {
     throwForThrottlingEarly: _.get(
       input,
       ['_zapier', 'app', 'flags', 'throwForThrottlingEarly'],
-      false,
+      true,
     ),
   });
 

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -1158,186 +1158,97 @@ describe('http prepareResponse', () => {
 });
 
 describe('throwForThrottling middleware', () => {
-  const throwForThrottling = require('../src/http-middlewares/after/throw-for-throttling');
+  const testLogger = () => Promise.resolve({});
 
   afterEach(() => {
     nock.cleanAll();
   });
 
   it('should throw ThrottledError for 429 status by default', async () => {
-    const testLogger = () => Promise.resolve({});
     const input = createInput({}, {}, testLogger);
     const request = createAppRequestClient(input);
 
     // Mock a 429 response
-    const scope = nock(HTTPBIN_URL)
-      .get('/status/429')
+    const scope = nock('https://example.zapier.com')
+      .get('/api')
       .reply(429, '', { 'retry-after': '60' });
 
     await request({
-      url: `${HTTPBIN_URL}/status/429`,
+      url: 'https://example.zapier.com/api',
     }).should.be.rejectedWith(errors.ThrottledError, {
       name: 'ThrottledError',
-      doNotContextify: true,
+      message:
+        '{"message":"The server returned 429 (Too Many Requests)","delay":60}',
     });
-
     scope.isDone().should.be.true();
   });
 
-  it('should not throw ThrottledError when throwForThrottlingEarly is true', async () => {
-    const testLogger = () => Promise.resolve({});
+  it('should set delay to null in ThrottledError if retry-after is not number', async () => {
     const input = createInput({}, {}, testLogger);
     const request = createAppRequestClient(input);
 
     // Mock a 429 response
-    const scope = nock(HTTPBIN_URL)
-      .get('/status/429')
+    const scope = nock('https://example.zapier.com')
+      .get('/api')
+      .reply(429, '', { 'retry-after': 'sixty' });
+
+    await request({
+      url: 'https://example.zapier.com/api',
+    }).should.be.rejectedWith(errors.ThrottledError, {
+      name: 'ThrottledError',
+      message:
+        '{"message":"The server returned 429 (Too Many Requests)","delay":null}',
+    });
+    scope.isDone().should.be.true();
+  });
+
+  it('should not throw ThrottledError when throwForThrottlingEarly is false', async () => {
+    const input = createInput({}, {}, testLogger);
+    const request = createAppRequestClient(input);
+
+    // Mock a 429 response
+    const scope = nock('https://example.zapier.com')
+      .get('/api')
       .reply(429, '', { 'retry-after': '60' });
 
-    // With throwForThrottlingEarly: true, the middleware should be skipped
-    // and throwForStatus should handle it instead
+    // With throwForThrottlingEarly: false, the middleware should be skipped and
+    // throwForStatus should handle it instead
     await request({
-      url: `${HTTPBIN_URL}/status/429`,
-      throwForThrottlingEarly: true,
+      url: 'https://example.zapier.com/api',
+      throwForThrottlingEarly: false,
     }).should.be.rejectedWith(errors.ResponseError, {
       name: 'ResponseError',
-      doNotContextify: true,
+      message:
+        '{"status":429,"headers":{"content-type":null,"retry-after":"60"},"content":"","request":{"url":"https://example.zapier.com/api"}}',
     });
-
     scope.isDone().should.be.true();
   });
 
-  it('should extract retry-after header correctly', () => {
-    const mockResponse = {
-      status: 429,
-      headers: {
-        get: (header) => {
-          if (header === 'retry-after') {
-            return '120';
-          }
-          return null;
-        },
-      },
-      request: {},
-    };
-
-    try {
-      throwForThrottling(mockResponse);
-      // Should not reach here
-      should.fail('Expected ThrottledError to be thrown');
-    } catch (error) {
-      error.should.be.instanceOf(errors.ThrottledError);
-      error.name.should.eql('ThrottledError');
-      // Parse the JSON message to check delay
-      const errorData = JSON.parse(error.message);
-      errorData.delay.should.eql(120);
-    }
-  });
-
-  it('should handle missing retry-after header', () => {
-    const mockResponse = {
-      status: 429,
-      headers: {
-        get: () => null,
-      },
-      request: {},
-    };
-
-    try {
-      throwForThrottling(mockResponse);
-      // Should not reach here
-      should.fail('Expected ThrottledError to be thrown');
-    } catch (error) {
-      error.should.be.instanceOf(errors.ThrottledError);
-      error.name.should.eql('ThrottledError');
-      // Parse the JSON message to check delay is null
-      const errorData = JSON.parse(error.message);
-      should(errorData.delay).be.null();
-    }
-  });
-
-  it('should pass through non-429 responses', () => {
-    const mockResponse = {
-      status: 200,
-      headers: {
-        get: () => null,
-      },
-      request: {},
-    };
-
-    const result = throwForThrottling(mockResponse);
-    result.should.equal(mockResponse);
-  });
-
-  it('should respect throwForThrottlingEarly flag in request', () => {
-    const mockResponse = {
-      status: 429,
-      headers: {
-        get: () => '60',
-      },
-      request: {
-        throwForThrottlingEarly: true,
-      },
-    };
-
-    const result = throwForThrottling(mockResponse);
-    result.should.equal(mockResponse);
-  });
-
-  it('should work in integration with middleware stack', async () => {
-    const testLogger = () => Promise.resolve({});
-    const appDefinition = {
-      afterResponse: [
-        (response) => {
-          // This afterResponse middleware should not see 429 when throwForThrottlingEarly is false
-          response.status.should.not.eql(429);
-          return response;
-        },
-      ],
-    };
-    const input = createInput(appDefinition, {}, testLogger);
+  it('should respect global throwForThrottlingEarly', async () => {
+    const input = createInput(
+      // This is how UI apps can run compatibly on core v18+ by setting
+      // flags.throwForThrottlingEarly to false.
+      { flags: { throwForThrottlingEarly: false } },
+      {},
+      testLogger,
+    );
     const request = createAppRequestClient(input);
 
     // Mock a 429 response
-    const scope = nock(HTTPBIN_URL)
-      .get('/status/429')
-      .reply(429, '', { 'retry-after': '30' });
+    const scope = nock('https://example.zapier.com')
+      .get('/api')
+      .reply(429, '', { 'retry-after': '60' });
 
+    // With throwForThrottlingEarly: false, the middleware should be skipped and
+    // throwForStatus should handle it instead
     await request({
-      url: `${HTTPBIN_URL}/status/429`,
-    }).should.be.rejectedWith(errors.ThrottledError);
-
-    scope.isDone().should.be.true();
-  });
-
-  it('should allow afterResponse to see 429 when throwForThrottlingEarly is true', async () => {
-    const testLogger = () => Promise.resolve({});
-    let afterResponseCalled = false;
-    const appDefinition = {
-      afterResponse: [
-        (response) => {
-          // This afterResponse middleware should see 429 when throwForThrottlingEarly is true
-          if (response.status === 429) {
-            afterResponseCalled = true;
-          }
-          return response;
-        },
-      ],
-    };
-    const input = createInput(appDefinition, {}, testLogger);
-    const request = createAppRequestClient(input);
-
-    // Mock a 429 response
-    const scope = nock(HTTPBIN_URL)
-      .get('/status/429')
-      .reply(429, '', { 'retry-after': '30' });
-
-    await request({
-      url: `${HTTPBIN_URL}/status/429`,
-      throwForThrottlingEarly: true,
-    }).should.be.rejectedWith(errors.ResponseError);
-
-    afterResponseCalled.should.be.true();
+      url: 'https://example.zapier.com/api',
+      throwForThrottlingEarly: false,
+    }).should.be.rejectedWith(errors.ResponseError, {
+      name: 'ResponseError',
+      message:
+        '{"status":429,"headers":{"content-type":null,"retry-after":"60"},"content":"","request":{"url":"https://example.zapier.com/api"}}',
+    });
     scope.isDone().should.be.true();
   });
 });


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Adjusted the code in #1151 to address the new requirements:
- The `throwForThrottling` middleware will run by default on v18
- Developers can pass `throwForThrottlingEarly: false` to `z.request()` to disable the `throwForThrottling` middleware
- Developers can also set `flags.throwForThrottlingEarly` to false globally to disable `throwForThrottling`