### PR TITLE
fix(cli): Validate displays failure icon when integration check has errors

### DIFF
--- a/packages/cli/src/oclif/commands/validate.js
+++ b/packages/cli/src/oclif/commands/validate.js
@@ -62,10 +62,18 @@ class ValidateCommand extends BaseCommand {
       checkResult = await validateApp(rawDefinition);
     }
 
-    const doneMessage = checkResult.passes
-      ? `Running integration checks ... ${checkResult.passes.length} checks passed`
-      : undefined;
-    this.stopSpinner({ message: doneMessage });
+    const success = !checkResult.errors.total_failures;
+    const message = 'Integration checks complete';
+    this.stopSpinner({ success, message });
+
+    this.log(`    - ${checkResult.passes.length} checks passed`);
+    this.log(`    - ${checkResult.errors.total_failures} checks failed`);
+    this.log(
+      `    - ${checkResult.warnings.total_failures} checks with publishing warning`,
+    );
+    this.log(
+      `    - ${checkResult.suggestions.total_failures} checks with general warning`,
+    );
 
     const checkIssues = flattenCheckResult(checkResult);
 


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

### **BEFORE:**

![](https://cdn.zappy.app/d0acae6b491abbaddb07ab129f0a6db0.png)


### **AFTER:**

![](https://cdn.zappy.app/ddc3d1b111d771eec0d929f37501e68f.png)