### PR TITLE
PDE-6574 doc(legacy-scripting-runner): add 4.0.0 changelog

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0
+
+_Released 2025-10-30_
+
+We updated several dependencies of legacy-scripting-runner to address security vulnerabilities. This includes a **breaking change** :exclamation: from underscore's `_.template()` function, where the `_.template(templateString, data)` usage is no longer supported. You will have to change your legacy scripting code to use `_.template(templateString)(data)` instead.
+
+That's the only breaking change. For details and more dependency updates, see the PR linked below:
+
+- :exclamation: Update underscore, lodash, xmldom ([#1177](https://github.com/zapier/zapier-platform/pull/1177))
+
 ## 3.8.18
 
 _Released 2025-07-17_


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

## legacy-scripting-runner 4.0.0

_Released 2025-10-30_

We updated several dependencies of legacy-scripting-runner to address security vulnerabilities. This includes a **breaking change** :exclamation: from underscore's `_.template()` function, where the `_.template(templateString, data)` usage is no longer supported. You will have to change your legacy scripting code to use `_.template(templateString)(data)` instead.

That's the only breaking change. For details and more dependency updates, see the PR linked below:

- :exclamation: Update underscore, lodash, xmldom ([#1177](https://github.com/zapier/zapier-platform/pull/1177))
