### PR TITLE
fix(core): Support request templates in appTester signatures

### DIFF
--- a/packages/core/types/custom.d.ts
+++ b/packages/core/types/custom.d.ts
@@ -7,6 +7,7 @@
 
 import { Agent } from 'http';
 import { Headers } from 'node-fetch';
+import type { Request } from './schemas.generated';
 
 // The EXPORTED OBJECT
 export const version: string;
@@ -15,14 +16,28 @@ export const console: Console;
 export const errors: ErrorsModule;
 
 // see: https://github.com/zapier/zapier-platform-cli/issues/339#issue-336888249
+//
+// The runtime (`resolveMethodPath` + `execute.js`) accepts either a perform
+// function or a request-template object as the first argument. The function
+// overload is kept first so `T` is still inferred from the perform's return
+// type at call sites; the request-template overload returns `Promise<unknown>`
+// because the platform returns `response.data` whose shape isn't expressed in
+// the `Request` type. See PDE-7153.
 export const createAppTester: (
   appRaw: object,
   options?: { customStoreKey?: string },
-) => <T, B extends Bundle>(
-  func: (z: ZObject, bundle: B) => T | Promise<T>,
-  bundle?: DeepPartial<B>, // partial so we don't have to make a full bundle in tests
-  clearZcacheBeforeUse?: boolean,
-) => Promise<T>; // appTester always returns a promise
+) => {
+  <T, B extends Bundle>(
+    func: (z: ZObject, bundle: B) => T | Promise<T>,
+    bundle?: DeepPartial<B>, // partial so we don't have to make a full bundle in tests
+    clearZcacheBeforeUse?: boolean,
+  ): Promise<T>; // appTester always returns a promise
+  <B extends Bundle = Bundle>(
+    request: Request,
+    bundle?: DeepPartial<B>,
+    clearZcacheBeforeUse?: boolean,
+  ): Promise<unknown>;
+};
 
 /** Recursively make all properties of an object optional. */
 type DeepPartial<T> = T extends object

--- a/packages/core/types/index.test-d.ts
+++ b/packages/core/types/index.test-d.ts
@@ -12,10 +12,12 @@ import type {
   Bundle,
   Create,
   InputFields,
+  Request,
   Search,
   Trigger,
   ZObject,
 } from '.';
+import { createAppTester } from '.';
 import { expectAssignable, expectDeprecated, expectType } from 'tsd';
 import { defineApp, defineCreate } from './typeHelpers';
 
@@ -214,3 +216,17 @@ async (z: ZObject) => {
   const result = await resp.json();
   expectType<{ id: number; name: string }>(result);
 };
+
+// createAppTester accepts a perform function (T is inferred) and a
+// request-template object (returns Promise<unknown>). See PDE-7153.
+const tester = createAppTester({});
+
+expectType<Promise<{ id: number }>>(
+  tester(async (_z: ZObject, _b: Bundle) => ({ id: 1 })),
+);
+
+const requestTemplate: Request = {
+  url: 'https://example.com/{{bundle.inputData.id}}',
+  method: 'GET',
+};
+expectType<Promise<unknown>>(tester(requestTemplate));

--- a/packages/core/types/schemas.generated.d.ts
+++ b/packages/core/types/schemas.generated.d.ts
@@ -4,7 +4,7 @@
  * files, and/or the schema-to-ts tool and run its CLI to regenerate
  * these typings.
  *
