### PR TITLE
feat(cli): send binary name in CLI analytics payload

### DIFF
--- a/packages/cli/src/tests/utils/analytics.js
+++ b/packages/cli/src/tests/utils/analytics.js
@@ -1,9 +1,53 @@
 require('should');
-const { shouldSkipAnalytics } = require('../../utils/analytics');
+const { getBinaryName, shouldSkipAnalytics } = require('../../utils/analytics');
 
 describe('analytics', () => {
   // causes a lot of noise
   it('should not run analytics when testing', () => {
     shouldSkipAnalytics().should.be.true();
+  });
+
+  describe('getBinaryName', () => {
+    const originalArgv = process.argv;
+    const originalPlatform = process.platform;
+
+    afterEach(() => {
+      process.argv = originalArgv;
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    const stubPlatform = (value) => {
+      Object.defineProperty(process, 'platform', { value });
+    };
+
+    it('returns "zapier" when invoked via the zapier symlink on Unix', () => {
+      stubPlatform('linux');
+      process.argv = ['/usr/bin/node', '/usr/local/bin/zapier', 'apps'];
+      getBinaryName().should.equal('zapier');
+    });
+
+    it('returns "zapier-platform" when invoked via the new symlink on Unix', () => {
+      stubPlatform('darwin');
+      process.argv = ['/usr/bin/node', '/usr/local/bin/zapier-platform', 'apps'];
+      getBinaryName().should.equal('zapier-platform');
+    });
+
+    it('strips the file extension if present', () => {
+      stubPlatform('linux');
+      process.argv = ['/usr/bin/node', '/usr/local/bin/zapier.js'];
+      getBinaryName().should.equal('zapier');
+    });
+
+    it('returns undefined on Windows where both wrappers map to the same exe', () => {
+      stubPlatform('win32');
+      process.argv = ['C:\\Program Files\\nodejs\\node.exe', 'C:\\foo\\zapier'];
+      (getBinaryName() === undefined).should.be.true();
+    });
+
+    it('returns undefined when argv[1] is missing', () => {
+      stubPlatform('linux');
+      process.argv = ['/usr/bin/node'];
+      (getBinaryName() === undefined).should.be.true();
+    });
   });
 });

--- a/packages/cli/src/utils/analytics.js
+++ b/packages/cli/src/utils/analytics.js
@@ -1,3 +1,4 @@
+const path = require('node:path');
 const { callAPI } = require('./api');
 // const { readFile } = require('./files');
 const debug = require('debug')('zapier:analytics');
@@ -5,6 +6,17 @@ const pkg = require('../../package.json');
 const { getLinkedAppConfig } = require('../utils/api');
 const { ANALYTICS_KEY, ANALYTICS_MODES, IS_TESTING } = require('../constants');
 const { readUserConfig, writeUserConfig } = require('./userConfig');
+
+// On Windows both the `zapier` and `zapier-platform` wrappers point at the same
+// script, so we can't reliably tell which one the user invoked. Return undefined
+// in that case — matches the avro schema's nullable default.
+const getBinaryName = () => {
+  if (process.platform === 'win32') {
+    return undefined;
+  }
+  const scriptPath = process.argv[1] || '';
+  return path.basename(scriptPath, path.extname(scriptPath)) || undefined;
+};
 
 const currentAnalyticsMode = async () => {
   const { [ANALYTICS_KEY]: mode } = await readUserConfig();
@@ -53,6 +65,7 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
     argsKeys: argKeys,
     flagKeys,
     cliVersion: pkg.version,
+    binaryName: getBinaryName(),
     os: shouldRecordAnonymously ? undefined : process.platform,
   };
 
@@ -75,6 +88,7 @@ const recordAnalytics = async (command, isValidCommand, args, flags) => {
 
 module.exports = {
   currentAnalyticsMode,
+  getBinaryName,
   recordAnalytics,
   shouldSkipAnalytics,
   modes: ANALYTICS_MODES,


### PR DESCRIPTION
Adds a `binaryName` field to the CLI analytics POST payload to record which binary (`zapier` vs `zapier-platform`) the user invoked. This feeds `cli_analytics.tracking.UserInteractionEvent.cli_binary_name`.

Windows returns `undefined` since both wrappers map to the same exe.

---

I tested these changes locally with the `DEBUG=zapier:analytics` env variable:

```
$ DEBUG=zapier:analytics zapier-platform apps 2>&1 | grep -A15 sending
(standard input):5:2026-05-14T17:56:23.290Z zapier:analytics sending {
(standard input)-6-  command: 'integrations',
(standard input)-7-  isValidCommand: true,
(standard input)-8-  numArgs: 0,
(standard input)-9-  appId: undefined,
(standard input)-10-  argsKeys: [],
(standard input)-11-  flagKeys: [ 'format' ],
(standard input)-12-  cliVersion: '18.6.0',
(standard input)-13-  binaryName: 'zapier-platform',
(standard input)-14-  os: 'darwin',
(standard input)-15-  sendUserId: true
(standard input)-16-}
(standard input)-17-2026-05-14T17:56:23.541Z zapier:analytics success: true

$ DEBUG=zapier:analytics zapier apps 2>&1 | grep -A15 sending
(standard input):5:2026-05-14T17:56:23.290Z zapier:analytics sending {
(standard input)-6-  command: 'integrations',
(standard input)-7-  isValidCommand: true,
(standard input)-8-  numArgs: 0,
(standard input)-9-  appId: undefined,
(standard input)-10-  argsKeys: [],
(standard input)-11-  flagKeys: [ 'format' ],
(standard input)-12-  cliVersion: '18.6.0',
(standard input)-13-  binaryName: 'zapier',
(standard input)-14-  os: 'darwin',
(standard input)-15-  sendUserId: true
(standard input)-16-}
(standard input)-17-2026-05-14T17:56:23.541Z zapier:analytics success: true
```