### PR TITLE
fix(core): drop non-auth bodies from the auth template

### DIFF
--- a/packages/core/src/auth-template/get-auth-template.js
+++ b/packages/core/src/auth-template/get-auth-template.js
@@ -293,12 +293,19 @@ const createUrlProbe = (baseUrl, matchAll) => {
 const extractTemplate = (req) => {
   const template = {};
 
+  // A body without placeholders is the auth test's own payload, not auth.
+  const body = req.body && hasAuthPlaceholders(req.body) ? req.body : null;
+
   if (req.headers) {
     const headers = { ...req.headers };
-    // Strip transport-level headers that shouldn't be in the auth template
+    // Transport headers aren't auth; content-type travels with the body.
     for (const key of Object.keys(headers)) {
       const lower = key.toLowerCase();
-      if (lower === 'content-length') {
+      if (
+        lower === 'content-length' ||
+        lower === 'user-agent' ||
+        (lower === 'content-type' && !body)
+      ) {
         delete headers[key];
       }
     }
@@ -338,8 +345,8 @@ const extractTemplate = (req) => {
     template.params = params;
   }
 
-  if (req.body) {
-    template.body = req.body;
+  if (body) {
+    template.body = body;
   }
 
   return template;

--- a/packages/core/test/auth-template/get-auth-template.js
+++ b/packages/core/test/auth-template/get-auth-template.js
@@ -938,4 +938,63 @@ describe('getAuthTemplate', () => {
       result.template.should.deepEqual({});
     });
   });
+
+  describe('body extraction', () => {
+    // Regression: Resend's auth test sends an email, and Relay was merging
+    // that payload into every proxied request.
+    it('excludes an auth-test body that carries no auth placeholder', async () => {
+      const result = await run({
+        authentication: {
+          type: 'custom',
+          fields: [{ key: 'api_key' }],
+          test: {
+            url: 'https://api.resend.com/emails',
+            method: 'POST',
+            headers: { Authorization: 'Bearer {{bundle.authData.api_key}}' },
+            body: {
+              from: 'zapier@resend.dev', // pii:allow
+              to: 'delivered@resend.dev', // pii:allow
+              subject: 'Zapier Auth Check',
+            },
+          },
+        },
+      });
+      result.supported.should.be.true();
+      result.template.should.deepEqual({
+        headers: { Authorization: 'Bearer {{bundle.authData.api_key}}' },
+      });
+    });
+
+    it('keeps an auth-test body that carries an auth placeholder', async () => {
+      const result = await run({
+        authentication: {
+          type: 'custom',
+          fields: [{ key: 'api_key' }],
+          test: {
+            url: 'https://api.example.com/login',
+            method: 'POST',
+            body: { apiKey: '{{bundle.authData.api_key}}', locale: 'en' },
+          },
+        },
+      });
+      result.supported.should.be.true();
+      result.template.body.should.match(/{{bundle\.authData\.api_key}}/);
+      result.template.headers['content-type'].should.match(/application\/json/);
+    });
+
+    it('strips transport headers the middleware added', async () => {
+      const result = await run({
+        authentication: {
+          type: 'custom',
+          fields: [{ key: 'api_key' }],
+          test: {
+            url: 'https://api.example.com/me',
+            headers: { Authorization: 'Bearer {{bundle.authData.api_key}}' },
+          },
+        },
+      });
+      result.template.headers.should.not.have.property('user-agent');
+      result.template.headers.should.not.have.property('content-length');
+    });
+  });
 });


### PR DESCRIPTION
## What

- `getAuthTemplate` now keeps a captured request body only when it carries an auth placeholder
- Strip more HTTP headers from template (`user-agent`, `content-length`)

## Why

Some integrations use a POST request for their auth test, but the POST body is unrelated to authentication. The POST payload was captured into the auth template, and was injected into every proxied request going forward.

## Testing

- 3 new cases in `test/auth-template/get-auth-template.js`. Extracting the request body had no coverage in the suite before this

## Notes

- Stacked on #1322 (which is also stacked on #1298). Those should be merged first and this will rebase to a single commit.