- * zapier-platform-schema version: 18.5.1
+ * zapier-platform-schema version: 19.0.0
  *  schema-to-ts compiler version: 0.1.0
  */
 import type {
@@ -1007,7 +1007,7 @@ export interface BasicHookOperation<
    * ensure the best UX for the end-user. For private apps, this is
    * strongly recommended for testing REST Hooks. Otherwise, you can
    * ignore warnings about this property with the `--without-style`
-   * flag during `zapier push`.
+   * flag during `zapier-platform push`.
    */
   performList?:
     | Request
@@ -1024,7 +1024,8 @@ export interface BasicHookOperation<
    * Note: this is required for public apps to ensure the best UX for
    * the end-user. For private apps, this is strongly recommended for
    * testing REST Hooks. Otherwise, you can ignore warnings about this
-   * property with the `--without-style` flag during `zapier push`.
+   * property with the `--without-style` flag during `zapier-platform
+   * push`.
    */
   performSubscribe?:
     | Request
@@ -1036,7 +1037,7 @@ export interface BasicHookOperation<
    * the best UX for the end-user. For private apps, this is strongly
    * recommended for testing REST Hooks. Otherwise, you can ignore
    * warnings about this property with the `--without-style` flag
-   * during `zapier push`.
+   * during `zapier-platform push`.
    */
   performUnsubscribe?:
     | Request


### PR DESCRIPTION
This allows the appTester (made via `createAppTester`) to accept request template objects in its type signature. This fixes a considerable issue where the `operation.perform` fields of triggers and actions are typed as this, and test code shows a lot of typing errors. So long as the request template is a valid member of the App tree, the app tester will render and perform the request as given.

Type tests are included in this PR, but I also tested downstream with an example suite that request templates are actually run by the app tester:

<details>
<summary>appTesterRequestTemplates.test.ts</summary>

```ts
import { describe, it, expect } from 'vitest';
import nock from 'nock';
import zapier, { version as platformVersion } from 'zapier-platform-core';

/**
 * Isolated probe: can `appTester` actually run a request template
 * (i.e. a plain `{ url, method, params, ... }` object) instead of a
 * `(z, bundle) => …` function?
 *
 * Findings, derived by reading
 *   node_modules/zapier-platform-core/src/tools/create-app-tester.js
 *   node_modules/zapier-platform-core/src/tools/resolve-method-path.js
 *   node_modules/zapier-platform-core/src/execute.js
 *
 * 1. `createAppTester`'s TS signature only allows `(z, bundle) => T`.
 *    The runtime is more permissive: it calls `resolveMethodPath`,
 *    which accepts functions, arrays, OR objects shaped like
 *    `{ url: string }` ("request methods").
 *
 * 2. For objects, `resolveMethodPath` requires that the *same* object
 *    exist somewhere on the App tree (matched first by reference, then
 *    by `_.isEqual`). If found, it returns the dotted path string
 *    (e.g. `triggers.tap.operation.perform`).
 *
 * 3. The lambda handler then dispatches in `execute.js`:
 *      if (_.isObject(method) && method.url) {
 *        return executeHttpRequest(input, options);
 *      }
 *    `executeHttpRequest` performs `z.request(options)` and returns
 *    `response.data` — i.e. the parsed JSON body.
 *
 * Conclusion: a request template is runnable through `appTester`, but
 * only when it lives on the app definition. An ad-hoc inline object
 * (one that is not somewhere on the app) is rejected.
 */

const MOCK_HOST = 'https://tap.example.test';

const listItemsRequest = {
  url: `${MOCK_HOST}/items`,
  method: 'GET',
  params: { limit: 5 },
};

const TapApp = {
  version: '1.0.0',
  platformVersion,
  triggers: {
    list_items: {
      key: 'list_items',
      noun: 'Item',
      display: {
        label: 'List items',
        description: 'Lists items using a request-template perform.',
      },
      operation: {
        perform: listItemsRequest,
        sample: { id: 1 },
      },
    },
  },
};

const appTester = zapier.createAppTester(TapApp);

describe('appTester + request template (no perform function)', () => {
  it('runs a request template that is referenced from the app', async () => {
    const scope = nock(MOCK_HOST)
      .get('/items')
      .query({ limit: '5' })
      .reply(200, [
        { id: 1, name: 'first' },
        { id: 2, name: 'second' },
      ]);

    const result = await appTester(
      TapApp.triggers.list_items.operation.perform as unknown as (
        z: unknown,
        bundle: unknown,
      ) => unknown,
    );

    expect(scope.isDone()).toBe(true);
    expect(result).toEqual([
      { id: 1, name: 'first' },
      { id: 2, name: 'second' },
    ]);
  });

  it('matches an inline object by deep equality if it shadows one on the app', async () => {
    const scope = nock(MOCK_HOST)
      .get('/items')
      .query({ limit: '5' })
      .reply(200, [{ id: 42 }]);

    const inlineClone = {
      url: `${MOCK_HOST}/items`,
      method: 'GET',
      params: { limit: 5 },
    };

    const result = await appTester(
      inlineClone as unknown as (z: unknown, bundle: unknown) => unknown,
    );

    expect(scope.isDone()).toBe(true);
    expect(result).toEqual([{ id: 42 }]);
  });

  it('rejects an inline request object that is NOT on the app', async () => {
    await expect(
      appTester({ url: `${MOCK_HOST}/missing` } as unknown as (
        z: unknown,
        bundle: unknown,
      ) => unknown),
    ).rejects.toThrow(/could not find your function\/array\/object/i);
  });
});

```
</details>