### PR TITLE
fix(cli): Allow deleting old non-semver versions

### DIFF
--- a/packages/cli/src/oclif/commands/delete/version.js
+++ b/packages/cli/src/oclif/commands/delete/version.js
@@ -6,7 +6,6 @@ const { callAPI } = require('../../../utils/api');
 class DeleteVersionCommand extends BaseCommand {
   async perform() {
     const { version } = this.args;
-    this.throwForInvalidVersion(version);
 
     const { id, title } = await this.getWritableApp();
 

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -6,10 +6,15 @@ const colors = require('colors/safe');
 const BuildCommand = require('./build');
 
 const { buildAndOrUpload } = require('../../utils/build');
+const { localAppCommand } = require('../../utils/local');
 
 class PushCommand extends ZapierBaseCommand {
   async perform() {
     const skipNpmInstall = this.flags['skip-npm-install'];
+    const definition = await localAppCommand({ command: 'definition' });
+    const version = definition.version;
+    this.throwForInvalidVersion(version);
+
     await buildAndOrUpload(
       { build: true, upload: true },
       {


### PR DESCRIPTION
In https://github.com/zapier/zapier-platform/pull/1093, we released a change to introduce a stricter semver. However, before that takes into effect, we have limited the ability to delete non-strict semver versions. This MR releases that check for the version delete CLI command