### PR TITLE
[PDE-7086] fix(core): throw actionable error when app definition fails to load

### DIFF
--- a/packages/core/src/tools/schema.js
+++ b/packages/core/src/tools/schema.js
@@ -109,6 +109,17 @@ const copyPropertiesFromResource = (type, action, appRaw) => {
 };
 
 const compileApp = (appRaw) => {
+  if (appRaw == null) {
+    throw new Error(
+      `App definition could not be loaded (got ${appRaw === null ? 'null' : 'undefined'}). ` +
+        'Try the following:\n' +
+        '  - Point package.json "main" at your built entry (often dist/index.js)\n' +
+        '  - Run your build so dist/ (or the entry path) exists (e.g. tsc, npm run build, or zapier build)\n' +
+        '  - Reinstall dependencies with your package manager (npm, pnpm, or yarn)\n' +
+        '  - If you use a lockfile, make sure it matches package.json (e.g. pnpm install --frozen-lockfile)\n' +
+        '  - Export the full app object from the entry: module.exports = { ... } in CommonJS, or export default in ESM',
+    );
+  }
   appRaw = dataTools.deepCopy(appRaw);
   appRaw = schemaTools.findSourceRequireFunctions(appRaw);
   const extras = convertResourceDos(appRaw);

--- a/packages/core/test/tools/schema.js
+++ b/packages/core/test/tools/schema.js
@@ -358,6 +358,43 @@ describe('schema', () => {
     });
   });
 
+  describe('compileApp with null or undefined appRaw', () => {
+    it('should throw a clear error when appRaw is undefined', () => {
+      (() => schema.compileApp(undefined)).should.throw(
+        /App definition could not be loaded/,
+      );
+    });
+
+    it('should not mention "resources" when appRaw is undefined', () => {
+      let message = '';
+      try {
+        schema.compileApp(undefined);
+      } catch (err) {
+        message = err.message;
+      }
+      message.should.not.containEql('resources');
+    });
+
+    it('should name null/undefined and CJS/ESM export hints in the message', () => {
+      (() => schema.compileApp(undefined)).should.throw(/got undefined/);
+      (() => schema.compileApp(null)).should.throw(/got null/);
+      (() => schema.compileApp(undefined)).should.throw(/module\.exports/);
+      (() => schema.compileApp(undefined)).should.throw(/export default/);
+    });
+
+    it('should throw a clear error when appRaw is null', () => {
+      (() => schema.compileApp(null)).should.throw(
+        /App definition could not be loaded/,
+      );
+    });
+
+    it('should throw a clear error when prepareApp receives undefined', () => {
+      (() => schema.prepareApp(undefined)).should.throw(
+        /App definition could not be loaded/,
+      );
+    });
+  });
+
   describe('compileApp', () => {
     it('should populate hook trigger performList when resource is linked', () => {
       const appRaw = {


### PR DESCRIPTION
When `compileApp` receives `null` or `undefined`, it previously propagated a cryptic `TypeError` from deep inside `convertResourceDos` with no hint of the root cause.                                                                                                                                                 
  
This adds an early guard that throws a clear, actionable error message listing common root causes: wrong `package.json` `main`, missing `dist/`, stale lockfile, or missing default export.