### PR TITLE
Bump form-data to 4.0.6 in core

### DIFF
--- a/example-apps/files/package.json
+++ b/example-apps/files/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "zapier-platform-core": "19.0.0",
-    "form-data": "4.0.0"
+    "form-data": "4.0.6"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "content-disposition": "0.5.4",
     "dotenv": "17.2.1",
     "fernet": "^0.3.3",
-    "form-data": "4.0.5",
+    "form-data": "4.0.6",
     "json-schema-to-ts": "3.1.1",
     "lodash": "4.18.1",
     "mime-types": "3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         specifier: ^0.3.3
         version: 0.3.3
       form-data:
-        specifier: 4.0.5
-        version: 4.0.5
+        specifier: 4.0.6
+        version: 4.0.6
       json-schema-to-ts:
         specifier: 3.1.1
         version: 3.1.1
@@ -3444,8 +3444,8 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   fs-extra@11.3.1:
@@ -3694,6 +3694,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -6149,11 +6153,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -8544,7 +8549,7 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 20.19.25
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/node@16.18.126': {}
 
@@ -9653,7 +9658,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -10176,12 +10181,12 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   fs-extra@11.3.1:
@@ -10453,6 +10458,10 @@ snapshots:
       to-buffer: 1.2.2
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 


### PR DESCRIPTION
## What

Upgrades `form-data` to `4.0.6`:
- `packages/core` (the published SDK): `4.0.5` → `4.0.6`
- `example-apps/files`: `4.0.0` → `4.0.6`

## Why

form-data 4.0.6 patches a `Content-Disposition` header injection vulnerability (CWE-93): field names and filenames containing CR/LF or quote characters were written verbatim into the multipart headers, which could be used to inject additional headers or smuggle multipart parts. 4.0.6 percent-encodes those characters (`%0D`, `%0A`, `%22`), matching browser behavior.

## Why a new PR

There were already automated (Renovate) PRs open for this bump, but their CI was failing — so I opened this one instead. On my side I've already worked around the advisory with an override in my main repo, but it'd be better to fix it upstream without an override.

## Notes

- Patch-level bump for core; same `node >= 6` engine constraint and dependency shape.
- `packages/core` lockfile regenerated with the repo-pinned pnpm `10.26.2`. The only incidental changes are in-range transitive refreshes (`hasown` 2.0.2 → 2.0.4) and npm-side deprecation-message metadata.
- `example-apps/files` isn't part of the pnpm workspace and has no lockfile, so it's a package.json-only change.
- `legacy-scripting-runner` is intentionally on the 2.x line and is left untouched.