### PR TITLE
chore(core): Add Input Field inference for parent, dict, and list fields

### DIFF
--- a/packages/core/types/inputs.d.ts
+++ b/packages/core/types/inputs.d.ts
@@ -132,9 +132,11 @@ type FieldResultTypes = {
 
 /**
  * Get the TypeScript type that corresponds to the zapier field type. If
- * `type` is not set, the field defaults to `string`.
+ * `type` is not set, the field defaults to `string`. Does not pay
+ * attention to `list` `, `dict`, or `required` statuses. Does not work
+ * for fields with `children` subfields either.
  */
-type FieldResultType<F extends PlainInputField> = F extends {
+type PrimitiveFieldResultType<$Field extends PlainInputField> = $Field extends {
   type: infer $T extends PlainInputField['type'];
 }
   ? $T extends string
@@ -179,15 +181,83 @@ export type InputFields = InputField[];
  * type result3 = PlainFieldContribution<{ key: "c"; type: "boolean" }>;
  * // { c?: boolean | undefined }
  */
-type PlainFieldContribution<$Field extends PlainInputField> = $Field extends {
-  required: true;
-}
-  ? FieldResultType<$Field> extends never
+export type PlainFieldContribution<$Field extends PlainInputField> =
+  $Field extends { children: PlainInputField[] }
+    ? ParentFieldContribution<$Field>
+    : $Field extends { dict: true }
+      ? DictFieldContribution<$Field>
+      : $Field extends { list: true }
+        ? ListFieldContribution<$Field>
+        : PrimitiveFieldContribution<$Field>;
+
+/**
+ * Extract the contribution of a parent field to the input data. A parent
+ * Field has a `children` field array. The parent's own `key` will be
+ * ignored, and the children's contributions will be merged into the top
+ * level inputData object.
+ *
+ * @example
+ * type result = ParentFieldContribution<{ key: "a"; children: [{ key: "b"; required: true }] }>;
+ * // { b: string }
+ */
+type ParentFieldContribution<
+  $Field extends PlainInputField & { children: PlainInputField[] },
+> = PlainFieldArrayContribution<$Field['children']>;
+
+/**
+ * Extract the contribution of a dictionary field to the input data. A
+ * dictionary field has a `dict:true` field. The type for this `key`
+ * field in the inputData object will therefore be a record of the key.
+ * Currently, the value type is always `string`, but this may change in
+ * the future.
+ *
+ * @see https://zapier.atlassian.net/browse/PDE-6547 for when non-string
+ * values will be supported.
+ *
+ * @example
+ * type result = DictFieldContribution<{ key: "a"; dict: true, required: true }>;
+ * // { a: Record<string, string> }
+ */
+type DictFieldContribution<$Field extends PlainInputField & { dict: true }> =
+  $Field extends { required: true }
+    ? Record<$Field['key'], Record<string, string>>
+    : Partial<Record<$Field['key'], Record<string, string>>>;
+
+/**
+ * Extract the contribution of a list field to the input data. A list
+ * field has a `list:true` field. The type for this `key` field in the
+ * inputData object will therefore be an array of the value type.
+ *
+ * @example
+ * type result1 = ListFieldContribution<{ key: "a"; list: true, required: true }>;
+ * // { a: string[] }
+ *
+ * type result2 = ListFieldContribution<{ key: "a"; list: true; type: "integer" }>;
+ * // { a?: number[] | undefined }
+ */
+type ListFieldContribution<$Field extends PlainInputField & { list: true }> =
+  $Field extends { required: true }
+    ? Record<$Field['key'], PrimitiveFieldResultType<$Field>[]>
+    : Partial<Record<$Field['key'], PrimitiveFieldResultType<$Field>[]>>;
+
+/**
+ * Extract the contribution of a primitive field to the input data. A
+ * primitive field is a PlainInputField that is not a parent, dict, or
+ * list field. The `type` field MAY be set, but will default to `string`.
+ *
+ * @example
+ * type result1 = PrimitiveFieldContribution<{ key: "a" }>;
+ * // { a?: string | undefined }
+ *
+ * type result2 = PrimitiveFieldContribution<{ key: "a"; type: "integer", required: true }>;
+ * // { a: number }
+ */
+type PrimitiveFieldContribution<$Field extends PlainInputField> =
+  PrimitiveFieldResultType<$Field> extends never
     ? {}
-    : Record<$Field['key'], FieldResultType<$Field>>
-  : FieldResultType<$Field> extends never
-    ? {}
-    : Partial<Record<$Field['key'], FieldResultType<$Field>>>;
+    : $Field extends { required: true }
+      ? Record<$Field['key'], PrimitiveFieldResultType<$Field>>
+      : Partial<Record<$Field['key'], PrimitiveFieldResultType<$Field>>>;
 
 /**
  * Extract the contribution of multiple plain fields defined in an
@@ -297,6 +367,18 @@ type FieldFunctionContribution<$F> = $F extends (
 // the fields that a plain field or field function will contribute to
 // the bundle, but the more straightforward term "InputData" is
 // exposed to for the public API.
+//
+// TERMINOLOGY
+// -----------
+// InputField: A PlainInputField or a FieldFunction.
+// FieldFunction: A function that returns an array of InputFields.
+// KnownFieldFunction: A FieldFunction that returns explicitly named InputFields.
+// UnknownFieldFunction: A FieldFunction that returns an array of InputFields that are not explicitly named.
+// PlainInputField: From the schema. Object with a key, and possibly `children`, `dict`, `list`, `type`, `required`, fields.
+// ParentInputField: A PlainInputField with a `children` field array.
+// DictInputField: A PlainInputField with a `dict:true` field.
+// ListInputField: A PlainInputField with a `list:true` field.
+// PrimitiveInputField: A PlainInputField with a `type` field that is not a parent, dict, or list field.
 
 /**
  * Get the bundle contribution of a single field. This is either a plain

--- a/packages/core/types/inputs.plainfields.test-d.ts
+++ b/packages/core/types/inputs.plainfields.test-d.ts
@@ -1,0 +1,343 @@
+import { expectAssignable, expectType } from 'tsd';
+
+import type { PlainFieldContribution } from './inputs';
+
+//
+// Parent fields (where `children` is set)
+//
+
+// Simplest `children: [{...}]` case.
+const singleRequiredChild = {
+  string_required: 'some_string',
+};
+type singleRequiredChildren = PlainFieldContribution<{
+  key: 'parent_input';
+  children: [{ key: 'string_required'; type: 'string'; required: true }];
+}>;
+expectType<singleRequiredChildren>(singleRequiredChild);
+
+// Complete `children: [{...}]` case.
+const multipleRequiredChild = {
+  string_required: 'some_string',
+  number_required: 1,
+  boolean_required: true,
+  datetime_required: '2021-01-01T00:00:00Z',
+  file_required: 'some_file',
+  password_required: 'some_password',
+  code_required: 'some_code',
+};
+type multipleRequiredChildren = PlainFieldContribution<{
+  key: 'parent_input';
+  children: [
+    { key: 'string_required'; type: 'string'; required: true },
+    { key: 'number_required'; type: 'number'; required: true },
+    { key: 'boolean_required'; type: 'boolean'; required: true },
+    { key: 'datetime_required'; type: 'datetime'; required: true },
+    { key: 'file_required'; type: 'file'; required: true },
+    { key: 'password_required'; type: 'password'; required: true },
+    { key: 'code_required'; type: 'code'; required: true },
+  ];
+}>;
+expectType<multipleRequiredChildren>(multipleRequiredChild);
+
+// Complete `children: [{...}]` case where all children are optional.
+const multipleOptionalChild = {
+  string_optional: 'some_string',
+  number_optional: 1,
+  boolean_optional: true,
+  datetime_optional: '2021-01-01T00:00:00Z',
+  file_optional: 'some_file',
+  password_optional: 'some_password',
+  code_optional: 'some_code',
+};
+type multipleOptionalChildren = PlainFieldContribution<{
+  key: 'parent_input';
+  children: [
+    { key: 'string_optional'; type: 'string'; required: false },
+    { key: 'number_optional'; type: 'number'; required: false },
+    { key: 'boolean_optional'; type: 'boolean'; required: false },
+    { key: 'datetime_optional'; type: 'datetime'; required: false },
+    { key: 'file_optional'; type: 'file'; required: false },
+    { key: 'password_optional'; type: 'password'; required: false },
+    { key: 'code_optional'; type: 'code'; required: false },
+  ];
+}>;
+expectAssignable<multipleOptionalChildren>(multipleOptionalChild);
+expectAssignable<multipleOptionalChildren>({});
+
+// Complete `children: [{...}]` case with complete mixture of required
+// and optional fields.
+const mixedOptionalChildren = {
+  string_required: 'some_string',
+  string_optional: 'some_string',
+  number_required: 1,
+  number_optional: 1,
+  boolean_required: true,
+  boolean_optional: true,
+  datetime_required: '2021-01-01T00:00:00Z',
+  datetime_optional: '2021-01-01T00:00:00Z',
+  file_required: 'some_file',
+  file_optional: 'some_file',
+  password_required: 'some_password',
+  password_optional: 'some_password',
+  code_optional: 'some_code',
+};
+type mixedOptionalChildren = PlainFieldContribution<{
+  key: 'parent_input';
+  children: [
+    { key: 'string_required'; type: 'string'; required: true },
+    { key: 'string_optional'; type: 'string'; required: false },
+  ];
+}>;
+expectAssignable<mixedOptionalChildren>(multipleRequiredChild);
+expectAssignable<mixedOptionalChildren>({
+  ...multipleRequiredChild,
+  ...multipleOptionalChild,
+});
+
+//
+// Dictionary fields (where `dict:true` is set)
+//
+// Required dictionary fields.
+const expectedDictRequired = {
+  dict_required: {
+    some_string_1: 'some_string_1',
+  } as Record<string, string>,
+};
+type dictRequiredResult = PlainFieldContribution<{
+  key: 'dict_required';
+  type: 'string';
+  required: true;
+  dict: true;
+}>;
+expectType<dictRequiredResult>(expectedDictRequired);
+
+// Optional dictionary fields.
+type dictOptionalResult = PlainFieldContribution<{
+  key: 'dict_optional';
+  type: 'string';
+  dict: true;
+}>;
+expectAssignable<dictOptionalResult>({
+  dict_optional: { a: 'aaa' },
+});
+expectAssignable<dictOptionalResult>({
+  dict_optional: {} as Record<string, string>,
+});
+expectAssignable<dictOptionalResult>({
+  dict_optional: {},
+});
+expectAssignable<dictOptionalResult>({ dict_optional: undefined });
+expectAssignable<dictOptionalResult>({});
+
+//
+// List fields (where `list:true` is set)
+//
+// Required string list fields.
+const expectedStringListRequired = {
+  list_required_string: ['some_string_1', 'some_string_2'],
+};
+type stringListRequiredResult = PlainFieldContribution<{
+  key: 'list_required_string';
+  type: 'string';
+  required: true;
+  list: true;
+}>;
+expectType<stringListRequiredResult>(expectedStringListRequired);
+
+// Optional string list fields.
+type stringListOptionalResult = PlainFieldContribution<{
+  key: 'list_optional_string';
+  type: 'string';
+  list: true;
+}>;
+expectAssignable<stringListOptionalResult>({
+  list_optional_string: ['some_string_1', 'some_string_2'],
+});
+expectAssignable<stringListOptionalResult>({
+  list_optional_string: [],
+});
+expectAssignable<stringListOptionalResult>({
+  list_optional_string: undefined,
+});
+expectAssignable<stringListOptionalResult>({});
+
+// Optional omitted type (string) list fields.
+type omittedTypeListOptionalResult = PlainFieldContribution<{
+  key: 'list_optional_omitted_type';
+  // No `type` set.
+  list: true;
+}>;
+expectAssignable<omittedTypeListOptionalResult>({
+  list_optional_omitted_type: ['some_string_1', 'some_string_2'],
+});
+expectAssignable<omittedTypeListOptionalResult>({
+  list_optional_omitted_type: [],
+});
+expectAssignable<omittedTypeListOptionalResult>({
+  list_optional_omitted_type: undefined,
+});
+expectAssignable<omittedTypeListOptionalResult>({});
+
+// Required integer list fields.
+const expectedIntegerListRequired = {
+  list_required_integer: [1, 2],
+};
+type integerListRequiredResult = PlainFieldContribution<{
+  key: 'list_required_integer';
+  type: 'integer';
+  required: true;
+  list: true;
+}>;
+expectType<integerListRequiredResult>(expectedIntegerListRequired);
+
+// Optional integer list fields.
+type integerListOptionalResult = PlainFieldContribution<{
+  key: 'list_required';
+  type: 'integer';
+  list: true;
+}>;
+expectAssignable<integerListOptionalResult>({
+  list_required: [1, 2],
+});
+expectAssignable<integerListOptionalResult>({
+  list_required: [],
+});
+expectAssignable<integerListOptionalResult>({
+  list_required: undefined,
+});
+expectAssignable<integerListOptionalResult>({});
+
+//
+// Primitive fields (no parent, dict, or list. Single input field.)
+//
+// Required primitive string field.
+const expectedPrimitiveRequired = {
+  primitive_required_string: 'some_string',
+};
+type primitiveRequiredStringResult = PlainFieldContribution<{
+  key: 'primitive_required_string';
+  type: 'string';
+  required: true;
+}>;
+expectType<primitiveRequiredStringResult>(expectedPrimitiveRequired);
+
+// Optional primitive string field.
+type primitiveOptionalStringResult = PlainFieldContribution<{
+  key: 'primitive_optional_string';
+  type: 'string';
+}>;
+expectAssignable<primitiveOptionalStringResult>({
+  primitive_optional_string: 'some_string',
+});
+expectAssignable<primitiveOptionalStringResult>({
+  primitive_optional_string: undefined,
+});
+expectAssignable<primitiveOptionalStringResult>({});
+
+// Required primitive integer field.
+const expectedPrimitiveRequiredInteger = {
+  primitive_required_integer: 1,
+};
+type primitiveRequiredIntegerResult = PlainFieldContribution<{
+  key: 'primitive_required_integer';
+  type: 'integer';
+  required: true;
+}>;
+expectType<primitiveRequiredIntegerResult>(expectedPrimitiveRequiredInteger);
+
+// Optional primitive integer field.
+type primitiveOptionalIntegerResult = PlainFieldContribution<{
+  key: 'primitive_optional_integer';
+  type: 'integer';
+}>;
+expectAssignable<primitiveOptionalIntegerResult>({
+  primitive_optional_integer: 1,
+});
+expectAssignable<primitiveOptionalIntegerResult>({
+  primitive_optional_integer: undefined,
+});
+expectAssignable<primitiveOptionalIntegerResult>({});
+
+// Required primitive number field.
+const expectedPrimitiveRequiredNumber = {
+  primitive_required_number: 1.1,
+};
+type primitiveRequiredNumberResult = PlainFieldContribution<{
+  key: 'primitive_required_number';
+  type: 'number';
+  required: true;
+}>;
+expectType<primitiveRequiredNumberResult>(expectedPrimitiveRequiredNumber);
+
+// Optional primitive number field.
+type primitiveOptionalNumberResult = PlainFieldContribution<{
+  key: 'primitive_optional_number';
+  type: 'number';
+}>;
+expectAssignable<primitiveOptionalNumberResult>({
+  primitive_optional_number: 1.1,
+});
+expectAssignable<primitiveOptionalNumberResult>({
+  primitive_optional_number: undefined,
+});
+expectAssignable<primitiveOptionalNumberResult>({});
+
+// Required primitive boolean field.
+const expectedPrimitiveRequiredBoolean = {
+  primitive_required_boolean: true,
+};
+type primitiveRequiredBooleanResult = PlainFieldContribution<{
+  key: 'primitive_required_boolean';
+  type: 'boolean';
+  required: true;
+}>;
+expectType<primitiveRequiredBooleanResult>(expectedPrimitiveRequiredBoolean);
+
+// Optional primitive boolean field.
+type primitiveOptionalBooleanResult = PlainFieldContribution<{
+  key: 'primitive_optional_boolean';
+  type: 'boolean';
+}>;
+expectAssignable<primitiveOptionalBooleanResult>({
+  primitive_optional_boolean: true,
+});
+expectAssignable<primitiveOptionalBooleanResult>({
+  primitive_optional_boolean: undefined,
+});
+expectAssignable<primitiveOptionalBooleanResult>({});
+
+// Required primitive datetime field.
+const expectedPrimitiveRequiredDatetime = {
+  primitive_required_datetime: '2021-01-01T00:00:00Z',
+};
+
+type primitiveRequiredDatetimeResult = PlainFieldContribution<{
+  key: 'primitive_required_datetime';
+  type: 'datetime';
+  required: true;
+}>;
+expectType<primitiveRequiredDatetimeResult>(expectedPrimitiveRequiredDatetime);
+
+// Optional primitive datetime field.
+type primitiveOptionalDatetimeResult = PlainFieldContribution<{
+  key: 'primitive_optional_datetime';
+  type: 'datetime';
+}>;
+expectAssignable<primitiveOptionalDatetimeResult>({
+  primitive_optional_datetime: '2021-01-01T00:00:00Z',
+});
+expectAssignable<primitiveOptionalDatetimeResult>({
+  primitive_optional_datetime: undefined,
+});
+expectAssignable<primitiveOptionalDatetimeResult>({});
+
+// Optional primitive copy field.
+type primitiveOptionalCopyResult = PlainFieldContribution<{
+  key: 'primitive_optional_copy';
+  type: 'copy';
+}>;
+expectAssignable<primitiveOptionalCopyResult>({
+  primitive_optional_copy: undefined,
+});
+expectAssignable<primitiveOptionalCopyResult>({});

--- a/packages/core/types/inputs.test-d.ts
+++ b/packages/core/types/inputs.test-d.ts
@@ -6,11 +6,7 @@
 // "plain" fields, or functions that return arrays of plain fields, sync
 // or async.
 
-import type {
-  InferInputData,
-  InputFieldFunctionWithInputs,
-  InputFields,
-} from './inputs';
+import type { InferInputData, InputFieldFunctionWithInputs } from './inputs';
 import { defineInputFields } from '.';
 import type { PlainInputField } from './schemas.generated';
 
@@ -18,9 +14,7 @@ import { expectAssignable, expectType } from 'tsd';
 
 //
 // Test for when `type` is not set, the field defaults to `string`.
-const defaultStringInputs = [
-  { key: 'default_string' },
-] as const satisfies InputFields;
+const defaultStringInputs = defineInputFields([{ key: 'default_string' }]);
 const defaultStringResult1: InferInputData<typeof defaultStringInputs> = {
   default_string: 'a',
 };
@@ -32,11 +26,11 @@ expectAssignable<{ default_string?: string }>(defaultStringResult2);
 
 //
 // Tests for `required` combinations.
-const requiredComboInputs = [
+const requiredComboInputs = defineInputFields([
   { key: 'required_true', required: true },
   { key: 'required_false', required: false },
   { key: 'required_omitted' }, // Will also be optional.
-] as const satisfies InputFields;
+]);
 
 const requiredComboResult1: InferInputData<typeof requiredComboInputs> = {
   required_true: 'a',
@@ -50,7 +44,7 @@ expectAssignable<{
 
 //
 // Test available types.
-const typeComboInputs = [
+const typeComboInputs = defineInputFields([
   { key: 'string_type', type: 'string', required: true },
   { key: 'text_type', type: 'text', required: true },
   { key: 'password_type', type: 'password', required: true },
@@ -60,7 +54,7 @@ const typeComboInputs = [
   { key: 'boolean_type', type: 'boolean', required: true },
   { key: 'datetime_type', type: 'datetime', required: true },
   { key: 'file_type', type: 'file', required: true },
-] as const satisfies InputFields;
+]);
 const typeComboResult: InferInputData<typeof typeComboInputs> = {
   string_type: 'a',
   text_type: 'b',
@@ -86,11 +80,11 @@ expectType<{
 
 //
 // Test that copy fields are never appear in the bundle.
-const copyComboInputs = [
+const copyComboInputs = defineInputFields([
   { key: 'copy_type', type: 'copy' },
   { key: 'copy_type_required', type: 'copy', required: true },
   { key: 'copy_type_not_required', type: 'copy', required: false },
-] as const satisfies InputFields;
+]);
 const copyComboResult: InferInputData<typeof copyComboInputs> = {};
 expectType<{}>(copyComboResult);
 
@@ -100,14 +94,14 @@ expectType<{}>(copyComboResult);
 //   the return type is a constant array.
 // - Even if the possible result fields are known, they will all be
 //   considered optional.
-const knownFieldFunctionInputs = [
+const knownFieldFunctionInputs = defineInputFields([
   () =>
-    [
+    defineInputFields([
       { key: 'ff_required', type: 'string', required: true },
       { key: 'ff_optional', type: 'string', required: false },
       { key: 'ff_omitted', type: 'string' },
-    ] as const satisfies InputFields,
-] as const satisfies InputFields;
+    ]),
+]);
 const fieldFunctionResult: InferInputData<typeof knownFieldFunctionInputs> = {
   ff_required: 'a',
   ff_optional: 'b',
@@ -121,14 +115,14 @@ expectType<{
 
 //
 // Same but Async.
-const knownFieldFunctionAsyncInputs = [
+const knownFieldFunctionAsyncInputs = defineInputFields([
   async () =>
-    [
+    defineInputFields([
       { key: 'ff_required', type: 'string', required: true },
       { key: 'ff_optional', type: 'string', required: false },
       { key: 'ff_omitted', type: 'string' },
-    ] as const satisfies InputFields,
-] as const satisfies InputFields;
+    ]),
+]);
 const knownFieldFunctionAsyncResult: InferInputData<
   typeof knownFieldFunctionAsyncInputs
 > = {
@@ -145,18 +139,18 @@ expectType<{
 //
 // Test that all possible inputs a field function could return are
 // combined into a flat object as optional fields.
-const unionOfFunctionResultInputs = [
+const unionOfFunctionResultInputs = defineInputFields([
   () => {
     if (Math.random() > 0.5) {
-      return [
+      return defineInputFields([
         { key: 'ff_a', type: 'string', required: true },
-      ] as const satisfies InputFields;
+      ]);
     }
-    return [
+    return defineInputFields([
       { key: 'ff_b', type: 'string', required: false },
-    ] as const satisfies InputFields;
+    ]);
   },
-] as const satisfies InputFields;
+]);
 const unionOfFunctionResultInputsResult: InferInputData<
   typeof unionOfFunctionResultInputs
 > = {
@@ -170,18 +164,18 @@ expectType<{
 
 //
 // Same but Async.
-const unionOfFunctionResultAsyncInputs = [
+const unionOfFunctionResultAsyncInputs = defineInputFields([
   async (z, bundle) => {
     if (Math.random() > 0.5) {
-      return [
+      return defineInputFields([
         { key: 'ff_a', type: 'string', required: true },
-      ] as const satisfies InputFields;
+      ]);
     }
-    return [
+    return defineInputFields([
       { key: 'ff_b', type: 'string', required: false },
-    ] as const satisfies InputFields;
+    ]);
   },
-] as const satisfies InputFields;
+]);
 const unionOfFunctionResultAsyncResult: InferInputData<
   typeof unionOfFunctionResultAsyncInputs
 > = {
@@ -196,12 +190,12 @@ expectType<{
 //
 // Test that inputFieldFunctions with unknown fields results produce
 // Record<string, unknown>.
-const unknownFieldFunctionInputs = [
+const unknownFieldFunctionInputs = defineInputFields([
   () => {
     // E.g. Fetch fields from an API
-    return [] as PlainInputField[];
+    return [];
   },
-] as const satisfies InputFields;
+]);
 const unknownFieldFunctionResult: InferInputData<
   typeof unknownFieldFunctionInputs
 > = {};
@@ -209,12 +203,12 @@ expectType<Record<string, unknown>>(unknownFieldFunctionResult);
 
 //
 // Same but Async.
-const unknownFieldFunctionAsyncInputs = [
+const unknownFieldFunctionAsyncInputs = defineInputFields([
   async () => {
     // E.g. Fetch fields from an API
     return [] as PlainInputField[];
   },
-] as const satisfies InputFields;
+]);
 const unknownFieldFunctionAsyncResult: InferInputData<
   typeof unknownFieldFunctionAsyncInputs
 > = {};
@@ -225,13 +219,13 @@ expectType<Record<string, unknown>>(unknownFieldFunctionAsyncResult);
 // function inputs, and then testing the result of all of the inputs
 // combined.
 
-const basicFields = [
+const basicFields = defineInputFields([
   { key: 'string_field', type: 'string', required: true },
   { key: 'number_field', type: 'number', required: true },
   { key: 'boolean_field', type: 'boolean', required: true },
   { key: 'optional_field', type: 'string', required: false },
   { key: 'omitted_field', type: 'string' },
-] as const satisfies InputFields;
+]);
 
 const dynamicField = ((z, bundle) => {
   expectType<{
@@ -241,9 +235,9 @@ const dynamicField = ((z, bundle) => {
     optional_field?: string;
     omitted_field?: string;
   }>(bundle.inputData);
-  return [
+  return defineInputFields([
     { key: 'dynamic_field', type: 'string', required: true },
-  ] as const satisfies InputFields;
+  ]);
 }) satisfies InputFieldFunctionWithInputs<typeof basicFields>;
 
 const allFields = defineInputFields([...basicFields, dynamicField]);


### PR DESCRIPTION
This improves the input field inference so that `bundle.inputData` will be correctly typed for Parent, List, and Dictionary fields. 

Previously, all fields were being considered as "primitive", being one field correlated to one scalar type like `string`, `number`, or `boolean`. This extends the inference to all these types of non-primitive plain inputs to the correct types.

In experimenting with the platform, it was found that `dict` types aren't respected, and will always be strings. See PDE-6547 for further details.

The mental and then typing model of fields had to be expanded. Relevant terms introduced in the inference code are:

- `PlainInputField`: Comes from the schema, any input field that is an object with a `key` field. (therefore is not a field function).
- `ParentInputField`: A `PlainInputField` that has an array of `children: […]` input fields that are themselves `PlainInputField` objects.
- `DictInputField`/`ListInputField`: Fields that have `dict:true` or `list:true`. These
- `PrimitiveInputField`: A `PlainInputField` that is not a Parent, Dict, nor List inputfield. A plain scalar field in the editor.

<img width="2775" height="1770" alt="image" src="https://github.com/user-attachments/assets/6d236a86-01a9-4bad-b640-dc1f6eeeea71" />
