### PR TITLE
chore(core): Add `choice` field hints to bundle inputs

### DIFF
--- a/packages/core/types/inputs.plainfields.test-d.ts
+++ b/packages/core/types/inputs.plainfields.test-d.ts
@@ -341,3 +341,144 @@ expectAssignable<primitiveOptionalCopyResult>({
   primitive_optional_copy: undefined,
 });
 expectAssignable<primitiveOptionalCopyResult>({});
+
+//
+// Choices auto-complete unions.
+//
+// Required object choices auto-complete unions.
+type requiredObjectChoicesAutoCompleteUnions = PlainFieldContribution<{
+  key: 'required_object_choices_auto_complete_unions';
+  type: 'string';
+  required: true;
+  choices: {
+    alpha: 'Alpha';
+    beta: 'Beta';
+  };
+}>;
+expectType<requiredObjectChoicesAutoCompleteUnions>(
+  {} as {
+    required_object_choices_auto_complete_unions:
+      | 'alpha'
+      | 'beta'
+      | (string & {});
+  },
+);
+expectAssignable<requiredObjectChoicesAutoCompleteUnions>({
+  required_object_choices_auto_complete_unions: 'alpha',
+});
+
+// Optional object choices auto-complete unions.
+type optionalObjectChoicesAutoCompleteUnions = PlainFieldContribution<{
+  key: 'optional_object_choices_auto_complete_unions';
+  type: 'string';
+  required: false;
+  choices: {
+    alpha: 'Alpha';
+    beta: 'Beta';
+  };
+}>;
+expectType<optionalObjectChoicesAutoCompleteUnions>(
+  {} as {
+    optional_object_choices_auto_complete_unions?:
+      | 'alpha'
+      | 'beta'
+      | (string & {});
+  },
+);
+expectAssignable<optionalObjectChoicesAutoCompleteUnions>({
+  optional_object_choices_auto_complete_unions: 'alpha',
+});
+expectAssignable<optionalObjectChoicesAutoCompleteUnions>({
+  optional_object_choices_auto_complete_unions: undefined,
+});
+expectAssignable<optionalObjectChoicesAutoCompleteUnions>({});
+
+// Required array choices auto-complete unions.
+type requiredFieldArrayChoicesAutoCompleteUnions = PlainFieldContribution<{
+  key: 'required_field_array_choices_auto_complete_unions';
+  type: 'string';
+  required: true;
+  choices: [
+    { label: 'Alpha'; value: 'alpha'; sample: 'alpha' },
+    { label: 'Beta'; value: 'beta'; sample: 'beta' },
+  ];
+}>;
+expectType<requiredFieldArrayChoicesAutoCompleteUnions>(
+  {} as {
+    required_field_array_choices_auto_complete_unions:
+      | 'alpha'
+      | 'beta'
+      | (string & {});
+  },
+);
+expectAssignable<requiredFieldArrayChoicesAutoCompleteUnions>({
+  required_field_array_choices_auto_complete_unions: 'alpha',
+});
+expectAssignable<requiredFieldArrayChoicesAutoCompleteUnions>({
+  required_field_array_choices_auto_complete_unions: 'something_else',
+});
+
+// Optional array choices auto-complete unions.
+type optionalFieldArrayChoicesAutoCompleteUnions = PlainFieldContribution<{
+  key: 'optional_field_array_choices_auto_complete_unions';
+  type: 'string';
+  required: false;
+  choices: [
+    { label: 'Alpha'; value: 'alpha'; sample: 'alpha' },
+    { label: 'Beta'; value: 'beta'; sample: 'beta' },
+  ];
+}>;
+expectType<optionalFieldArrayChoicesAutoCompleteUnions>(
+  {} as {
+    optional_field_array_choices_auto_complete_unions?:
+      | 'alpha'
+      | 'beta'
+      | (string & {});
+  },
+);
+expectAssignable<optionalFieldArrayChoicesAutoCompleteUnions>({
+  optional_field_array_choices_auto_complete_unions: 'alpha',
+});
+expectAssignable<optionalFieldArrayChoicesAutoCompleteUnions>({});
+
+//
+// Required string array choices auto-complete unions.
+type requiredStringArrayChoicesAutoCompleteUnions = PlainFieldContribution<{
+  key: 'required_string_array_choices_auto_complete_unions';
+  type: 'string';
+  required: true;
+  choices: ['alpha', 'beta'];
+}>;
+expectType<requiredStringArrayChoicesAutoCompleteUnions>(
+  {} as {
+    required_string_array_choices_auto_complete_unions:
+      | 'alpha'
+      | 'beta'
+      | (string & {});
+  },
+);
+expectAssignable<requiredStringArrayChoicesAutoCompleteUnions>({
+  required_string_array_choices_auto_complete_unions: 'alpha',
+});
+expectAssignable<requiredStringArrayChoicesAutoCompleteUnions>({
+  required_string_array_choices_auto_complete_unions: 'something_else',
+});
+
+type optionalStringArrayChoicesAutoCompleteUnions = PlainFieldContribution<{
+  key: 'optional_string_array_choices_auto_complete_unions';
+  type: 'string';
+  required: false;
+  choices: ['alpha', 'beta'];
+}>;
+expectType<optionalStringArrayChoicesAutoCompleteUnions>(
+  {} as {
+    optional_string_array_choices_auto_complete_unions?:
+      | 'alpha'
+      | 'beta'
+      | (string & {});
+  },
+);
+expectAssignable<optionalStringArrayChoicesAutoCompleteUnions>({
+  optional_string_array_choices_auto_complete_unions: 'alpha',
+});
+expectAssignable<optionalStringArrayChoicesAutoCompleteUnions>({});

