### PR TITLE
draft: [PDE-7091] feat(core): thread targetRequest through renderAuthTemplate

### DIFF
--- a/packages/core/src/auth-template/render-auth-template.js
+++ b/packages/core/src/auth-template/render-auth-template.js
@@ -103,12 +103,18 @@ const renderAuthTemplate = async (compiledApp, input) => {
 
   // Ensure all bundle fields are populated so middleware doesn't crash
   // accessing e.g. bundle.inputData.someField or bundle.meta.isLoadingSample
+  //
+  // targetRequest carries the partner request being proxied. Signature-based
+  // auth (AWS SigV4, OAuth1, HMAC) needs the real url/method/body to compute
+  // a valid signature; absent it, the middleware runs against a stub and
+  // produces a signature for the wrong request.
   const bundle = {
     authData: eventBundle.authData || {},
     inputData: eventBundle.inputData || {},
     meta: eventBundle.meta || {},
     subscribeData: eventBundle.subscribeData || {},
     targetUrl: eventBundle.targetUrl || '',
+    targetRequest: eventBundle.targetRequest || null,
   };
 
   // Rebuild input with the fully-populated bundle so prepareRequest
@@ -213,12 +219,14 @@ const renderAuthTemplate = async (compiledApp, input) => {
     extraArgs: [stubZ, bundle],
   });
 
+  const target = bundle.targetRequest || {};
   try {
     await client({
-      url: 'https://example.com',
-      method: 'GET',
-      headers: {},
-      params: {},
+      url: target.url || 'https://example.com',
+      method: target.method || 'GET',
+      headers: target.headers || {},
+      params: target.params || {},
+      body: target.body,
       merge: true,
       [REPLACE_CURLIES]: true,
     });

--- a/packages/core/test/auth-template/render-auth-template.js
+++ b/packages/core/test/auth-template/render-auth-template.js
@@ -4,20 +4,26 @@ require('should');
 
 const renderAuthTemplate = require('../../src/auth-template/render-auth-template');
 
-const buildInput = (compiledApp, authData = {}) => ({
-  bundle: { authData },
-  _zapier: {
-    app: compiledApp,
-    event: { bundle: { authData } },
-    promises: [],
-    logger: () => Promise.resolve(),
-    logBuffer: [],
-    whatHappened: [],
-  },
-});
+const buildInput = (compiledApp, authData = {}, bundleExtras = {}) => {
+  const bundle = { authData, ...bundleExtras };
+  return {
+    bundle,
+    _zapier: {
+      app: compiledApp,
+      event: { bundle },
+      promises: [],
+      logger: () => Promise.resolve(),
+      logBuffer: [],
+      whatHappened: [],
+    },
+  };
+};
 
-const run = (compiledApp, authData) =>
-  renderAuthTemplate(compiledApp, buildInput(compiledApp, authData));
+const run = (compiledApp, authData, bundleExtras) =>
+  renderAuthTemplate(
+    compiledApp,
+    buildInput(compiledApp, authData, bundleExtras),
+  );
 
 describe('renderAuthTemplate', () => {
   describe('early returns', () => {
@@ -127,6 +133,96 @@ describe('renderAuthTemplate', () => {
       result.authType.should.eql('custom');
       result.error.should.match(/middleware blew up/);
       result.template.should.deepEqual({});
+    });
+  });
+
+  describe('targetRequest', () => {
+    it('threads url, method, body, headers, and params into the middleware', async () => {
+      let observed = null;
+      const beforeRequest = (req) => {
+        observed = {
+          url: req.url,
+          method: req.method,
+          body: req.body,
+          headers: { ...req.headers },
+          params: { ...req.params },
+        };
+        return req;
+      };
+      await run(
+        {
+          authentication: {
+            type: 'custom',
+            test: { url: 'https://example.com' },
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { api_key: 'x' },
+        {
+          targetRequest: {
+            url: 'https://api.bedrock.aws.com/invoke',
+            method: 'POST',
+            body: '{"prompt":"hi"}',
+            headers: { 'Content-Type': 'application/json' },
+            params: { foo: 'bar' },
+          },
+        },
+      );
+      observed.url.should.eql('https://api.bedrock.aws.com/invoke');
+      observed.method.should.eql('POST');
+      observed.body.should.eql('{"prompt":"hi"}');
+      observed.headers['Content-Type'].should.eql('application/json');
+      observed.params.foo.should.eql('bar');
+    });
+
+    it('falls back to stub values when targetRequest is absent', async () => {
+      let observed = null;
+      const beforeRequest = (req) => {
+        observed = { url: req.url, method: req.method };
+        return req;
+      };
+      await run(
+        {
+          authentication: {
+            type: 'custom',
+            test: { url: 'https://example.com' },
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { api_key: 'x' },
+      );
+      observed.url.should.eql('https://example.com');
+      observed.method.should.eql('GET');
+    });
+
+    it('lets signature-style middleware sign the real request', async () => {
+      // Simulates a SigV4-style signer that hashes method+url+body
+      const beforeRequest = (req, _z, bundle) => {
+        const payload = `${req.method}|${req.url}|${req.body || ''}`;
+        req.headers['X-Signature'] =
+          `sig:${payload}:${bundle.authData.secret_key}`;
+        return req;
+      };
+      const result = await run(
+        {
+          authentication: {
+            type: 'custom',
+            test: { url: 'https://example.com' },
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { secret_key: 'shh' },
+        {
+          targetRequest: {
+            url: 'https://api.example.com/widgets',
+            method: 'POST',
+            body: '{"a":1}',
+          },
+        },
+      );
+      result.template.headers['X-Signature'].should.eql(
+        'sig:POST|https://api.example.com/widgets|{"a":1}:shh',
+      );
     });
   });
 


### PR DESCRIPTION
Lets callers pass the partner request being proxied (url, method, body, headers, params) into the bundle so signature-based auth (AWS SigV4, OAuth1, HMAC) can sign the real request instead of the hardcoded https://example.com GET stub.

Without this, middleware that signs a request using its url, method, or body produces a signature valid for nothing. The monolith's auth template interface needs this to migrate Relay off Notary, since Relay proxies Bedrock and other signature-based APIs.

When targetRequest is absent, the existing stub values are used so static auth (Bearer, OAuth2 access tokens, API keys) keeps working unchanged.

<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->
