### PR TITLE
fix(core): Allow null and undefined values for page_token in SearchResult type

### DIFF
--- a/packages/core/types/functions.d.ts
+++ b/packages/core/types/functions.d.ts
@@ -171,7 +171,7 @@ export type CreatePerformGet<
  *
  * When `canPaginate` is true for the search, the object shape is required.
  */
-type SearchResult<T> = T[] | { results: T[]; paging_token: string };
+type SearchResult<T> = T[] | { results: T[]; paging_token: string | null | undefined };
 
 /**
  * Search for objects on a partner API.

--- a/packages/core/types/functions.test-d.ts
+++ b/packages/core/types/functions.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable, expectType } from 'tsd';
-import type { PollingTriggerPerform } from './functions';
+import type { PollingTriggerPerform, SearchPerform } from './functions';
 import { Bundle, ZObject } from './custom';
 import { InferInputData } from './inputs';
 import { defineInputFields } from './typeHelpers';
@@ -62,3 +62,73 @@ expectType<
     bundle: Bundle<{ key1: string; key2?: number | undefined }>,
   ) => Promise<{ id: string; name: string }[]>
 >(simplePerformWithInputFieldsAndAutomaticInference);
+
+//
+// SearchResult<T> and SearchPerform tests
+//
+
+// Test SearchResult<T> with simple array return
+const simpleSearchPerform = (async (z, bundle) => {
+  return [{ id: '1', name: 'test' }];
+}) satisfies SearchPerform;
+
+expectAssignable<SearchPerform<{}, { id: string; name: string }>>(
+  simpleSearchPerform,
+);
+
+// Test SearchResult<T> with paginated object return
+const paginatedSearchPerform = (async (z, bundle) => {
+  return {
+    results: [{ id: '1', name: 'test' }],
+    paging_token: 'next-page-token',
+  };
+}) satisfies SearchPerform;
+
+expectAssignable<SearchPerform<{}, { id: string; name: string }>>(
+  paginatedSearchPerform,
+);
+
+// Test SearchResult<T> with null paging_token
+const nullPagingTokenSearchPerform = (async (z, bundle) => {
+  return {
+    results: [{ id: '1', name: 'test' }],
+    paging_token: null,
+  };
+}) satisfies SearchPerform;
+
+expectAssignable<SearchPerform<{}, { id: string; name: string }>>(
+  nullPagingTokenSearchPerform,
+);
+
+// Test SearchResult<T> with undefined paging_token
+const undefinedPagingTokenSearchPerform = (async (z, bundle) => {
+  return {
+    results: [{ id: '1', name: 'test' }],
+    paging_token: undefined,
+  };
+}) satisfies SearchPerform;
+
+expectAssignable<SearchPerform<{}, { id: string; name: string }>>(
+  undefinedPagingTokenSearchPerform,
+);
+
+// Test SearchResult<T> with empty results array
+const emptyResultsSearchPerform = (async (z, bundle) => {
+  return {
+    results: [],
+    paging_token: 'next-page-token',
+  };
+}) satisfies SearchPerform;
+
+expectAssignable<SearchPerform<{}, { id: string; name: string }>>(
+  emptyResultsSearchPerform,
+);
+
+// Test SearchResult<T> with empty array return
+const emptyArraySearchPerform = (async (z, bundle) => {
+  return [];
+}) satisfies SearchPerform;
+
+expectAssignable<SearchPerform<{}, { id: string; name: string }>>(
+  emptyArraySearchPerform,
+);


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Followup to https://github.com/zapier/zapier-platform/pull/1166