### PR TITLE
[PDE-7120] feat(auth): add OIDC federation authentication support

### DIFF
--- a/packages/cli/src/generators/index.js
+++ b/packages/cli/src/generators/index.js
@@ -126,6 +126,7 @@ const authTypes = {
   'oauth1-trello': 'oauth1',
   oauth2: 'oauth2',
   'session-auth': 'session',
+  'oidc-federation-auth': 'oidcFederation',
 };
 
 const writeGenericAuth = (gen) => {
@@ -224,6 +225,7 @@ const TEMPLATE_ROUTES = {
   openai: writeForStandaloneTemplate,
   'search-or-create': writeForStandaloneTemplate,
   'session-auth': writeForAuthTemplate,
+  'oidc-federation-auth': writeForAuthTemplate,
 };
 
 const ESM_SUPPORTED_TEMPLATES = ['minimal'];
@@ -236,6 +238,7 @@ const TS_SUPPORTED_TEMPLATES = [
   'oauth1-trello',
   'oauth2',
   'session-auth',
+  'oidc-federation-auth',
 ];
 
 const TEMPLATE_CHOICES = Object.keys(TEMPLATE_ROUTES);

--- a/packages/cli/src/generators/templates/authTests/oidc_federation.test.js
+++ b/packages/cli/src/generators/templates/authTests/oidc_federation.test.js
@@ -1,0 +1,43 @@
+/* globals describe, it, expect */
+
+const zapier = require('zapier-platform-core');
+
+const App = require('../index');
+const appTester = zapier.createAppTester(App);
+
+describe('oidc federation auth app', () => {
+  it('fetches federation credentials via perform', async () => {
+    const bundle = {
+      authData: {
+        region: 'us-east-1',
+        roleArn: 'arn:aws:iam::123456789012:role/example',
+        sessionName: 'zapier',
+      },
+    };
+
+    const newAuthData = await appTester(
+      App.authentication.oidcFederationConfig.perform,
+      bundle,
+    );
+
+    expect(newAuthData.accessKeyId).toBe('AKIAEXAMPLE');
+    expect(newAuthData.secretAccessKey).toBe(
+      'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    );
+    expect(newAuthData.sessionToken).toBe('EXAMPLE_SESSION_TOKEN');
+  });
+
+  it('can make an authenticated test request', async () => {
+    const bundle = {
+      authData: {
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        sessionToken: 'EXAMPLE_SESSION_TOKEN',
+      },
+    };
+
+    const response = await appTester(App.authentication.test, bundle);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/cli/src/generators/templates/authTests/oidc_federation.test.ts
+++ b/packages/cli/src/generators/templates/authTests/oidc_federation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import zapier from 'zapier-platform-core';
+
+import App from '../index.js';
+const appTester = zapier.createAppTester(App);
+
+describe('oidc federation auth app', () => {
+  it('fetches federation credentials via perform', async () => {
+    const bundle = {
+      authData: {
+        region: 'us-east-1',
+        roleArn: 'arn:aws:iam::123456789012:role/example',
+        sessionName: 'zapier',
+      },
+    };
+
+    const newAuthData = await appTester(
+      App.authentication.oidcFederationConfig.perform,
+      bundle,
+    );
+
+    expect(newAuthData.accessKeyId).toBe('AKIAEXAMPLE');
+    expect(newAuthData.secretAccessKey).toBe(
+      'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    );
+    expect(newAuthData.sessionToken).toBe('EXAMPLE_SESSION_TOKEN');
+  });
+
+  it('can make an authenticated test request', async () => {
+    const bundle = {
+      authData: {
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        sessionToken: 'EXAMPLE_SESSION_TOKEN',
+      },
+    };
+
+    const response = await appTester(App.authentication.test, bundle);
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/packages/cli/src/oclif/commands/describe.js
+++ b/packages/cli/src/oclif/commands/describe.js
@@ -15,6 +15,7 @@ const authenticationPaths = [
   'authentication.oauth2Config.getAccessToken',
   'authentication.oauth2Config.refreshAccessToken',
   'authentication.sessionConfig.perform',
+  'authentication.oidcFederationConfig.perform',
 ];
 
 // {type:triggers}.{key:lead}.operation.perform

--- a/packages/cli/src/utils/auth-files-codegen.js
+++ b/packages/cli/src/utils/auth-files-codegen.js
@@ -595,6 +595,78 @@ const sessionFiles = (language) => {
   };
 };
 
+const oidcFederationAuthFile = (language) => {
+  const getFederationCredentialsFuncName = 'getFederationCredentials';
+  const fileInput = [
+    authTestFunc(language),
+    tokenExchangeFunc(
+      getFederationCredentialsFuncName,
+      language,
+      'https://httpbin.zapier-tooling.com/post',
+      [
+        objProperty('region', 'bundle.authData.region '),
+        objProperty('roleArn', 'bundle.authData.roleArn '),
+        objProperty('sessionName', 'bundle.authData.sessionName '),
+      ],
+      [
+        comment(
+          'FIXME: The fallback values below are just for demo purposes, you should remove them.',
+        ),
+        objProperty(
+          'accessKeyId',
+          'response.data.accessKeyId || "AKIAEXAMPLE"',
+        ),
+        objProperty(
+          'secretAccessKey',
+          'response.data.secretAccessKey || "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"',
+        ),
+        objProperty(
+          'sessionToken',
+          'response.data.sessionToken || "EXAMPLE_SESSION_TOKEN"',
+        ),
+      ],
+    ),
+    authFileExport(
+      language,
+      'oidcFederation',
+      '"oidcFederation" auth uses perform to fetch OIDC federation credentials.',
+      {
+        extraConfigProps: [
+          objProperty(
+            'oidcFederationConfig',
+            obj(
+              objProperty('perform', getFederationCredentialsFuncName),
+              objProperty('audience', strLiteral('audience.example')),
+            ),
+          ),
+        ],
+      },
+    ),
+  ];
+  return language === 'typescript'
+    ? fileTS(standardTypes, ...fileInput)
+    : file(...fileInput);
+};
+
+const oidcFederationMiddlewareFile = (language) => {
+  const fileInput = [
+    ...middlewareFileExport(language, {
+      beforeFuncNames: [],
+      afterFuncNames: [],
+    }),
+  ];
+  return language === 'typescript'
+    ? fileTS(standardTypes, ...fileInput)
+    : file(...fileInput);
+};
+
+const oidcFederationFiles = (language) => {
+  return {
+    middleware: oidcFederationMiddlewareFile(language),
+    authentication: oidcFederationAuthFile(language),
+  };
+};
+
 // just different enough from oauth2 that it gets its own function
 const oauth1TokenExchangeFunc = (
   funcName,
@@ -755,4 +827,5 @@ module.exports = {
   oauth1: oauth1Files,
   oauth2: oauth2Files,
   session: sessionFiles,
+  oidcFederation: oidcFederationFiles,
 };

--- a/packages/core/src/auth-template/get-auth-template.js
+++ b/packages/core/src/auth-template/get-auth-template.js
@@ -122,6 +122,24 @@ const SESSION_AUTH_COMMON_KEYS = [
   'token',
 ];
 
+// Credential keys that oidcFederation perform may return without declaring
+// them in authentication.fields (AWS STS, GCP/Azure token exchange, Vault).
+const OIDC_FEDERATION_COMMON_KEYS = [
+  // AWS STS
+  'accessKeyId',
+  'secretAccessKey',
+  'sessionToken',
+  // GCP / Azure OAuth-style
+  'access_token',
+  'token_type',
+  'expires_in',
+  'expires_on',
+  'token',
+  // Vault
+  'client_token',
+  'accessor',
+];
+
 // Build placeholder authData where each value is an opaque sentinel
 // string. Sentinels survive core's normalize/curly-stripping and any
 // stringification middleware does, so the captured request still
@@ -173,6 +191,12 @@ const buildPlaceholderAuthData = (auth) => {
   // template.
   if (auth.type === 'session') {
     for (const key of SESSION_AUTH_COMMON_KEYS) {
+      authData[key] = authData[key] || wrapAuthSentinel(key);
+    }
+  }
+
+  if (auth.type === 'oidcFederation') {
+    for (const key of OIDC_FEDERATION_COMMON_KEYS) {
       authData[key] = authData[key] || wrapAuthSentinel(key);
     }
   }

--- a/packages/core/src/tools/create-app-request-client.js
+++ b/packages/core/src/tools/create-app-request-client.js
@@ -59,6 +59,7 @@ const createAppRequestClient = (input, options) => {
   if (
     app.authentication &&
     (app.authentication.type === 'session' ||
+      app.authentication.type === 'oidcFederation' ||
       (app.authentication.type === 'oauth2' &&
         _.get(app, 'authentication.oauth2Config.autoRefresh')))
   ) {

--- a/packages/core/src/tools/create-logger.js
+++ b/packages/core/src/tools/create-logger.js
@@ -135,6 +135,7 @@ const buildSensitiveValues = (event, data) => {
     event.method &&
     (event.method.endsWith('refreshAccessToken') ||
       event.method.endsWith('sessionConfig.perform') ||
+      event.method.endsWith('oidcFederationConfig.perform') ||
       event.method.endsWith('oauth1Config.getAccessToken'));
 
   for (const prop of ['response_content', 'request_data']) {

--- a/packages/core/test/auth-template/get-auth-template.js
+++ b/packages/core/test/auth-template/get-auth-template.js
@@ -900,6 +900,59 @@ describe('getAuthTemplate', () => {
         '{{bundle.authData.PHPSESSID}}',
       );
     });
+
+    it('oidcFederation gets standard credential placeholders for common key names', async () => {
+      const beforeRequest = (req, z, bundle) => {
+        req.headers = req.headers || {};
+        req.headers['X-Access-Key-Id'] = bundle.authData.accessKeyId;
+        req.headers['X-Secret-Access-Key'] = bundle.authData.secretAccessKey;
+        req.headers['X-Session-Token'] = bundle.authData.sessionToken;
+        req.headers['X-Access-Token'] = bundle.authData.access_token;
+        req.headers['X-Token-Type'] = bundle.authData.token_type;
+        req.headers['X-Expires-In'] = bundle.authData.expires_in;
+        req.headers['X-Expires-On'] = bundle.authData.expires_on;
+        req.headers['X-Token'] = bundle.authData.token;
+        req.headers['X-Client-Token'] = bundle.authData.client_token;
+        req.headers['X-Accessor'] = bundle.authData.accessor;
+        return req;
+      };
+      const result = await run({
+        authentication: { type: 'oidcFederation', test: STUB_TEST },
+        beforeRequest: [beforeRequest],
+      });
+      result.supported.should.be.true();
+      result.source.should.eql('authentication.test');
+      result.template.headers['X-Access-Key-Id'].should.eql(
+        '{{bundle.authData.accessKeyId}}',
+      );
+      result.template.headers['X-Secret-Access-Key'].should.eql(
+        '{{bundle.authData.secretAccessKey}}',
+      );
+      result.template.headers['X-Session-Token'].should.eql(
+        '{{bundle.authData.sessionToken}}',
+      );
+      result.template.headers['X-Access-Token'].should.eql(
+        '{{bundle.authData.access_token}}',
+      );
+      result.template.headers['X-Token-Type'].should.eql(
+        '{{bundle.authData.token_type}}',
+      );
+      result.template.headers['X-Expires-In'].should.eql(
+        '{{bundle.authData.expires_in}}',
+      );
+      result.template.headers['X-Expires-On'].should.eql(
+        '{{bundle.authData.expires_on}}',
+      );
+      result.template.headers['X-Token'].should.eql(
+        '{{bundle.authData.token}}',
+      );
+      result.template.headers['X-Client-Token'].should.eql(
+        '{{bundle.authData.client_token}}',
+      );
+      result.template.headers['X-Accessor'].should.eql(
+        '{{bundle.authData.accessor}}',
+      );
+    });
   });
 
   describe('regression: addQueryParams should not see urlProbe behavior', () => {

--- a/packages/core/test/create-app.js
+++ b/packages/core/test/create-app.js
@@ -469,6 +469,22 @@ describe('create-app', () => {
       );
     });
 
+    it('should be applied to oidc federation auth app on z.request in functions', () => {
+      return testResponse(
+        {
+          ...appDefinition,
+          authentication: {
+            type: 'oidcFederation',
+            oidcFederationConfig: {
+              audience: 'audience.example',
+            },
+          },
+        },
+        false,
+        verifyRefreshAuthError,
+      );
+    });
+
     it('should not be applied to custom auth app on z.request in functions', () => {
       return testResponse(
         {

--- a/packages/core/types/schemas.generated.d.ts
+++ b/packages/core/types/schemas.generated.d.ts
@@ -145,7 +145,14 @@ export type Middlewares = Function[] | Function;
 /** Represents authentication schemes. */
 export interface Authentication {
   /** Choose which scheme you want to use. */
-  type: 'basic' | 'custom' | 'digest' | 'oauth1' | 'oauth2' | 'session';
+  type:
+    | 'basic'
+    | 'custom'
+    | 'digest'
+    | 'oauth1'
+    | 'oauth2'
+    | 'session'
+    | 'oidcFederation';
 
   /**
    * A function or request that confirms the authentication is
@@ -176,6 +183,8 @@ export interface Authentication {
   oauth2Config?: AuthenticationOAuth2Config;
 
   sessionConfig?: AuthenticationSessionConfig;
+
+  oidcFederationConfig?: AuthenticationOIDCFederationConfig;
 }
 
 /**
@@ -486,6 +495,18 @@ export interface AuthenticationSessionConfig {
    * API calls.
    */
   perform: Request | Function;
+}
+
+/** Config for OIDC federation authentication. */
+export interface AuthenticationOIDCFederationConfig {
+  /**
+   * Define how Zapier fetches the additional authData needed to make
+   * API calls.
+   */
+  perform: Request | Function;
+
+  /** The service the OIDC token is generated for. */
+  audience: string;
 }
 
 /** An object whose values can only be primitives */

--- a/packages/schema/docs/build/schema.md
+++ b/packages/schema/docs/build/schema.md
@@ -25,6 +25,7 @@ Alternatively, modify the URL directly: https://github.com/zapier/zapier-platfor
 * [/AuthenticationDigestConfigSchema](#authenticationdigestconfigschema)
 * [/AuthenticationOAuth1ConfigSchema](#authenticationoauth1configschema)
 * [/AuthenticationOAuth2ConfigSchema](#authenticationoauth2configschema)
+* [/AuthenticationOIDCFederationConfigSchema](#authenticationoidcfederationconfigschema)
 * [/AuthenticationSchema](#authenticationschema)
 * [/AuthenticationSessionConfigSchema](#authenticationsessionconfigschema)
 * [/BasicActionOperationSchema](#basicactionoperationschema)
@@ -415,6 +416,33 @@ Key | Required | Type | Description
 
 -----
 
+## /AuthenticationOIDCFederationConfigSchema
+
+Config for OIDC federation authentication.
+
+#### Details
+
+* **Type** - `object`
+* [**Source Code**](https://github.com/zapier/zapier-platform/blob/zapier-platform-schema@19.0.0/packages/schema/lib/schemas/AuthenticationOIDCFederationConfigSchema.js)
+
+#### Properties
+
+Key | Required | Type | Description
+--- | -------- | ---- | -----------
+`perform` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | Define how Zapier fetches the additional authData needed to make API calls.
+`audience` | **yes** | `string` | The service the OIDC token is generated for.
+
+#### Examples
+
+* `{ perform: { require: 'some/path/to/file.js' }, audience: 'sts.amazonaws.com' }`
+
+#### Anti-Examples
+
+* `{}` - _Missing required key: perform and audience_
+* `{ perform: { require: 'some/path/to/file.js' } }` - _Missing required key: audience_
+
+-----
+
 ## /AuthenticationSchema
 
 Represents authentication schemes.
@@ -428,7 +456,7 @@ Represents authentication schemes.
 
 Key | Required | Type | Description
 --- | -------- | ---- | -----------
-`type` | **yes** | `string` in (`'basic'`, `'custom'`, `'digest'`, `'oauth1'`, `'oauth2'`, `'session'`) | Choose which scheme you want to use.
+`type` | **yes** | `string` in (`'basic'`, `'custom'`, `'digest'`, `'oauth1'`, `'oauth2'`, `'session'`, `'oidcFederation'`) | Choose which scheme you want to use.
 `test` | **yes** | oneOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema)) | A function or request that confirms the authentication is working.
 `fields` | no | [/AuthFieldsSchema](#authfieldsschema) | Fields you can request from the user before they connect your app to Zapier.
 `connectionLabel` | no | anyOf([/RequestSchema](#requestschema), [/FunctionSchema](#functionschema), `string`) | A string with variables, function, or request that returns the connection label for the authenticated user.
@@ -438,6 +466,7 @@ Key | Required | Type | Description
 `oauth1Config` | no | [/AuthenticationOAuth1ConfigSchema](#authenticationoauth1configschema) | _No description given._
 `oauth2Config` | no | [/AuthenticationOAuth2ConfigSchema](#authenticationoauth2configschema) | _No description given._
 `sessionConfig` | no | [/AuthenticationSessionConfigSchema](#authenticationsessionconfigschema) | _No description given._
+`oidcFederationConfig` | no | [/AuthenticationOIDCFederationConfigSchema](#authenticationoidcfederationconfigschema) | _No description given._
 
 #### Examples
 

--- a/packages/schema/exported-schema.json
+++ b/packages/schema/exported-schema.json
@@ -648,6 +648,30 @@
       },
       "additionalProperties": false
     },
+    "AuthenticationOIDCFederationConfigSchema": {
+      "id": "/AuthenticationOIDCFederationConfigSchema",
+      "description": "Config for OIDC federation authentication.",
+      "type": "object",
+      "required": ["perform", "audience"],
+      "properties": {
+        "perform": {
+          "description": "Define how Zapier fetches the additional authData needed to make API calls.",
+          "oneOf": [
+            {
+              "$ref": "/RequestSchema"
+            },
+            {
+              "$ref": "/FunctionSchema"
+            }
+          ]
+        },
+        "audience": {
+          "description": "The service the OIDC token is generated for.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "RefResourceSchema": {
       "id": "/RefResourceSchema",
       "description": "Reference a resource by key and the data it returns. In the format of: `{resource_key}.{foreign_key}(.{human_label_key})`.",
@@ -2037,7 +2061,15 @@
         "type": {
           "description": "Choose which scheme you want to use.",
           "type": "string",
-          "enum": ["basic", "custom", "digest", "oauth1", "oauth2", "session"]
+          "enum": [
+            "basic",
+            "custom",
+            "digest",
+            "oauth1",
+            "oauth2",
+            "session",
+            "oidcFederation"
+          ]
         },
         "test": {
           "description": "A function or request that confirms the authentication is working.",
@@ -2085,6 +2117,9 @@
         },
         "sessionConfig": {
           "$ref": "/AuthenticationSessionConfigSchema"
+        },
+        "oidcFederationConfig": {
+          "$ref": "/AuthenticationOIDCFederationConfigSchema"
         }
       },
       "additionalProperties": false

--- a/packages/schema/lib/schemas/AuthenticationOIDCFederationConfigSchema.js
+++ b/packages/schema/lib/schemas/AuthenticationOIDCFederationConfigSchema.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const makeSchema = require('../utils/makeSchema');
+
+const RequestSchema = require('./RequestSchema');
+const FunctionSchema = require('./FunctionSchema');
+
+module.exports = makeSchema(
+  {
+    id: '/AuthenticationOIDCFederationConfigSchema',
+    description: 'Config for OIDC federation authentication.',
+    type: 'object',
+    required: ['perform', 'audience'],
+    properties: {
+      perform: {
+        description:
+          'Define how Zapier fetches the additional authData needed to make API calls.',
+        oneOf: [{ $ref: RequestSchema.id }, { $ref: FunctionSchema.id }],
+      },
+      audience: {
+        description: 'The service the OIDC token is generated for.',
+        type: 'string',
+      },
+    },
+    additionalProperties: false,
+    examples: [
+      {
+        perform: { require: 'some/path/to/file.js' },
+        audience: 'sts.amazonaws.com',
+      },
+    ],
+    antiExamples: [
+      {
+        example: {},
+        reason: 'Missing required key: perform and audience',
+      },
+      {
+        example: {
+          perform: { require: 'some/path/to/file.js' },
+        },
+        reason: 'Missing required key: audience',
+      },
+    ],
+  },
+  [FunctionSchema, RequestSchema],
+);

--- a/packages/schema/lib/schemas/AuthenticationSchema.js
+++ b/packages/schema/lib/schemas/AuthenticationSchema.js
@@ -8,6 +8,7 @@ const AuthenticationDigestConfigSchema = require('./AuthenticationDigestConfigSc
 const AuthenticationOAuth1ConfigSchema = require('./AuthenticationOAuth1ConfigSchema.js');
 const AuthenticationOAuth2ConfigSchema = require('./AuthenticationOAuth2ConfigSchema.js');
 const AuthenticationSessionConfigSchema = require('./AuthenticationSessionConfigSchema.js');
+const AuthenticationOIDCFederationConfigSchema = require('./AuthenticationOIDCFederationConfigSchema.js');
 const FunctionSchema = require('./FunctionSchema');
 const RequestSchema = require('./RequestSchema');
 const AuthFieldsSchema = require('./AuthFieldsSchema');
@@ -22,7 +23,15 @@ module.exports = makeSchema(
       type: {
         description: 'Choose which scheme you want to use.',
         type: 'string',
-        enum: ['basic', 'custom', 'digest', 'oauth1', 'oauth2', 'session'],
+        enum: [
+          'basic',
+          'custom',
+          'digest',
+          'oauth1',
+          'oauth2',
+          'session',
+          'oidcFederation',
+        ],
       },
       test: {
         description:
@@ -50,6 +59,9 @@ module.exports = makeSchema(
       oauth1Config: { $ref: AuthenticationOAuth1ConfigSchema.id },
       oauth2Config: { $ref: AuthenticationOAuth2ConfigSchema.id },
       sessionConfig: { $ref: AuthenticationSessionConfigSchema.id },
+      oidcFederationConfig: {
+        $ref: AuthenticationOIDCFederationConfigSchema.id,
+      },
     },
     additionalProperties: false,
     examples: [
@@ -114,5 +126,6 @@ module.exports = makeSchema(
     AuthenticationOAuth1ConfigSchema,
     AuthenticationOAuth2ConfigSchema,
     AuthenticationSessionConfigSchema,
+    AuthenticationOIDCFederationConfigSchema,
   ],
 );

--- a/packages/schema/test/index.js
+++ b/packages/schema/test/index.js
@@ -9,7 +9,7 @@ const appDefinition = require('../examples/definition.json');
 
 const copy = (o) => JSON.parse(JSON.stringify(o));
 
-const NUM_SCHEMAS = 65; // changes regularly as we expand
+const NUM_SCHEMAS = 66; // changes regularly as we expand
 
 describe('app', () => {
   describe('validation', () => {


### PR DESCRIPTION
## What

Adds `oidcFederation` as a new authentication type for Zapier integrations that use OIDC token exchange to obtain cloud provider credentials (e.g. AWS STS, GCP, Azure, Vault).

## Changes

**schema**
- New `AuthenticationOIDCFederationConfigSchema` with required `perform` and `audience` fields
- Added `oidcFederation` to the `type` enum and `oidcFederationConfig` property in `AuthenticationSchema`
- Regenerated `exported-schema.json`, `schema.md`, and TypeScript types

**core**
- `get-auth-template.js`: builds placeholder `authData` sentinels for common OIDC credential keys (AWS STS, GCP/Azure, Vault) so request templates resolve correctly during testing
- `create-app-request-client.js`: enables auto-refresh for `oidcFederation` auth the same way `session` auth does

**cli**
- `auth-files-codegen.js`: generates `authentication.js`/`.ts` and `middleware.js`/`.ts` scaffolding for `oidcFederation` integrations via `zapier init`
- `generators/index.js`: registers the new auth type in the generator
- `describe.js`: includes `authentication.oidcFederationConfig.perform` in described paths

**Note:** `zapier invoke` is not supported for `oidcFederation` — the auth type relies on a token injected by Zapier infrastructure that isn't available in local invocation.

## Testing

- Added unit tests in `packages/core/test/auth-template/get-auth-template.js` and `packages/core/test/create-app.js`
- Added generated test templates `oidc_federation.test.js` / `.ts`
- Schema validated via `packages/schema/test/index.js`


Note: A previous [PR](https://github.com/zapier/zapier-platform/pull/1303) was created for this work due to insufficient permissions at the time.