### PR TITLE
Fix zapier-platform command name in source and add regression test

### DIFF
--- a/packages/cli/src/oclif/ZapierBaseCommand.js
+++ b/packages/cli/src/oclif/ZapierBaseCommand.js
@@ -267,7 +267,7 @@ class ZapierBaseCommand extends Command {
     }));
     const visibleArgv = argv.filter((arg) => !arg.hidden);
 
-    return ['zapier', name, ...visibleArgv.map(formatArg)].join(' ');
+    return ['zapier-platform', name, ...visibleArgv.map(formatArg)].join(' ');
   }
 
   // this is fine for now but we'll want to hack into https://github.com/oclif/plugin-help/blob/master/src/command.ts at some point

--- a/packages/cli/src/oclif/commands/analytics.js
+++ b/packages/cli/src/oclif/commands/analytics.js
@@ -40,7 +40,7 @@ AnalyticsCommand.flags = buildFlags({
     }),
   },
 });
-AnalyticsCommand.examples = ['zapier analytics --mode enabled'];
+AnalyticsCommand.examples = ['zapier-platform analytics --mode enabled'];
 AnalyticsCommand.description = `Show the status of the analytics that are collected. Also used to change what is collected.`;
 AnalyticsCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/build.js
+++ b/packages/cli/src/oclif/commands/build.js
@@ -24,12 +24,12 @@ class BuildCommand extends BaseCommand {
 
     this.log(
       `\nBuild complete! Created ${BUILD_PATH} and ${SOURCE_PATH}.\n` +
-        `Now you can upload them with the ${colors.bold.underline('zapier upload')} command.`,
+        `Now you can upload them with the ${colors.bold.underline('zapier-platform upload')} command.`,
     );
 
     if (!skipDepInstall) {
       this.log(
-        `\nTip: Try ${colors.bold.underline('zapier build --skip-dep-install')} for faster builds.`,
+        `\nTip: Try ${colors.bold.underline('zapier-platform build --skip-dep-install')} for faster builds.`,
       );
     }
   }
@@ -64,6 +64,6 @@ This command does the following:
 * Zips up all needed \`.js\` files. If you want to include more files, add a "includeInBuild" property (array with strings of regexp paths) to your \`${CURRENT_APP_FILE}\`.
 * Moves the zip to \`${BUILD_PATH}\` and \`${SOURCE_PATH}\` and deletes the temp folder
 
-This command is typically followed by \`zapier upload\`.`;
+This command is typically followed by \`zapier-platform upload\`.`;
 
 module.exports = BuildCommand;

--- a/packages/cli/src/oclif/commands/cache/clear.js
+++ b/packages/cli/src/oclif/commands/cache/clear.js
@@ -104,9 +104,12 @@ ClearCacheCommand.description = `Clear the cache data for a major version.
 
 This command clears the cache data for a major version of your integration.
 The job will be run in the background and may take some time to complete.
-You can check \`zapier history\` to see the job status.
+You can check \`zapier-platform history\` to see the job status.
 `;
-ClearCacheCommand.examples = [`zapier cache:clear`, `zapier cache:clear 2`];
+ClearCacheCommand.examples = [
+  `zapier-platform cache:clear`,
+  `zapier-platform cache:clear 2`,
+];
 ClearCacheCommand.skipValidInstallCheck = true;
 ClearCacheCommand.hide = true;
 

--- a/packages/cli/src/oclif/commands/canary/create.js
+++ b/packages/cli/src/oclif/commands/canary/create.js
@@ -24,7 +24,7 @@ class CanaryCreateCommand extends ZapierBaseCommand {
       this
         .log(`A canary deployment already exists from version ${existingCanary.from_version} to version ${existingCanary.to_version}, there are ${secondsRemaining} seconds remaining.
         
-If you would like to stop this canary now, run \`zapier canary:delete ${existingCanary.from_version} ${existingCanary.to_version}\``);
+If you would like to stop this canary now, run \`zapier-platform canary:delete ${existingCanary.from_version} ${existingCanary.to_version}\``);
       return;
     }
 
