### PR TITLE
PDE-6592 test(core): fix failing tests due to HttpBin URL change

### DIFF
--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -250,7 +250,6 @@ describe('create-app', () => {
 
     const result = output.results[0];
 
-    result.url.should.eql(`${HTTPBIN_URL}/get`);
     result.headers['X-Hashy'].should.deepEqual([
       '1a3ba5251cb33ee7ade01af6a7b960b8',
     ]);
@@ -295,12 +294,15 @@ describe('create-app', () => {
       bundle: {
         request: {
           url: `${HTTPBIN_URL}/get`,
+          params: {
+            foo: 'bar',
+          },
         },
       },
     });
     const output = await app(input);
     const response = output.results;
-    JSON.parse(response.content).url.should.eql(`${HTTPBIN_URL}/get`);
+    JSON.parse(response.content).args.should.deepEqual({ foo: ['bar'] });
   });
 
   it('should error on curlies for raw request', async () => {

--- a/packages/core/test/create-request-client.js
+++ b/packages/core/test/create-request-client.js
@@ -22,7 +22,6 @@ describe('request client', function () {
 
     response.request.headers['user-agent'].should.eql('Zapier');
     response.status.should.eql(200);
-    response.data.url.should.eql(`${HTTPBIN_URL}/get`);
   });
 
   it('should allow overriding the user-agent header', async () => {
@@ -37,7 +36,6 @@ describe('request client', function () {
     should(response.request.headers['user-agent']).eql(undefined);
     response.request.headers['User-Agent'].should.eql('Zapier!');
     response.status.should.eql(200);
-    response.data.url.should.eql(`${HTTPBIN_URL}/get`);
   });
 
   it('should have json serializable response', async () => {
@@ -51,14 +49,16 @@ describe('request client', function () {
     response.status.should.eql(200);
 
     const body = JSON.parse(response.content);
-    body.url.should.eql(`${HTTPBIN_URL}/get`);
+    body.method.should.eql('GET');
+    body.url.should.endWith('/get');
   });
 
   it('should wrap a request entirely', async () => {
     const request = createAppRequestClient(input);
     const response = await request({ url: `${HTTPBIN_URL}/get` });
     response.status.should.eql(200);
-    response.data.url.should.eql(`${HTTPBIN_URL}/get`);
+    response.data.method.should.eql('GET');
+    response.data.url.should.endWith('/get');
   });
 
   it('should support promise bodies', async () => {
@@ -139,7 +139,8 @@ describe('request client', function () {
     const request = createAppRequestClient(input);
     const response = await request(`${HTTPBIN_URL}/get`);
     response.status.should.eql(200);
-    response.data.url.should.eql(`${HTTPBIN_URL}/get`);
+    response.data.method.should.eql('GET');
+    response.data.url.should.endWith('/get');
   });
 
   it('should support url param with options', async () => {
@@ -150,7 +151,8 @@ describe('request client', function () {
 
     response.status.should.eql(200);
     const body = JSON.parse(response.content);
-    body.url.should.eql(`${HTTPBIN_URL}/get`);
+    body.method.should.eql('GET');
+    body.url.should.endWith('/get');
     body.headers.A.should.deepEqual(['B']);
   });
 
@@ -219,7 +221,8 @@ describe('request client', function () {
 
     response.request.headers['X-Testing-True'].should.eql('Yes');
     response.status.should.eql(200);
-    response.data.url.should.eql(`${HTTPBIN_URL}/get`);
+    response.data.method.should.eql('GET');
+    response.data.url.should.endWith('/get');
   });
 
   it('should default to run throwForStatus', () => {
@@ -427,7 +430,7 @@ describe('request client', function () {
       response.status.should.eql(200);
 
       const body = JSON.parse(response.content);
-      body.url.should.eql(`${HTTPBIN_URL}/get?something=&really=&cool=true`);
+      body.url.should.endWith('/get?something=&really=&cool=true');
     });
 
     it('should omit empty params when set as true', async () => {
@@ -475,8 +478,8 @@ describe('request client', function () {
       response.status.should.eql(200);
 
       const body = JSON.parse(response.content);
-      body.url.should.eql(
-        `${HTTPBIN_URL}/get?cool=false&name=zapier&zzz=%5B%5D&yyy=%7B%7D&qqq=%20`,
+      body.url.should.endWith(
+        `/get?cool=false&name=zapier&zzz=%5B%5D&yyy=%7B%7D&qqq=%20`,
       );
     });
 
@@ -498,7 +501,7 @@ describe('request client', function () {
       response.status.should.eql(200);
 
       const body = JSON.parse(response.content);
-      body.url.should.eql(`${HTTPBIN_URL}/get`);
+      body.url.should.endWith('/get');
     });
   });
 
@@ -550,7 +553,7 @@ describe('request client', function () {
 
       const { url } = JSON.parse(response.content);
       response.data.args.id.should.deepEqual(['123']);
-      url.should.eql(`${HTTPBIN_URL}/delete?id=123`);
+      url.should.endWith('/delete?id=123');
     });
   });
 
@@ -818,7 +821,7 @@ describe('request client', function () {
 
       const { headers } = response.data;
       const { url } = JSON.parse(response.content);
-      url.should.eql(`${HTTPBIN_URL}/get?limit=20&id=123`);
+      url.should.endWith('/get?limit=20&id=123');
       headers.Authorization.should.deepEqual(['Bearer Let me in']);
       // covers the case where replacing the same value in multiple places didn't work
       headers['X-Api-Key'].should.deepEqual(['Let me in']);

--- a/packages/core/test/http-middleware.js
+++ b/packages/core/test/http-middleware.js
@@ -868,8 +868,8 @@ describe('http logResponse after middleware', () => {
     });
 
     const loggedResponseBody = JSON.parse(logData.response_content);
+    loggedResponseBody.url.should.endWith('/post');
     loggedResponseBody.should.containEql({
-      url,
       data: '{"foo":"bar"}',
     });
   });
@@ -895,8 +895,8 @@ describe('http logResponse after middleware', () => {
     });
 
     const loggedResponseBody = JSON.parse(logData.response_content);
+    loggedResponseBody.url.should.endWith('/post');
     loggedResponseBody.should.containEql({
-      url,
       form: { filename: ['sample.txt'] },
     });
   });

--- a/packages/core/test/request-client-internal.js
+++ b/packages/core/test/request-client-internal.js
@@ -17,18 +17,15 @@ describe('http requests', () => {
     response.content.headers['User-Agent'][0]
       .includes('zapier-platform-core/')
       .should.be.true();
-    response.content.url.should.eql(`${HTTPBIN_URL}/get`);
+    response.content.url.should.endWith('/get');
   });
 
-  it('should make GET with url sugar param', (done) => {
-    request(`${HTTPBIN_URL}/get`)
-      .then((response) => {
-        response.status.should.eql(200);
-        should.exist(response.content);
-        response.content.url.should.eql(`${HTTPBIN_URL}/get`);
-        done();
-      })
-      .catch(done);
+  it('should make GET with url sugar param', async () => {
+    const response = await request(`${HTTPBIN_URL}/get`);
+    response.status.should.eql(200);
+    should.exist(response.content);
+    response.content.method.should.eql('GET');
+    response.content.url.should.endWith('/get');
   });
 
   it('should make GET with url sugar param and options', async () => {
@@ -36,7 +33,8 @@ describe('http requests', () => {
     const response = await request(`${HTTPBIN_URL}/get`, options);
     response.status.should.eql(200);
     should.exist(response.content);
-    response.content.url.should.eql(`${HTTPBIN_URL}/get`);
+    response.content.method.should.eql('GET');
+    response.content.url.should.endWith('/get');
     response.content.headers.A.should.deepEqual(['B']);
     // don't clobber other internal user-agent headers if we decide to use them
     response.content.headers['User-Agent'].should.deepEqual(['cool thing']);

--- a/packages/legacy-scripting-runner/test/integration-test.js
+++ b/packages/legacy-scripting-runner/test/integration-test.js
@@ -644,7 +644,7 @@ describe('Integration Test', function () {
       return _app(input).then((output) => {
         const echoed = output.results[0];
         should.deepEqual(echoed.args, { name: ['john'], active: ['False'] });
-        should.equal(echoed.url, `${HTTPBIN_URL}/get?name=john&active=False`);
+        echoed.url.should.endWith('/get?name=john&active=False');
       });
     });
 
@@ -911,7 +911,7 @@ describe('Integration Test', function () {
       );
       return _app(input).then((output) => {
         const echoed = output.results[0];
-        should.equal(echoed.url, `${HTTPBIN_URL}/get`);
+        echoed.url.should.endWith('/get');
 
         // There should be a log for the http request and the bundle
         should.equal(logs.length, 2);
@@ -1236,9 +1236,7 @@ describe('Integration Test', function () {
         req.args.should.deepEqual({
           things: ['eyedrops,cyclops,ipod'],
         });
-        req.url.should.equal(
-          `${HTTPBIN_URL}/get?things=eyedrops%2Ccyclops%2Cipod`,
-        );
+        req.url.should.endWith('/get?things=eyedrops%2Ccyclops%2Cipod');
       });
     });
 
@@ -1338,7 +1336,7 @@ describe('Integration Test', function () {
       return _app(input)
         .then((output) => {
           const result = output.results[0];
-          should.equal(result.url, `${HTTPBIN_URL}/get?a=1&a=1&a=2&a=2`);
+          result.url.should.endWith('/get?a=1&a=1&a=2&a=2');
           should.deepEqual(result.args.a, ['1', '1', '2', '2']);
         })
         .finally(() => {


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

Following up on this [comment](https://github.com/zapier/zapier-platform/pull/1169#issuecomment-3326341774), this PR fixes the failing tests related to HttpBin's `url`.

> Tests are failing because https://httpbin.zapier-tooling.com/get somehow now responds with `url: http://httpbin.zapier-tooling.com/get` instead of `url: https://httpbin.zapier-tooling.com/get` (`http://` vs. `https://`).