### PR TITLE
PDE-7054 fix(core): use dedicated RPC hosts instead of zapier.com path

### DIFF
--- a/packages/core/src/tools/create-rpc-client.js
+++ b/packages/core/src/tools/create-rpc-client.js
@@ -6,7 +6,15 @@ const constants = require('../constants');
 const request = require('./request-client-internal');
 const { genId } = require('./data');
 
-const FALLBACK_RPC = process.env.ZAPIER_BASE_ENDPOINT + '/platform/rpc/cli';
+const RPC_HOSTS = {
+  'https://zapier.com': 'https://rpc.zapier.com/cli',
+  'https://zapier-staging.com': 'https://rpc.zapier-staging.com/cli',
+};
+const FALLBACK_RPC =
+  RPC_HOSTS[process.env.ZAPIER_BASE_ENDPOINT] ||
+  (process.env.ZAPIER_BASE_ENDPOINT
+    ? `${process.env.ZAPIER_BASE_ENDPOINT}/platform/rpc/cli`
+    : RPC_HOSTS['https://zapier.com']);
 
 const rpcCacheMock = (zcacheTestObj, method, key, value = null, ttl = null) => {
   if (method === 'zcache_get') {


### PR DESCRIPTION
The `FALLBACK_RPC` URL in `create-rpc-client.js` constructs the RPC endpoint as `ZAPIER_BASE_ENDPOINT + '/platform/rpc/cli'`, which resolves to `zapier.com/platform/rpc/cli`. This path now returns a 404 HTML page. This broke the smoke test on the `files` template ([example](https://github.com/zapier/zapier-platform/actions/runs/24441669217/job/71421473367?pr=1284#step:6:54)).

**Fix:** Use dedicated RPC hosts (`rpc.zapier.com` for production, `rpc.zapier-staging.com` for staging) instead of constructing the URL from the base endpoint. Falls back to the old `ZAPIER_BASE_ENDPOINT + '/platform/rpc/cli'` pattern for localhost.