@@ -126,7 +126,7 @@ CanaryCreateCommand.args = {
 
 CanaryCreateCommand.description = `Create a new canary deployment, diverting a specified percentage of traffic from one version to another for a specified duration.
 
-Only one canary can be active at the same time. You can run \`zapier canary:list\` to check. If you would like to create a new canary with different parameters, you can wait for the canary to finish, or delete it using \`zapier canary:delete a.b.c x.y.z\`.
+Only one canary can be active at the same time. You can run \`zapier-platform canary:list\` to check. If you would like to create a new canary with different parameters, you can wait for the canary to finish, or delete it using \`zapier-platform canary:delete a.b.c x.y.z\`.
 
 To canary traffic for a specific user, use the --user flag.
 
@@ -134,15 +134,15 @@ To canary traffic for an entire account, use the --account-id. Note: this scenar
 
 To canary traffic for a specific user within a specific account, use both --user and --account-id flags.
 
-Note: this is similar to \`zapier migrate\` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
+Note: this is similar to \`zapier-platform migrate\` but different in that this is temporary and will "revert" the changes once the specified duration is expired.
 
 **Only use this command to canary traffic between non-breaking versions!**`;
 
 CanaryCreateCommand.examples = [
-  'zapier canary:create 1.0.0 1.1.0 -p 10 -d 3600',
-  'zapier canary:create 2.0.0 2.1.0 --percent 25 --duration 1800 --user user@example.com',
-  'zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345 -u user@example.com',
-  'zapier canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345',
+  'zapier-platform canary:create 1.0.0 1.1.0 -p 10 -d 3600',
+  'zapier-platform canary:create 2.0.0 2.1.0 --percent 25 --duration 1800 --user user@example.com',
+  'zapier-platform canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345 -u user@example.com',
+  'zapier-platform canary:create 2.0.0 2.1.0 -p 15 -d 7200 -a 12345',
 ];
 CanaryCreateCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/canary/delete.js
+++ b/packages/cli/src/oclif/commands/canary/delete.js
@@ -63,7 +63,7 @@ CanaryDeleteCommand.args = {
   }),
 };
 CanaryDeleteCommand.description = 'Delete an active canary deployment';
-CanaryDeleteCommand.examples = ['zapier canary:delete 1.0.0 1.1.0'];
+CanaryDeleteCommand.examples = ['zapier-platform canary:delete 1.0.0 1.1.0'];
 CanaryDeleteCommand.skipValidInstallCheck = true;
 
 module.exports = CanaryDeleteCommand;

--- a/packages/cli/src/oclif/commands/canary/list.js
+++ b/packages/cli/src/oclif/commands/canary/list.js
@@ -34,7 +34,7 @@ class CanaryListCommand extends ZapierBaseCommand {
 
 CanaryListCommand.flags = buildFlags({ opts: { format: true } });
 CanaryListCommand.description = 'List all active canary deployments';
-CanaryListCommand.examples = ['zapier canary:list'];
+CanaryListCommand.examples = ['zapier-platform canary:list'];
 CanaryListCommand.skipValidInstallCheck = true;
 
 module.exports = CanaryListCommand;

--- a/packages/cli/src/oclif/commands/convert.js
+++ b/packages/cli/src/oclif/commands/convert.js
@@ -156,7 +156,7 @@ The resulting CLI integration will be identical to its Visual Builder version an
 
 If you re-run this command on an existing directory it will leave existing files alone and not clobber them.
 
-You'll need to do a \`zapier push\` before the new version is visible in the editor, but otherwise you're good to go.`;
+You'll need to do a \`zapier-platform push\` before the new version is visible in the editor, but otherwise you're good to go.`;
 
 ConvertCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/delete/integration.js
+++ b/packages/cli/src/oclif/commands/delete/integration.js
@@ -17,7 +17,7 @@ class DeleteAppCommand extends BaseCommand {
 DeleteAppCommand.flags = buildFlags();
 DeleteAppCommand.description = `Delete your integration (including all versions).
 
-This only works if there are no active users or Zaps on any version. If you only want to delete certain versions, use the \`zapier delete:version\` command instead. It's unlikely that you'll be able to run this on an app that you've pushed publicly, since there are usually still users.`;
+This only works if there are no active users or Zaps on any version. If you only want to delete certain versions, use the \`zapier-platform delete:version\` command instead. It's unlikely that you'll be able to run this on an app that you've pushed publicly, since there are usually still users.`;
 DeleteAppCommand.aliases = ['delete:app'];
 DeleteAppCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/delete/version.js
+++ b/packages/cli/src/oclif/commands/delete/version.js
@@ -27,6 +27,6 @@ DeleteVersionCommand.flags = buildFlags();
 DeleteVersionCommand.skipValidInstallCheck = true;
 DeleteVersionCommand.description = `Delete a specific version of your integration.
 
-This only works if there are no users or Zaps on that version. You will probably need to have run \`zapier migrate\` and \`zapier deprecate\` before this command will work.`;
+This only works if there are no users or Zaps on that version. You will probably need to have run \`zapier-platform migrate\` and \`zapier-platform deprecate\` before this command will work.`;
 
 module.exports = DeleteVersionCommand;

--- a/packages/cli/src/oclif/commands/deprecate.js
+++ b/packages/cli/src/oclif/commands/deprecate.js
@@ -23,7 +23,7 @@ class DeprecateCommand extends BaseCommand {
 
     this.log(
       `${colors.yellow('Warning: Deprecation is an irreversible action that will eventually block access to this version.')}\n` +
-        `${colors.yellow('If all your changes are non-breaking, use `zapier migrate` instead to move users over to a newer version.')}\n`,
+        `${colors.yellow('If all your changes are non-breaking, use `zapier-platform migrate` instead to move users over to a newer version.')}\n`,
     );
 
     // Get deprecation reason - either from flag or prompt user
@@ -118,9 +118,9 @@ DeprecateCommand.args = {
   }),
 };
 DeprecateCommand.examples = [
-  'zapier deprecate 1.2.3 2011-10-01',
-  'zapier deprecate 1.2.3 2011-10-01 --reason=security_vulnerability',
-  'zapier deprecate 1.2.3 2011-10-01 -r critical_bug',
+  'zapier-platform deprecate 1.2.3 2011-10-01',
+  'zapier-platform deprecate 1.2.3 2011-10-01 --reason=security_vulnerability',
+  'zapier-platform deprecate 1.2.3 2011-10-01 -r critical_bug',
 ];
 DeprecateCommand.description = `Mark a non-production version of your integration as deprecated, with removal by a certain date.
 

--- a/packages/cli/src/oclif/commands/describe.js
+++ b/packages/cli/src/oclif/commands/describe.js
@@ -95,7 +95,7 @@ class DescribeCommand extends BaseCommand {
           authentication.redirect_uri = version.oauth_redirect_uri;
         } else {
           authentication.redirect_uri = grey(
-            'Run `zapier push` to see the redirect_uri.',
+            'Run `zapier-platform push` to see the redirect_uri.',
           );
         }
       }
@@ -182,13 +182,13 @@ class DescribeCommand extends BaseCommand {
           ['Available Methods', 'paths', grey('n/a')],
         ],
         emptyMessage: grey(
-          `Nothing found for ${type}. Use the \`zapier scaffold\` command to add one.`,
+          `Nothing found for ${type}. Use the \`zapier-platform scaffold\` command to add one.`,
         ),
       });
 
       this.log();
 
