### PR TITLE
PDE-7106 docs(cli): rename binary name to `zapier-platform` in `help` command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -105,8 +105,8 @@
     "additionalVersionFlags": [
       "-v"
     ],
-    "bin": "zapier",
-    "dirname": "zapier",
+    "bin": "zapier-platform",
+    "dirname": "zapier-platform",
     "plugins": [
       "@oclif/plugin-autocomplete",
       "@oclif/plugin-help",


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

`zapier-platform help` still shows `zapier` as the executable binary name. This PR fixes it.