--- a/packages/core/types/inputs.test-d.ts
+++ b/packages/core/types/inputs.test-d.ts
@@ -6,7 +6,11 @@
 // "plain" fields, or functions that return arrays of plain fields, sync
 // or async.
 
-import type { InferInputData, InputFieldFunctionWithInputs } from './inputs';
+import type {
+  InferInputData,
+  InputFieldFunctionWithInputs,
+  StringHints,
+} from './inputs';
 import { defineInputFields } from '.';
 import type { PlainInputField } from './schemas.generated';
 
@@ -258,3 +262,69 @@ expectType<{
   omitted_field?: string;
   dynamic_field?: string; // Becomes optional.
 }>(allFieldsResult);
+
+// Choices
+const choicesInputs = defineInputFields([
+  {
+    key: 'choices_string_array',
+    type: 'string',
+    required: true,
+    choices: ['c1', 'c2'],
+  },
+  {
+    key: 'choices_object',
+    type: 'string',
+    required: true,
+    choices: { c3: 'C3', c4: 'C4' },
+  },
+  {
+    key: 'choices_field_array',
+    type: 'string',
+    required: true,
+    choices: [
+      { label: 'C5', value: 'c5', sample: 'c5' },
+      { label: 'C6', value: 'c6', sample: 'c6' },
+    ],
+  },
+  {
+    key: 'choices_list',
+    type: 'string',
+    required: true,
+    list: true,
+    choices: ['c7', 'c8'],
+  },
+  {
+    key: 'ignored_parent',
+    children: [
+      {
+        key: 'child_choice',
+        type: 'string',
+        required: true,
+        choices: { c9: 'C9', c10: 'C10' },
+      },
+      {
+        key: 'child_choice_list',
+        type: 'string',
+        required: true,
+        list: true,
+        choices: ['c11', 'c12'],
+      },
+    ],
+  },
+]);
+const choicesResult: InferInputData<typeof choicesInputs> = {
+  choices_string_array: 'c1',
+  choices_object: 'c3',
+  choices_field_array: 'c5',
+  choices_list: ['c7'],
+  child_choice: 'c9',
+  child_choice_list: ['c11'],
+};
+expectType<{
+  choices_string_array: StringHints<'c1' | 'c2'>;
+  choices_object: StringHints<'c3' | 'c4'>;
+  choices_field_array: StringHints<'c5' | 'c6'>;
+  choices_list: StringHints<'c7' | 'c8'>[];
+  child_choice: StringHints<'c9' | 'c10'>;
+  child_choice_list: StringHints<'c11' | 'c12'>[];
+}>(choicesResult);


### PR DESCRIPTION
When `choices` is set, as either an array of strings, array FieldChoiceLabels, or a `Record<string, string>`, the inferred inputData now captures the possible values and pass them through as hints to the `perform` function:

![choicehints](https://github.com/user-attachments/assets/0ad38d4e-c7c4-4d15-8639-1979658425dc)

1. Shows the new `StringHints` type derieved from the `Record<string, string>` style `choices` for two of the inputs.
2. Shows hints for relevant values, while allowing other strings, too.

Note that because custom values are permitted, these are treated as hints only, and does not enforce union of a string literal values as a whitelist.