### PR TITLE
fix(cli): Display failure reasons for env:set

### DIFF
--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -73,12 +73,12 @@ class SetEnvCommand extends BaseCommand {
       const failedKeys = e.json.errors[0].split('update: ')[1].split(', ');
       const successfulResult = omit(payload, failedKeys);
       if (!Object.keys(successfulResult).length) {
-        this.error(e.json.errors[0]);
+        this.error(e.json.errors.join('\nError: '));
       }
 
       this.warn(successMessage(version));
       this.logJSON(successfulResult);
-      this.warn(`However, these keys failed to update: ${failedKeys}`);
+      this.warn(e.json.errors.join('\nWarning: '));
     }
   }
 }


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
