### PR TITLE
PDE-6267 chore: release legacy-scripting-runner 4.0.8

### DIFF
--- a/packages/legacy-scripting-runner/CHANGELOG.md
+++ b/packages/legacy-scripting-runner/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.8
+
+- :hammer: Bump `@xmldom/xmldom` from 0.8.11 to 0.8.13 ([#1286](https://github.com/zapier/zapier-platform/pull/1286))
+
 ## 4.0.7
 
 - :hammer: Bump `underscore` from 1.13.7 to 1.13.8 ([#1256](https://github.com/zapier/zapier-platform/pull/1256))

--- a/packages/legacy-scripting-runner/package.json
+++ b/packages/legacy-scripting-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-platform-legacy-scripting-runner",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "Zapier's Legacy Scripting Runner, used by Web Builder apps converted to CLI.",
   "repository": "zapier/zapier-platform",
   "homepage": "https://platform.zapier.com/",


### PR DESCRIPTION
## legacy-scripting-runner 4.0.8

- :hammer: Bump `@xmldom/xmldom` from 0.8.11 to 0.8.13 ([#1286](https://github.com/zapier/zapier-platform/pull/1286))