### PR TITLE
[PDE-7283] feat(core): support customRequestProperties in renderAuthTemplate bundle

### DIFF
--- a/packages/core/src/auth-template/render-auth-template.js
+++ b/packages/core/src/auth-template/render-auth-template.js
@@ -228,13 +228,16 @@ const renderAuthTemplate = async (compiledApp, input) => {
 
   const target = bundle.targetRequest || {};
   try {
+    // customRequestProperties is spread first so the explicit HTTP fields
+    // below always win — registry-supplied flags must never clobber the
+    // request being signed.
     await client({
+      ...bundle.customRequestProperties,
       url: target.url || 'https://example.com',
       method: target.method || 'GET',
       headers: target.headers || {},
       params: target.params || {},
       body: target.body,
-      ...bundle.customRequestProperties,
       merge: true,
       [REPLACE_CURLIES]: true,
     });

--- a/packages/core/src/auth-template/render-auth-template.js
+++ b/packages/core/src/auth-template/render-auth-template.js
@@ -108,6 +108,12 @@ const renderAuthTemplate = async (compiledApp, input) => {
   // auth (AWS SigV4, OAuth1, HMAC) needs the real url/method/body to compute
   // a valid signature; absent it, the middleware runs against a stub and
   // produces a signature for the wrong request.
+  //
+  // customRequestProperties carries integration-internal middleware flags
+  // (e.g. Slack's `withUserToken: true`) that control which credential the
+  // integration's beforeRequest injects. They are spread onto the synthetic
+  // request below — kept separate from targetRequest because they are not
+  // HTTP fields and must not participate in signature computation.
   const bundle = {
     authData: eventBundle.authData || {},
     inputData: eventBundle.inputData || {},
@@ -115,6 +121,7 @@ const renderAuthTemplate = async (compiledApp, input) => {
     subscribeData: eventBundle.subscribeData || {},
     targetUrl: eventBundle.targetUrl || '',
     targetRequest: eventBundle.targetRequest || null,
+    customRequestProperties: eventBundle.customRequestProperties || {},
   };
 
   // Rebuild input with the fully-populated bundle so prepareRequest
@@ -227,6 +234,7 @@ const renderAuthTemplate = async (compiledApp, input) => {
       headers: target.headers || {},
       params: target.params || {},
       body: target.body,
+      ...bundle.customRequestProperties,
       merge: true,
       [REPLACE_CURLIES]: true,
     });

--- a/packages/core/src/auth-template/render-auth-template.js
+++ b/packages/core/src/auth-template/render-auth-template.js
@@ -110,7 +110,7 @@ const renderAuthTemplate = async (compiledApp, input) => {
   // produces a signature for the wrong request.
   //
   // customRequestProperties carries integration-internal middleware flags
-  // (e.g. Slack's `withUserToken: true`) that control which credential the
+  // (e.g. `withUserToken: true`) that control which credential the
   // integration's beforeRequest injects. They are spread onto the synthetic
   // request below — kept separate from targetRequest because they are not
   // HTTP fields and must not participate in signature computation.

--- a/packages/core/test/auth-template/render-auth-template.js
+++ b/packages/core/test/auth-template/render-auth-template.js
@@ -226,6 +226,92 @@ describe('renderAuthTemplate', () => {
     });
   });
 
+  describe('customRequestProperties', () => {
+    // Slack-shaped middleware: defaults to bot_token, switches to
+    // access_token when the request carries `withUserToken: true`.
+    const slackShapedMiddleware = (req, z, bundle) => {
+      if (req.withManualToken) {
+        return req;
+      }
+      if (bundle.authData.bot_token) {
+        req.headers.Authorization = `Bearer ${bundle.authData.bot_token}`;
+      }
+      if (req.withUserToken) {
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+      }
+      return req;
+    };
+
+    const slackShapedApp = {
+      authentication: {
+        type: 'oauth2',
+        test: { url: 'https://example.com' },
+      },
+      beforeRequest: [slackShapedMiddleware],
+    };
+
+    const slackShapedAuthData = {
+      bot_token: 'xoxb-bot-token',
+      access_token: 'xoxp-user-token',
+    };
+
+    it('spreads custom properties onto the synthetic request', async () => {
+      const result = await run(slackShapedApp, slackShapedAuthData, {
+        customRequestProperties: { withUserToken: true },
+      });
+      result.template.headers.Authorization.should.eql(
+        'Bearer xoxp-user-token',
+      );
+    });
+
+    it('takes the middleware default path when absent', async () => {
+      const result = await run(slackShapedApp, slackShapedAuthData);
+      result.template.headers.Authorization.should.eql('Bearer xoxb-bot-token');
+    });
+
+    it('takes the middleware default path when empty', async () => {
+      const result = await run(slackShapedApp, slackShapedAuthData, {
+        customRequestProperties: {},
+      });
+      result.template.headers.Authorization.should.eql('Bearer xoxb-bot-token');
+    });
+
+    it('supports skip-style flags that suppress auth injection', async () => {
+      const result = await run(slackShapedApp, slackShapedAuthData, {
+        customRequestProperties: { withManualToken: true },
+      });
+      (result.template.headers === undefined ||
+        result.template.headers.Authorization === undefined).should.be.true();
+    });
+
+    it('combines with targetRequest without clobbering HTTP fields', async () => {
+      let observed = null;
+      const observingMiddleware = (req, z, bundle) => {
+        observed = { url: req.url, method: req.method };
+        return slackShapedMiddleware(req, z, bundle);
+      };
+      const result = await run(
+        {
+          ...slackShapedApp,
+          beforeRequest: [observingMiddleware],
+        },
+        slackShapedAuthData,
+        {
+          targetRequest: {
+            url: 'https://slack.com/api/chat.postMessage',
+            method: 'POST',
+          },
+          customRequestProperties: { withUserToken: true },
+        },
+      );
+      observed.url.should.eql('https://slack.com/api/chat.postMessage');
+      observed.method.should.eql('POST');
+      result.template.headers.Authorization.should.eql(
+        'Bearer xoxp-user-token',
+      );
+    });
+  });
+
   describe('auth-type-specific middleware', () => {
     it('basic auth applies the addBasicAuthHeader middleware', async () => {
       const result = await run(

--- a/packages/core/test/auth-template/render-auth-template.js
+++ b/packages/core/test/auth-template/render-auth-template.js
@@ -284,6 +284,37 @@ describe('renderAuthTemplate', () => {
         result.template.headers.Authorization === undefined).should.be.true();
     });
 
+    it('cannot clobber HTTP fields of the target request', async () => {
+      let observed = null;
+      const observingMiddleware = (req, z, bundle) => {
+        observed = { url: req.url, method: req.method };
+        return slackShapedMiddleware(req, z, bundle);
+      };
+      const result = await run(
+        {
+          ...slackShapedApp,
+          beforeRequest: [observingMiddleware],
+        },
+        slackShapedAuthData,
+        {
+          targetRequest: {
+            url: 'https://slack.com/api/chat.postMessage',
+            method: 'POST',
+          },
+          customRequestProperties: {
+            withUserToken: true,
+            url: 'https://evil.example.com',
+            method: 'DELETE',
+          },
+        },
+      );
+      observed.url.should.eql('https://slack.com/api/chat.postMessage');
+      observed.method.should.eql('POST');
+      result.template.headers.Authorization.should.eql(
+        'Bearer xoxp-user-token',
+      );
+    });
+
     it('combines with targetRequest without clobbering HTTP fields', async () => {
       let observed = null;
       const observingMiddleware = (req, z, bundle) => {

--- a/packages/core/test/auth-template/render-auth-template.js
+++ b/packages/core/test/auth-template/render-auth-template.js
@@ -227,14 +227,15 @@ describe('renderAuthTemplate', () => {
   });
 
   describe('customRequestProperties', () => {
-    // Slack-shaped middleware: defaults to bot_token, switches to
-    // access_token when the request carries `withUserToken: true`.
-    const slackShapedMiddleware = (req, z, bundle) => {
+    // Middleware that selects between credentials based on custom request
+    // properties: defaults to service_token, switches to access_token when
+    // the request carries `withUserToken: true`.
+    const credentialSwitchingMiddleware = (req, z, bundle) => {
       if (req.withManualToken) {
         return req;
       }
-      if (bundle.authData.bot_token) {
-        req.headers.Authorization = `Bearer ${bundle.authData.bot_token}`;
+      if (bundle.authData.service_token) {
+        req.headers.Authorization = `Bearer ${bundle.authData.service_token}`;
       }
       if (req.withUserToken) {
         req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
@@ -242,44 +243,57 @@ describe('renderAuthTemplate', () => {
       return req;
     };
 
-    const slackShapedApp = {
+    const credentialSwitchingApp = {
       authentication: {
         type: 'oauth2',
         test: { url: 'https://example.com' },
       },
-      beforeRequest: [slackShapedMiddleware],
+      beforeRequest: [credentialSwitchingMiddleware],
     };
 
-    const slackShapedAuthData = {
-      bot_token: 'xoxb-bot-token',
-      access_token: 'xoxp-user-token',
+    const multiCredentialAuthData = {
+      service_token: 'service-token',
+      access_token: 'user-token',
     };
 
     it('spreads custom properties onto the synthetic request', async () => {
-      const result = await run(slackShapedApp, slackShapedAuthData, {
-        customRequestProperties: { withUserToken: true },
-      });
-      result.template.headers.Authorization.should.eql(
-        'Bearer xoxp-user-token',
+      const result = await run(
+        credentialSwitchingApp,
+        multiCredentialAuthData,
+        {
+          customRequestProperties: { withUserToken: true },
+        },
       );
+      result.template.headers.Authorization.should.eql('Bearer user-token');
     });
 
     it('takes the middleware default path when absent', async () => {
-      const result = await run(slackShapedApp, slackShapedAuthData);
-      result.template.headers.Authorization.should.eql('Bearer xoxb-bot-token');
+      const result = await run(
+        credentialSwitchingApp,
+        multiCredentialAuthData,
+      );
+      result.template.headers.Authorization.should.eql('Bearer service-token');
     });
 
     it('takes the middleware default path when empty', async () => {
-      const result = await run(slackShapedApp, slackShapedAuthData, {
-        customRequestProperties: {},
-      });
-      result.template.headers.Authorization.should.eql('Bearer xoxb-bot-token');
+      const result = await run(
+        credentialSwitchingApp,
+        multiCredentialAuthData,
+        {
+          customRequestProperties: {},
+        },
+      );
+      result.template.headers.Authorization.should.eql('Bearer service-token');
     });
 
     it('supports skip-style flags that suppress auth injection', async () => {
-      const result = await run(slackShapedApp, slackShapedAuthData, {
-        customRequestProperties: { withManualToken: true },
-      });
+      const result = await run(
+        credentialSwitchingApp,
+        multiCredentialAuthData,
+        {
+          customRequestProperties: { withManualToken: true },
+        },
+      );
       (result.template.headers === undefined ||
         result.template.headers.Authorization === undefined).should.be.true();
     });
@@ -288,58 +302,54 @@ describe('renderAuthTemplate', () => {
       let observed = null;
       const observingMiddleware = (req, z, bundle) => {
         observed = { url: req.url, method: req.method };
-        return slackShapedMiddleware(req, z, bundle);
+        return credentialSwitchingMiddleware(req, z, bundle);
       };
       const result = await run(
         {
-          ...slackShapedApp,
+          ...credentialSwitchingApp,
           beforeRequest: [observingMiddleware],
         },
-        slackShapedAuthData,
+        multiCredentialAuthData,
         {
           targetRequest: {
-            url: 'https://slack.com/api/chat.postMessage',
+            url: 'https://api.example.com/messages',
             method: 'POST',
           },
           customRequestProperties: {
             withUserToken: true,
-            url: 'https://evil.example.com',
+            url: 'https://attacker.example.com',
             method: 'DELETE',
           },
         },
       );
-      observed.url.should.eql('https://slack.com/api/chat.postMessage');
+      observed.url.should.eql('https://api.example.com/messages');
       observed.method.should.eql('POST');
-      result.template.headers.Authorization.should.eql(
-        'Bearer xoxp-user-token',
-      );
+      result.template.headers.Authorization.should.eql('Bearer user-token');
     });
 
     it('combines with targetRequest without clobbering HTTP fields', async () => {
       let observed = null;
       const observingMiddleware = (req, z, bundle) => {
         observed = { url: req.url, method: req.method };
-        return slackShapedMiddleware(req, z, bundle);
+        return credentialSwitchingMiddleware(req, z, bundle);
       };
       const result = await run(
         {
-          ...slackShapedApp,
+          ...credentialSwitchingApp,
           beforeRequest: [observingMiddleware],
         },
-        slackShapedAuthData,
+        multiCredentialAuthData,
         {
           targetRequest: {
-            url: 'https://slack.com/api/chat.postMessage',
+            url: 'https://api.example.com/messages',
             method: 'POST',
           },
           customRequestProperties: { withUserToken: true },
         },
       );
-      observed.url.should.eql('https://slack.com/api/chat.postMessage');
+      observed.url.should.eql('https://api.example.com/messages');
       observed.method.should.eql('POST');
-      result.template.headers.Authorization.should.eql(
-        'Bearer xoxp-user-token',
-      );
+      result.template.headers.Authorization.should.eql('Bearer user-token');
     });
   });
 


### PR DESCRIPTION
## What

Adds `bundle.customRequestProperties` to the `renderAuthTemplate` command and spreads it onto the synthetic request before the middleware pipeline runs.

## Why

Some integrations use custom (non-HTTP) request properties to control which stored credential their `beforeRequest` middleware injects — e.g. a middleware that defaults to a service token and only selects the user token when the request carries `withUserToken: true`. Callers of `renderAuthTemplate` need a way to request the non-default credential, so these flags must travel through the bundle onto the synthetic request the middleware runs against.

## Notes

- The spread sits **before** the explicit HTTP fields (`url`, `method`, `headers`, `params`, `body`), so custom properties can never override the request being rendered.
- Kept separate from `targetRequest` because these flags are not HTTP fields and must not participate in signature computation.

## Testing

New test cases in `test/auth-template/render-auth-template.js`: credential-switching middleware selecting the alternate token when the flag is present, the middleware default path when the field is absent or empty, skip-style flags that suppress auth injection, combination with `targetRequest`, and a guard proving custom properties cannot clobber the target request's HTTP fields.