-      this.log('To add more, use the `zapier scaffold` command.');
+      this.log('To add more, use the `zapier-platform scaffold` command.');
     });
   }
 }

--- a/packages/cli/src/oclif/commands/env/get.js
+++ b/packages/cli/src/oclif/commands/env/get.js
@@ -19,7 +19,7 @@ class GetEnvCommand extends BaseCommand {
       emptyMessage: `Version ${version} has no environment values set`,
     });
 
-    this.log('Set new values with `zapier env:set`');
+    this.log('Set new values with `zapier-platform env:set`');
   }
 }
 
@@ -31,7 +31,7 @@ GetEnvCommand.args = {
 };
 GetEnvCommand.flags = buildFlags({ opts: { format: true } });
 GetEnvCommand.description = `Get environment variables for a version.`;
-GetEnvCommand.examples = [`zapier env:get 1.2.3`];
+GetEnvCommand.examples = [`zapier-platform env:get 1.2.3`];
 GetEnvCommand.skipValidInstallCheck = true;
 
 module.exports = GetEnvCommand;

--- a/packages/cli/src/oclif/commands/env/set.js
+++ b/packages/cli/src/oclif/commands/env/set.js
@@ -104,7 +104,9 @@ SetEnvCommand.flags = buildFlags({
   },
 });
 SetEnvCommand.description = `Set environment variables for a version.`;
-SetEnvCommand.examples = [`zapier env:set 1.2.3 SECRET=12345 OTHER=4321`];
+SetEnvCommand.examples = [
+  `zapier-platform env:set 1.2.3 SECRET=12345 OTHER=4321`,
+];
 SetEnvCommand.strict = false;
 SetEnvCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/env/unset.js
+++ b/packages/cli/src/oclif/commands/env/unset.js
@@ -90,7 +90,7 @@ UnsetEnvCommand.flags = buildFlags({
   },
 });
 UnsetEnvCommand.description = `Unset environment variables for a version.`;
-UnsetEnvCommand.examples = [`zapier env:unset 1.2.3 SECRET OTHER`];
+UnsetEnvCommand.examples = [`zapier-platform env:unset 1.2.3 SECRET OTHER`];
 UnsetEnvCommand.strict = false;
 UnsetEnvCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/init.js
+++ b/packages/cli/src/oclif/commands/init.js
@@ -56,16 +56,16 @@ InitCommand.args = {
   }),
 };
 InitCommand.examples = [
-  'zapier init myapp',
-  'zapier init ./path/myapp --template oauth2',
-  'zapier init ./path/myapp --template minimal --module esm',
-  'zapier init ./path/myapp --template oauth2 --language typescript',
+  'zapier-platform init myapp',
+  'zapier-platform init ./path/myapp --template oauth2',
+  'zapier-platform init ./path/myapp --template minimal --module esm',
+  'zapier-platform init ./path/myapp --template oauth2 --language typescript',
 ];
 InitCommand.description = `Initialize a new Zapier integration with a project template.
 
 After running this, you'll have a new integration in the specified directory. If you re-run this command on an existing directory, it will prompt before overwriting any existing files.
 
-This doesn't register or deploy the integration with Zapier - try the \`zapier register\` and \`zapier push\` commands for that!`;
+This doesn't register or deploy the integration with Zapier - try the \`zapier-platform register\` and \`zapier-platform push\` commands for that!`;
 
 InitCommand.skipValidInstallCheck = true;
 

--- a/packages/cli/src/oclif/commands/integrations.js
+++ b/packages/cli/src/oclif/commands/integrations.js
@@ -19,7 +19,8 @@ class IntegrationsCommand extends BaseCommand {
         ['Date Created', 'date'],
         ['Linked', 'linked'],
       ],
