### PR TITLE
PDE-6592 docs(cli): fix incorrect docs in `zapier migrate`

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -603,8 +603,8 @@ You cannot pass both `--user` and `--account`.
 * `percent` | Percentage (between 1 and 100) of users to migrate.
 
 **Flags**
-* `--user` | Migrates all of a user's Private Zaps in the accounts they own, excluding team accounts
-* `--account` | Migrates all Zaps, Private & Shared, within all accounts for which the specified user is a member
+* `--user` | Migrates a user's private Zaps under the user's individual account, excluding organization accounts
+* `--account` | Migrates a user's private and shared Zaps under the user's individual and organization accounts
 * `-y, --yes` | Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.
 * `-d, --debug` | Show extra debugging output.
 

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -603,8 +603,8 @@ You cannot pass both `--user` and `--account`.
 * `percent` | Percentage (between 1 and 100) of users to migrate.
 
 **Flags**
-* `--user` | Migrates all of a users' Private Zaps within all accounts for which the specified user is a member
-* `--account` | Migrates all of a users' Zaps, Private & Shared, within all accounts for which the specified user is a member
+* `--user` | Migrates all of a user's Private Zaps in the accounts they own, excluding team accounts
+* `--account` | Migrates all Zaps, Private & Shared, within all accounts for which the specified user is a member
 * `-y, --yes` | Automatically answer "yes" to any prompts. Useful if you want to avoid interactive prompts to run this command in CI.
 * `-d, --debug` | Show extra debugging output.
 

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -152,11 +152,11 @@ MigrateCommand.flags = buildFlags({
   commandFlags: {
     user: Flags.string({
       description:
-        "Migrates all of a users' Private Zaps within all accounts for which the specified user is a member",
+        "Migrates all of a user's Private Zaps in the accounts they own, excluding team accounts",
     }),
     account: Flags.string({
       description:
-        "Migrates all of a users' Zaps, Private & Shared, within all accounts for which the specified user is a member",
+        'Migrates all Zaps, Private & Shared, within all accounts for which the specified user is a member',
     }),
     yes: Flags.boolean({
       char: 'y',

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -152,11 +152,11 @@ MigrateCommand.flags = buildFlags({
   commandFlags: {
     user: Flags.string({
       description:
-        "Migrates all of a user's Private Zaps in the accounts they own, excluding team accounts",
+        "Migrates a user's private Zaps under the user's individual account, excluding organization accounts",
     }),
     account: Flags.string({
       description:
-        'Migrates all Zaps, Private & Shared, within all accounts for which the specified user is a member',
+        "Migrates a user's private and shared Zaps under the user's individual and organization accounts",
     }),
     yes: Flags.boolean({
       char: 'y',


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
