### PR TITLE
feat(cli) - Add natural snapshot support for zapier push

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -668,16 +668,19 @@ Zapier may release new versions of your integration with bug fixes or new featur
 ## push
 
 > Build and upload the current integration.
+This command is the same as running `zapier build` and `zapier upload` in sequence. See those for more info.
 
 **Usage**: `zapier push`
-
-This command is the same as running `zapier build` and `zapier upload` in sequence. See those for more info.
 
 **Flags**
 * `--disable-dependency-detection` | Disable "smart" file inclusion. By default, Zapier only includes files that are required by your entry point (`index.js` by default). If you (or your dependencies) require files dynamically (such as with `require(someVar)`), then you may see "Cannot find module" errors. Disabling this may make your `build.zip` too large. If that's the case, try using the `includeInBuild` option in your `.zapierapprc`. See the docs about `includeInBuild` for more info.
 * `--skip-npm-install` | Skips installing a fresh copy of npm dependencies for shorter build time. Helpful for using yarn, pnpm, or local copies of dependencies.
 * `-d, --debug` | Show extra debugging output.
 * `--snapshot` | Pass in a label to create a snapshot version of this integration for development and testing purposes. The version will be created as: 0.0.0-MY-LABEL
+
+**Examples**
+* `zapier push`
+* `zapier push --snapshot MY-LABEL`
 
 
 ## register

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -677,6 +677,7 @@ This command is the same as running `zapier build` and `zapier upload` in sequen
 * `--disable-dependency-detection` | Disable "smart" file inclusion. By default, Zapier only includes files that are required by your entry point (`index.js` by default). If you (or your dependencies) require files dynamically (such as with `require(someVar)`), then you may see "Cannot find module" errors. Disabling this may make your `build.zip` too large. If that's the case, try using the `includeInBuild` option in your `.zapierapprc`. See the docs about `includeInBuild` for more info.
 * `--skip-npm-install` | Skips installing a fresh copy of npm dependencies for shorter build time. Helpful for using yarn, pnpm, or local copies of dependencies.
 * `-d, --debug` | Show extra debugging output.
+* `--snapshot` | Pass in a label to create a snapshot version of this integration for development and testing purposes. The version will be created as: 0.0.0-MY-LABEL
 
 
 ## register

--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -668,9 +668,10 @@ Zapier may release new versions of your integration with bug fixes or new featur
 ## push
 
 > Build and upload the current integration.
-This command is the same as running `zapier build` and `zapier upload` in sequence. See those for more info.
 
 **Usage**: `zapier push`
+
+This command is the same as running `zapier build` and `zapier upload` in sequence. See those for more info.
 
 **Flags**
 * `--disable-dependency-detection` | Disable "smart" file inclusion. By default, Zapier only includes files that are required by your entry point (`index.js` by default). If you (or your dependencies) require files dynamically (such as with `require(someVar)`), then you may see "Cannot find module" errors. Disabling this may make your `build.zip` too large. If that's the case, try using the `includeInBuild` option in your `.zapierapprc`. See the docs about `includeInBuild` for more info.

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -14,7 +14,7 @@ class PushCommand extends ZapierBaseCommand {
     const definition = await localAppCommand({ command: 'definition' });
 
     const snapshotLabel = this.flags.snapshot;
-    if (snapshotLabel && snapshotLabel.length >= 18) {
+    if (snapshotLabel && snapshotLabel.length > 18) {
       throw new Error('Snapshot label cannot exceed 18 characters');
     }
 

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -59,6 +59,7 @@ PushCommand.flags = {
 };
 PushCommand.examples = ['zapier push', 'zapier push --snapshot MY-LABEL'];
 PushCommand.description = `Build and upload the current integration.
+
 This command is the same as running \`zapier build\` and \`zapier upload\` in sequence. See those for more info.`;
 
 module.exports = PushCommand;

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -57,8 +57,8 @@ PushCommand.flags = {
       'Pass in a label to create a snapshot version of this integration for development and testing purposes. The version will be created as: 0.0.0-MY-LABEL',
   }),
 };
+PushCommand.examples = ['zapier push', 'zapier push --snapshot MY-LABEL'];
 PushCommand.description = `Build and upload the current integration.
-
 This command is the same as running \`zapier build\` and \`zapier upload\` in sequence. See those for more info.`;
 
 module.exports = PushCommand;

--- a/packages/cli/src/utils/api.js
+++ b/packages/cli/src/utils/api.js
@@ -429,6 +429,7 @@ const downloadSourceZip = async (dst) => {
 const upload = async (
   app,
   { skipValidation = false, overwritePartnerChanges = false } = {},
+  versionOverride,
 ) => {
   const zipPath = constants.BUILD_PATH;
   const sourceZipPath = constants.SOURCE_PATH;
@@ -461,10 +462,11 @@ const upload = async (
     headers['X-Overwrite-Partner-Changes'] = 'true';
   }
 
-  startSpinner(`Uploading version ${definition.version}`);
+  const version = versionOverride ?? definition.version;
+  startSpinner(`Uploading version ${version}`);
   try {
     await callAPI(
-      `/apps/${app.id}/versions/${definition.version}`,
+      `/apps/${app.id}/versions/${version}`,
       {
         method: 'PUT',
         body: {

--- a/packages/cli/src/utils/build.js
+++ b/packages/cli/src/utils/build.js
@@ -761,6 +761,7 @@ const _buildFunc = async ({
 const buildAndOrUpload = async (
   { build = false, upload = false } = {},
   buildOpts,
+  versionOverride,
 ) => {
   if (!(build || upload)) {
     throw new Error('must either build or upload');
@@ -777,7 +778,7 @@ const buildAndOrUpload = async (
     await _buildFunc(buildOpts);
   }
   if (upload) {
-    await _uploadFunc(app, buildOpts);
+    await _uploadFunc(app, buildOpts, versionOverride);
   }
 };
 


### PR DESCRIPTION
https://zapierorg.atlassian.net/browse/PDE-6609

Zapier push currently takes the package.json version to push to. This makes for a poor DX for creating snapshots because we need to change and then revert. Instead, we can add a option to push to a snapshot label (akin to pushing to a branch that isn't the one you're checked out on in git).