-      emptyMessage: 'No integrations found, try the `zapier register` command.',
+      emptyMessage:
+        'No integrations found, try the `zapier-platform register` command.',
     });
   }
 }

--- a/packages/cli/src/oclif/commands/invoke/auth/refresh.js
+++ b/packages/cli/src/oclif/commands/invoke/auth/refresh.js
@@ -69,7 +69,7 @@ const refreshAuth = async (context) => {
   }
   if (_.isEmpty(context.authData)) {
     throw new Error(
-      'No auth data found in the .env file. Run `zapier invoke auth start` first to initialize the auth data.',
+      'No auth data found in the .env file. Run `zapier-platform invoke auth start` first to initialize the auth data.',
     );
   }
   switch (authentication.type) {

--- a/packages/cli/src/oclif/commands/jobs.js
+++ b/packages/cli/src/oclif/commands/jobs.js
@@ -75,12 +75,12 @@ class JobsCommand extends BaseCommand {
         ['Errors', 'error_message'],
       ],
       emptyMessage:
-        'No recent migration or promotion jobs found. Try `zapier history` if you see older jobs.',
+        'No recent migration or promotion jobs found. Try `zapier-platform history` if you see older jobs.',
     });
   }
 }
 
-JobsCommand.examples = ['zapier jobs'];
+JobsCommand.examples = ['zapier-platform jobs'];
 JobsCommand.description = `Lists ongoing migration or promotion jobs for the current integration.
 
 A job represents a background process that will be queued up when users execute a "migrate" or "promote" command for the current integration.

--- a/packages/cli/src/oclif/commands/legacy.js
+++ b/packages/cli/src/oclif/commands/legacy.js
@@ -45,7 +45,7 @@ LegacyCommand.args = {
     required: true,
   }),
 };
-LegacyCommand.examples = ['zapier legacy 1.2.3'];
+LegacyCommand.examples = ['zapier-platform legacy 1.2.3'];
 LegacyCommand.description = `Mark a non-production version of your integration as legacy.
 
 Use this when an integration version is no longer recommended for new users, but you don't want to block existing users from using it.

--- a/packages/cli/src/oclif/commands/link.js
+++ b/packages/cli/src/oclif/commands/link.js
@@ -37,7 +37,7 @@ class LinkCommand extends BaseCommand {
     this.startSpinner(`Setting up ${CURRENT_APP_FILE}`);
     await writeLinkedAppConfig(chosenApp);
     this.stopSpinner();
-    this.log(`Done! Now you can \`${cyan('zapier push')}\``);
+    this.log(`Done! Now you can \`${cyan('zapier-platform push')}\``);
   }
 }
 
@@ -47,6 +47,6 @@ LinkCommand.description = `Link the current directory with an existing integrati
 
 This command generates a \`${CURRENT_APP_FILE}\` file in the directory in which it's ran. This file ties this code to an integration and is referenced frequently during \`push\` and \`validate\` operations. This file should be checked into source control.
 
-If you're starting an integration from scratch, use \`zapier init\` instead.`;
+If you're starting an integration from scratch, use \`zapier-platform init\` instead.`;
 
 module.exports = LinkCommand;

