### PR TITLE
fix(core): Remove platformData from bundle [INC-615]

### DIFF
--- a/packages/cli/docs/cli.md
+++ b/packages/cli/docs/cli.md
@@ -308,7 +308,7 @@ This doesn't register or deploy the integration with Zapier - try the `zapier re
 * (required) `path` | Where to create the new integration. If the directory doesn't exist, it will be created. If the directory isn't empty, we'll ask for confirmation
 
 **Flags**
-* `-t, --template` | The template to start your integration with. One of `[basic-auth | callback | custom-auth | digest-auth | dynamic-dropdown | files | minimal | oauth1-trello | oauth2 | openai | search-or-create | session-auth]`.
+* `-t, --template` | The template to start your integration with. One of `[basic-auth | callback | custom-auth | digest-auth | dynamic-dropdown | files | line-items | minimal | oauth1-trello | oauth2 | openai | search-or-create | session-auth]`.
 * `-m, --module` | Choose module type: CommonJS or ES Modules. Only enabled for Typescript and Minimal templates. One of `[commonjs | esm]`.
 * `-l, --language` | Choose the language to use for your new integration. Defaults to JavaScript. One of `[javascript | typescript]`.
 * `-d, --debug` | Show extra debugging output.
@@ -435,7 +435,6 @@ The `--debug` flag will show you the HTTP request logs and any console logs you 
 The following is a non-exhaustive list of current limitations in local and relay mode. We may support them in the future.
 
 - Hook triggers, including REST hook subscribe/unsubscribe
-- Line items
 - Output hydration
 - File upload
 - Function-based connection label

--- a/packages/core/src/app-middlewares/before/add-app-context.js
+++ b/packages/core/src/app-middlewares/before/add-app-context.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 // remove sensitive data from bundle before logging
 const logSafeBundle = (bundle) => {
-  return _.omit(bundle, 'authData');
+  return _.omit(bundle, ['authData', 'platformData']);
 };
 
 /*


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

We shouldn't include `platformData` in bundle logging. This PR removes that part of the bundle.

Also, it looks like the auto-generated docs didn't pick up a change that we made that supports line items and adds a line item template, so this PR also includes those generated doc changes.