### PR TITLE
PDE-5830 fix(cli): address `punycode` deprecation warning partially by removing `node-fetch`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,6 @@
     "luxon": "3.6.1",
     "marked": "14.1.4",
     "marked-terminal": "7.2.1",
-    "node-fetch": "2.7.0",
     "open": "10.1.2",
     "ora": "5.4.0",
     "parse-gitignore": "0.5.1",

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -11,7 +11,6 @@ const qs = require('querystring');
 
 const fs = require('fs');
 const AdmZip = require('adm-zip');
-const fetch = require('node-fetch');
 const path = require('path');
 
 const { writeFile, readFile } = require('./files');

--- a/packages/cli/src/utils/credentials.js
+++ b/packages/cli/src/utils/credentials.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const { BASE_ENDPOINT } = require('../constants');
 
 const isSamlEmail = async (email) => {

--- a/packages/cli/src/utils/npm.js
+++ b/packages/cli/src/utils/npm.js
@@ -1,5 +1,3 @@
-const fetch = require('node-fetch');
-
 const BASE_URL = 'https://registry.npmjs.org';
 
 const getPackageLatestVersion = async (name) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11789,16 +11789,7 @@ string-length@4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11871,14 +11862,7 @@ stringify-object@3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13015,7 +12999,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13028,15 +13012,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

This is to fix the following `punycode` deprecation warning on Node.js 22+:

```
$ zapier-dev --version
(node:5361) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
* CLI version: 17.7.2
* Node.js version: v22.13.0
* OS info: darwin-arm64
* `zapier-platform-core` dependency: 17.7.2
```

node-fetch 2.7.0 is the culprit. It [depends on whatwg-url](https://github.com/node-fetch/node-fetch/blob/v2.7.0/src/index.js#L23), which in turn, [imports](https://github.com/jsdom/whatwg-url/blob/v5.0.0/src/url-state-machine.js#L2) Node.js's [deprecated `punycode` module](https://nodejs.org/docs/latest-v22.x/api/punycode.html).

Removing node-fetch from the zapier-platform-cli package is simple. On the other hand, removing node-fetch from zapier-platform-core package is a lot trickier. Luckily, in this PR, we only need to remove it from the CLI package to remove _some_ of the sources contributing to this warning.

This PR alone won't fully eliminate the warning. yeoman-generator 3.19.3 (the version we're using) is another source. It depends on node-fetch indirectly:

- yeoman-generator
  - github-username ([import site](https://github.com/yeoman/generator/blob/v4.0.0/lib/actions/user.js#L3))
    - @octokit/rest ([import site](https://github.com/sindresorhus/github-username/blob/v6.0.0/index.js#L2))
      - @octokit/core ([import site](https://github.com/octokit/rest.js/blob/v20.1.2/src/index.ts#L1))
        - @octokit/request ([import site](https://github.com/octokit/core.js/blob/v3.6.0/src/index.ts#L3))
          - node-fetch ([import site](https://github.com/octokit/request.js/blob/v5.6.3/src/fetch-wrapper.ts#L2))

Fortunately, we have another [PR](https://github.com/zapier/zapier-platform/pull/1111) (thanks @Natay) that upgraded yeoman-generator and will be shipped in v18. So I expect the `punycode` deprecation warning to be completely gone in v18.