--- a/packages/cli/src/oclif/commands/logs.js
+++ b/packages/cli/src/oclif/commands/logs.js
@@ -93,7 +93,7 @@ class LogsCommand extends BaseCommand {
       rows: logs.reverse(), // oldest logs first
       headers,
       emptyMessage:
-        'No logs found. Try adding some `z.request()`, `z.console.log()` and doing a `zapier push`!\n',
+        'No logs found. Try adding some `z.request()`, `z.console.log()` and doing a `zapier-platform push`!\n',
     });
 
     if (hasLogs) {
@@ -102,7 +102,7 @@ class LogsCommand extends BaseCommand {
       if (this.flags.type === 'http' && !this.flags.detailed) {
         this.log(
           grey(
-            '  TIP: Use `zapier logs --type=http --detailed` to include response information.',
+            '  TIP: Use `zapier-platform logs --type=http --detailed` to include response information.',
           ),
         );
       }
@@ -119,6 +119,6 @@ LogsCommand.description = `Print recent logs.
 
 Logs are created when your integration is run as part of a Zap. They come from explicit calls to \`z.console.log()\`, usage of \`z.request()\`, and any runtime errors.
 
-This won't show logs from running locally with \`zapier test\`, since those never hit our server.`;
+This won't show logs from running locally with \`zapier-platform test\`, since those never hit our server.`;
 
 module.exports = LogsCommand;

--- a/packages/cli/src/oclif/commands/migrate.js
+++ b/packages/cli/src/oclif/commands/migrate.js
@@ -143,7 +143,7 @@ class MigrateCommand extends BaseCommand {
     this.stopSpinner();
 
     this.log(
-      `\nMigration successfully queued, check ${colors.bold.underline('zapier jobs')} to track the status. Migrations usually take between 5-10 minutes.`,
+      `\nMigration successfully queued, check ${colors.bold.underline('zapier-platform jobs')} to track the status. Migrations usually take between 5-10 minutes.`,
     );
   }
 }
@@ -184,24 +184,24 @@ MigrateCommand.args = {
 
 MigrateCommand.skipValidInstallCheck = true;
 MigrateCommand.examples = [
-  'zapier migrate 1.0.0 1.0.1',
-  'zapier migrate 1.0.1 2.0.0 10',
-  'zapier migrate 2.0.0 2.0.1 --user=user@example.com',
-  'zapier migrate 2.0.0 2.0.1 --account=account@example.com',
+  'zapier-platform migrate 1.0.0 1.0.1',
+  'zapier-platform migrate 1.0.1 2.0.0 10',
+  'zapier-platform migrate 2.0.0 2.0.1 --user=user@example.com',
+  'zapier-platform migrate 2.0.0 2.0.1 --account=account@example.com',
 ];
 MigrateCommand.description = `Migrate a percentage of users or a single user from one version of your integration to another.
 
-Start a migration to move users between different versions of your integration. You may also "revert" by simply swapping the from/to verion strings in the command line arguments (i.e. \`zapier migrate 1.0.1 1.0.0\`).
+Start a migration to move users between different versions of your integration. You may also "revert" by simply swapping the from/to verion strings in the command line arguments (i.e. \`zapier-platform migrate 1.0.1 1.0.0\`).
 
-**Only use this command to migrate users between non-breaking versions, use \`zapier deprecate\` if you have breaking changes!**
+**Only use this command to migrate users between non-breaking versions, use \`zapier-platform deprecate\` if you have breaking changes!**
 
-Migration time varies based on the number of affected Zaps. Be patient and check \`zapier jobs\` to track the status. Or use \`zapier history\` if you want to see older jobs.
+Migration time varies based on the number of affected Zaps. Be patient and check \`zapier-platform jobs\` to track the status. Or use \`zapier-platform history\` if you want to see older jobs.
 
 Since a migration is only for non-breaking changes, users are not emailed about the update/migration. It will be a transparent process for them.
 
 We recommend migrating a small subset of users first, via the percent argument, then watching error logs of the new version for any sort of odd behavior. When you feel confident there are no bugs, go ahead and migrate everyone. If you see unexpected errors, you can revert.
 
-You can migrate a specific user's Zaps by using \`--user\` (i.e. \`zapier migrate 1.0.0 1.0.1 --user=user@example.com\`). This will migrate Zaps that are private for that user. Zaps that are
+You can migrate a specific user's Zaps by using \`--user\` (i.e. \`zapier-platform migrate 1.0.0 1.0.1 --user=user@example.com\`). This will migrate Zaps that are private for that user. Zaps that are
 
   - [shared across the team](https://help.zapier.com/hc/en-us/articles/8496277647629),
   - [shared app connections](https://help.zapier.com/hc/en-us/articles/8496326497037-Share-app-connections-with-your-team), or
@@ -209,7 +209,7 @@ You can migrate a specific user's Zaps by using \`--user\` (i.e. \`zapier migrat
 
 will **not** be migrated.
 
-Alternatively, you can pass the \`--account\` flag, (i.e. \`zapier migrate 1.0.0 1.0.1 --account=account@example.com\`). This will migrate all Zaps owned by the user, Private & Shared, within all accounts for which the specified user is a member.
+Alternatively, you can pass the \`--account\` flag, (i.e. \`zapier-platform migrate 1.0.0 1.0.1 --account=account@example.com\`). This will migrate all Zaps owned by the user, Private & Shared, within all accounts for which the specified user is a member.
 
 **The \`--account\` flag should be used cautiously as it can break shared Zaps for other users in Team or Enterprise accounts.**
 

--- a/packages/cli/src/oclif/commands/promote.js
+++ b/packages/cli/src/oclif/commands/promote.js
@@ -279,15 +279,15 @@ PromoteCommand.args = {
 };
 
 PromoteCommand.skipValidInstallCheck = true;
-PromoteCommand.examples = ['zapier promote 1.0.0'];
+PromoteCommand.examples = ['zapier-platform promote 1.0.0'];
 PromoteCommand.description = `Promote a specific version to public access.
 
 Promote an integration version into production (non-private) rotation, which means new users can use this integration version.
 
 * This **does** mark the version as the official public version - all other versions & users are grandfathered.
-* This does **NOT** build/upload or deploy a version to Zapier - you should \`zapier push\` first.
-* This does **NOT** move old users over to this version - \`zapier migrate 1.0.0 1.0.1\` does that.
-* This does **NOT** recommend old users stop using this version - \`zapier deprecate 1.0.0 2017-01-01\` does that.
+* This does **NOT** build/upload or deploy a version to Zapier - you should \`zapier-platform push\` first.
+* This does **NOT** move old users over to this version - \`zapier-platform migrate 1.0.0 1.0.1\` does that.
+* This does **NOT** recommend old users stop using this version - \`zapier-platform deprecate 1.0.0 2017-01-01\` does that.
 
 Promotes are an inherently safe operation for all existing users of your integration.
 
@@ -295,6 +295,6 @@ After a promotion, go to your developer platform to [close issues that were reso
 
 If your integration is private and passes our integration checks, this will give you a URL to a form where you can fill in additional information for your integration to go public. After reviewing, the Zapier team will approve to make it public if there are no issues or decline with feedback.
 
-Check \`zapier jobs\` to track the status of the promotion. Or use \`zapier history\` if you want to see older jobs.`;
+Check \`zapier-platform jobs\` to track the status of the promotion. Or use \`zapier-platform history\` if you want to see older jobs.`;
 
 module.exports = PromoteCommand;

--- a/packages/cli/src/oclif/commands/pull.js
+++ b/packages/cli/src/oclif/commands/pull.js
@@ -58,7 +58,7 @@ PullCommand.description = `Retrieve and update your local integration files with
 
 This command updates your local integration files with the promoted version (or latest version if not public). You will be prompted with a confirmation dialog before continuing if there any destructive file changes.
 
-Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running \`zapier pull\`:
+Zapier may release new versions of your integration with bug fixes or new features. In the event this occurs, you will be unable to do the following until your local files are updated by running \`zapier-platform pull\`:
 
 * push to the promoted version
 * promote a new version

--- a/packages/cli/src/oclif/commands/push.js
+++ b/packages/cli/src/oclif/commands/push.js
@@ -56,9 +56,12 @@ PushCommand.flags = {
       'Pass in a label to create a snapshot version of this integration for development and testing purposes. The version will be created as: 0.0.0-MY-LABEL',
   }),
 };
-PushCommand.examples = ['zapier push', 'zapier push --snapshot MY-LABEL'];
+PushCommand.examples = [
+  'zapier-platform push',
+  'zapier-platform push --snapshot MY-LABEL',
+];
 PushCommand.description = `Build and upload the current integration.
 
-This command is the same as running \`zapier build\` and \`zapier upload\` in sequence. See those for more info.`;
+This command is the same as running \`zapier-platform build\` and \`zapier-platform upload\` in sequence. See those for more info.`;
 
 module.exports = PushCommand;

--- a/packages/cli/src/oclif/commands/register.js
+++ b/packages/cli/src/oclif/commands/register.js
@@ -18,7 +18,7 @@ const {
 
 class RegisterCommand extends ZapierBaseCommand {
   /**
-   * Entry point function that runs when user runs `zapier register`
+   * Entry point function that runs when user runs `zapier-platform register`
    */
   async perform() {
     // Flag validation
@@ -73,7 +73,7 @@ class RegisterCommand extends ZapierBaseCommand {
         await writeLinkedAppConfig(app, process.cwd());
         this.stopSpinner();
         this.log(
-          '\nFinished! Now that your integration is registered with Zapier, you can `zapier push`!',
+          '\nFinished! Now that your integration is registered with Zapier, you can `zapier-platform push`!',
         );
         break;
       }
@@ -297,16 +297,16 @@ RegisterCommand.flags = buildFlags({
   },
 });
 RegisterCommand.examples = [
-  'zapier register',
-  'zapier register "My Cool Integration"',
-  'zapier register "My Cool Integration" --desc "My Cool Integration helps you integrate your apps with the apps that you need." --no-subscribe',
-  'zapier register "My Cool Integration" --url "https://www.zapier.com" --audience private --role employee --category marketing-automation',
-  'zapier register --subscribe',
+  'zapier-platform register',
+  'zapier-platform register "My Cool Integration"',
+  'zapier-platform register "My Cool Integration" --desc "My Cool Integration helps you integrate your apps with the apps that you need." --no-subscribe',
+  'zapier-platform register "My Cool Integration" --url "https://www.zapier.com" --audience private --role employee --category marketing-automation',
+  'zapier-platform register --subscribe',
 ];
 RegisterCommand.description = `Register a new integration in your account, or update the existing one if a \`${CURRENT_APP_FILE}\` file is found.
 
 This command creates a new integration and links it in the \`./${CURRENT_APP_FILE}\` file. If \`${CURRENT_APP_FILE}\` already exists, it will ask you if you want to update the currently-linked integration, as opposed to creating a new one.
 
-After registering a new integration, you can run \`zapier push\` to build and upload your integration for use in the Zapier editor. This will change \`${CURRENT_APP_FILE}\`, which identifies this directory as holding code for a specific integration.`;
+After registering a new integration, you can run \`zapier-platform push\` to build and upload your integration for use in the Zapier editor. This will change \`${CURRENT_APP_FILE}\`, which identifies this directory as holding code for a specific integration.`;
 
 module.exports = RegisterCommand;

--- a/packages/cli/src/oclif/commands/scaffold.js
+++ b/packages/cli/src/oclif/commands/scaffold.js
@@ -203,10 +203,10 @@ ScaffoldCommand.flags = buildFlags({
 });
 
 ScaffoldCommand.examples = [
-  'zapier scaffold trigger contact',
-  'zapier scaffold search contact --dest=my_src/searches',
-  'zapier scaffold create contact --entry=src/index.js',
-  'zapier scaffold resource contact --force',
+  'zapier-platform scaffold trigger contact',
+  'zapier-platform scaffold search contact --dest=my_src/searches',
+  'zapier-platform scaffold create contact --entry=src/index.js',
+  'zapier-platform scaffold resource contact --force',
 ];
 
 ScaffoldCommand.description = `Add a starting trigger, create, search, or resource to your integration.

--- a/packages/cli/src/oclif/commands/team/add.js
+++ b/packages/cli/src/oclif/commands/team/add.js
@@ -83,9 +83,9 @@ These users come in three levels:
 Team members can be freely added and removed.`;
 
 TeamAddCommand.examples = [
-  'zapier team:add bruce@wayne.com admin',
-  'zapier team:add robin@wayne.com collaborator "Hey Robin, check out this app."',
-  'zapier team:add alfred@wayne.com subscriber "Hey Alfred, check out this app."',
+  'zapier-platform team:add bruce@wayne.com admin',
+  'zapier-platform team:add robin@wayne.com collaborator "Hey Robin, check out this app."',
+  'zapier-platform team:add alfred@wayne.com subscriber "Hey Alfred, check out this app."',
 ];
 TeamAddCommand.aliases = ['team:invite'];
 TeamAddCommand.skipValidInstallCheck = true;

--- a/packages/cli/src/oclif/commands/team/get.js
+++ b/packages/cli/src/oclif/commands/team/get.js
@@ -34,7 +34,7 @@ class TeamListCommand extends ZapierBaseCommand {
 
     this.log(
       `To invite more team members, use the \`${cyan(
-        'zapier team:add',
+        'zapier-platform team:add',
       )}\` command.`,
     );
   }
@@ -49,7 +49,7 @@ These users come in three levels:
   * \`collaborator\`, who has read-only access for the app, and will receive periodic email updates. These updates include quarterly health scores and more.
   * \`subscriber\`, who can't directly access the app, but will receive periodic email updates. These updates include quarterly health scores and more.
 
-Use the \`zapier team:add\` and \`zapier team:remove\` commands to modify your team.
+Use the \`zapier-platform team:add\` and \`zapier-platform team:remove\` commands to modify your team.
 `;
 TeamListCommand.aliases = ['team:list'];
 TeamListCommand.skipValidInstallCheck = true;

--- a/packages/cli/src/oclif/commands/test.js
+++ b/packages/cli/src/oclif/commands/test.js
@@ -73,7 +73,7 @@ TestCommand.flags = buildFlags({
   commandFlags: {
     'skip-validate': Flags.boolean({
       description:
-        "Forgo running `zapier validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.",
+        "Forgo running `zapier-platform validate` before tests are run. This will speed up tests if you're modifying functionality of an existing integration rather than adding new actions.",
     }),
     yarn: Flags.boolean({
       description:
@@ -89,9 +89,9 @@ TestCommand.flags = buildFlags({
 TestCommand.skipValidInstallCheck = false;
 TestCommand.strict = false;
 TestCommand.examples = [
-  'zapier test',
-  'zapier test --skip-validate -- -t 30000 --grep api',
-  'zapier test -- -fo --testNamePattern "auth pass"',
+  'zapier-platform test',
+  'zapier-platform test --skip-validate -- -t 30000 --grep api',
+  'zapier-platform test -- -fo --testNamePattern "auth pass"',
 ];
 TestCommand.description = `Test your integration via the "test" script in your "package.json".
 

--- a/packages/cli/src/oclif/commands/upload.js
+++ b/packages/cli/src/oclif/commands/upload.js
@@ -21,7 +21,7 @@ UploadCommand.description = `Upload the latest build of your integration to Zapi
 
 This command sends both ${BUILD_PATH} and ${SOURCE_PATH} to Zapier for use.
 
-Typically we recommend using \`zapier push\`, which does a build and upload, rather than \`upload\` by itself.
+Typically we recommend using \`zapier-platform push\`, which does a build and upload, rather than \`upload\` by itself.
 `;
 
 module.exports = UploadCommand;

--- a/packages/cli/src/oclif/commands/users/add.js
+++ b/packages/cli/src/oclif/commands/users/add.js
@@ -49,12 +49,12 @@ UsersAddCommand.flags = buildFlags({
   },
 });
 UsersAddCommand.examples = [
-  'zapier users:add bruce@wayne.com',
-  'zapier users:add alfred@wayne.com 1.2.3',
+  'zapier-platform users:add bruce@wayne.com',
+  'zapier-platform users:add alfred@wayne.com 1.2.3',
 ];
 UsersAddCommand.description = `Add a user to some or all versions of your integration.
 
-When this command is run, we'll send an email to the user inviting them to try your integration. You can track the status of that invite using the \`zapier users:get\` command.
+When this command is run, we'll send an email to the user inviting them to try your integration. You can track the status of that invite using the \`zapier-platform users:get\` command.
 
 Invited users will be able to see your integration's name, logo, and description. They'll also be able to create Zaps using any available triggers and actions.`;
 UsersAddCommand.aliases = ['users:invite'];

--- a/packages/cli/src/oclif/commands/users/get.js
+++ b/packages/cli/src/oclif/commands/users/get.js
@@ -33,9 +33,9 @@ class UsersListCommand extends ZapierBaseCommand {
 
     this.log(
       `\nTo invite users via a link, use the \`${cyan(
-        'zapier users:links',
+        'zapier-platform users:links',
       )}\` command. To invite a specific user by email, use the \`${cyan(
-        'zapier users:add',
+        'zapier-platform users:add',
       )}\` command.`,
     );
   }
@@ -45,9 +45,9 @@ UsersListCommand.flags = buildFlags({ opts: { format: true } });
 UsersListCommand.description = `Get a list of users who have been invited to your integration.
 
 Note that this list of users is NOT a comprehensive list of everyone who is using your integration. It only includes users who were invited directly by email (using the \`${cyan(
-  'zapier users:add',
+  'zapier-platform users:add',
 )}\` command or the web UI). Users who joined by clicking links generated using the \`${cyan(
-  'zapier user:links',
+  'zapier-platform user:links',
 )}\` command won't show up here.`;
 UsersListCommand.aliases = ['users:list'];
 UsersListCommand.skipValidInstallCheck = true;

--- a/packages/cli/src/oclif/commands/users/links.js
+++ b/packages/cli/src/oclif/commands/users/links.js
@@ -33,7 +33,7 @@ class UsersLinksCommand extends ZapierBaseCommand {
     });
 
     this.log(
-      '\nTo invite a specific user by email, use the `zapier users:add` command.',
+      '\nTo invite a specific user by email, use the `zapier-platform users:add` command.',
     );
   }
 }

--- a/packages/cli/src/oclif/commands/validate.js
+++ b/packages/cli/src/oclif/commands/validate.js
@@ -144,13 +144,13 @@ ValidateCommand.flags = buildFlags({
 });
 
 ValidateCommand.examples = [
-  'zapier validate',
-  'zapier validate --without-style',
-  'zapier validate --skip-build',
-  'zapier validate --format json',
+  'zapier-platform validate',
+  'zapier-platform validate --without-style',
+  'zapier-platform validate --skip-build',
+  'zapier-platform validate --format json',
 ];
 ValidateCommand.description = `Validate your integration.
 
-Run the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during \`zapier build\`, \`zapier upload\`, \`zapier push\` or even as a test in \`zapier test\`.`;
+Run the standard validation routine powered by json-schema that checks your integration for any structural errors. This is the same routine that runs during \`zapier-platform build\`, \`zapier-platform upload\`, \`zapier-platform push\` or even as a test in \`zapier-platform test\`.`;
 
 module.exports = ValidateCommand;

--- a/packages/cli/src/oclif/commands/versions.js
+++ b/packages/cli/src/oclif/commands/versions.js
@@ -31,7 +31,7 @@ class VersionsCommand extends BaseCommand {
         ['Updated at', 'last_changed'],
       ],
       emptyMessage:
-        'No versions to show. Try adding one with the `zapier push` command',
+        'No versions to show. Try adding one with the `zapier-platform push` command',
     });
 
     if (versions.map((v) => v.user_count).filter((c) => c === null).length) {

--- a/packages/cli/src/tests/baseCommand.js
+++ b/packages/cli/src/tests/baseCommand.js
@@ -212,4 +212,17 @@ describe('BaseCommand', () => {
       should(stdout).startWith(MESSAGE);
     });
   });
+
+  describe('markdownHelp', () => {
+    it('should use zapier-platform as the command name in usage', () => {
+      class SimpleCommand extends TestBaseCommand {
+        async perform() {}
+      }
+      SimpleCommand.description = 'A test command';
+      SimpleCommand.flags = buildFlags();
+
+      const output = SimpleCommand.markdownHelp('test');
+      should(output).containEql('**Usage**: `zapier-platform test`');
+    });
+  });
 });

--- a/packages/cli/src/tests/register.test.js
+++ b/packages/cli/src/tests/register.test.js
@@ -138,7 +138,7 @@ describe('RegisterCommand', () => {
         '--subscribe',
       ]);
       expect(stdout).to.contain(
-        'Finished! Now that your integration is registered with Zapier, you can `zapier push`!',
+        'Finished! Now that your integration is registered with Zapier, you can `zapier-platform push`!',
       );
     });
   });


### PR DESCRIPTION
## Problem

PR #1291 manually updated `cli.md` to use `zapier-platform` instead of `zapier`, but didn't fix the source that generates it. `cli.md` is auto-generated by `scripts/docs.js`, and the command name is hardcoded as `'zapier'` in `ZapierBaseCommand.zUsage()`. The precommit hook reruns `build-docs` on every commit, so the fix from #1291 will be silently overwritten the next time anyone commits a `.js` file.

## Changes

- Fix `ZapierBaseCommand.zUsage()` to return `zapier-platform` instead of `zapier`
- Replace all hardcoded `zapier <command>` references in `examples` and `description` strings across 36 command source files
- Regenerate `cli.md` from the corrected sources
- Add a test to `baseCommand.js` to verify `markdownHelp()` uses `zapier-platform` and prevent future regression

## Test plan

- [ ] `pnpm test` passes in `packages/cli`
- [ ] `pnpm build-docs` produces a `cli.md` with no bare `zapier <command>` references