### PR TITLE
fix(core): Preserve z.request options in auth-template request stubs

### DIFF
--- a/packages/core/src/auth-template/get-auth-template.js
+++ b/packages/core/src/auth-template/get-auth-template.js
@@ -2,6 +2,7 @@
 
 const applyMiddleware = require('../middleware');
 const ensureArray = require('../tools/ensure-array');
+const { createRequestOptions } = require('../tools/request-sugar');
 
 // before middlewares
 const addBasicAuthHeader = require('../http-middlewares/before/add-basic-auth-header');
@@ -289,6 +290,28 @@ const createUrlProbe = (baseUrl, matchAll) => {
   return s;
 };
 
+// `customRequestProperties` rides in on the bundle from the request client.
+// It carries request-level properties that the app's beforeRequest middleware
+// reads while building auth. Unlike authData these are real values, not
+// placeholders, so they go onto the request verbatim — but they must never
+// reach the template, which is a static artifact shared across connections
+//
+// `body` is dropped here rather than at the request sites. extractTemplate
+// reads exactly headers, params and body; every request literal already
+// defines headers and params, so a custom value for those is always
+// overridden — but neither defines body, so a custom one would survive into
+// the template. `form` and `json` go too: sugarBody funnels both into
+// req.body, so they are the same leak through a different key.
+const getCustomRequestProperties = (input) => {
+  const {
+    body: _body,
+    form: _form,
+    json: _json,
+    ...rest
+  } = input?._zapier?.event?.bundle?.customRequestProperties || {};
+  return rest;
+};
+
 // Extract headers/params/body from a captured request, stripping defaults.
 const extractTemplate = (req) => {
   const template = {};
@@ -356,11 +379,14 @@ const extractTemplate = (req) => {
 const createStubZ = (compiledApp, cachedZap) => {
   const Zap = cachedZap !== undefined ? cachedZap : loadLegacyZap(compiledApp);
 
-  const stubRequest = async () => ({
+  // Accepts both z.request shapes so a two-arg call isn't silently reduced to
+  // its url. Echoes the normalized request back the way the real client does.
+  const stubRequest = async (reqOrUrl, options) => ({
     status: 200,
     headers: {},
     data: {},
     content: '{}',
+    request: createRequestOptions(reqOrUrl, options),
   });
 
   const stubZ = {
@@ -369,7 +395,7 @@ const createStubZ = (compiledApp, cachedZap) => {
     JSON: { parse: JSON.parse, stringify: JSON.stringify },
     legacyScripting: buildLegacyScripting(
       compiledApp,
-      (req) => stubZ.request(req),
+      (req, options) => stubZ.request(req, options),
       Zap,
     ),
     request: stubRequest,
@@ -454,9 +480,15 @@ const runMiddlewareSurvival = async (
     extraArgs: [stubZ, syntheticBundle],
   });
 
+  const customRequestProperties = getCustomRequestProperties(input);
+
   try {
     await withProxiedEnv(() =>
       client({
+        // Spread first so everything below takes precedence: custom
+        // properties fill in keys the request doesn't define, but never
+        // override headers/params/url or the rest of the plumbing.
+        ...customRequestProperties,
         method: 'GET',
         headers: {},
         params: {},
@@ -533,9 +565,15 @@ const runTestFunctionSurvival = async (
     extraArgs: [stubZ, syntheticBundle],
   });
 
-  stubZ.request = async (reqOrUrl) => {
-    const req =
-      typeof reqOrUrl === 'string' ? { url: reqOrUrl } : { ...reqOrUrl };
+  // Mirror the real z.request signature via the same sugar helper the app
+  // request client uses (requestSugar.addUrlOrOptions).
+  //
+  // No customRequestProperties here, unlike runMiddlewareSurvival: the
+  // request client doesn't apply them to every outgoing request, and this
+  // path runs the integration's own authentication.test, which passes
+  // whatever it needs through these options itself.
+  stubZ.request = async (reqOrUrl, options) => {
+    const req = { ...createRequestOptions(reqOrUrl, options) };
     // Run through the beforeRequest middleware pipeline
     const response = await client({
       ...req,

--- a/packages/core/src/auth-template/render-auth-template.js
+++ b/packages/core/src/auth-template/render-auth-template.js
@@ -2,6 +2,7 @@
 
 const applyMiddleware = require('../middleware');
 const ensureArray = require('../tools/ensure-array');
+const { createRequestOptions } = require('../tools/request-sugar');
 
 // before middlewares
 const addBasicAuthHeader = require('../http-middlewares/before/add-basic-auth-header');
@@ -180,9 +181,8 @@ const renderAuthTemplate = async (compiledApp, input) => {
   // pipeline — that would re-invoke beforeRequest for every sub-request and
   // likely loop. Real refresh-token-style middlewares call separate endpoints
   // that don't need the same auth applied.
-  const realRequest = async (reqOrUrl) => {
-    const req =
-      typeof reqOrUrl === 'string' ? { url: reqOrUrl } : { ...reqOrUrl };
+  const realRequest = async (reqOrUrl, options) => {
+    const req = { ...createRequestOptions(reqOrUrl, options) };
     const response = await fetch(req.url, {
       method: req.method || 'GET',
       headers: req.headers,
@@ -310,9 +310,8 @@ const renderAuthTemplate = async (compiledApp, input) => {
 
     const testStubZ = {
       ...stubZ,
-      request: async (reqOrUrl) => {
-        const req =
-          typeof reqOrUrl === 'string' ? { url: reqOrUrl } : { ...reqOrUrl };
+      request: async (reqOrUrl, options) => {
+        const req = { ...createRequestOptions(reqOrUrl, options) };
         const response = await testClient({
           ...req,
           method: req.method || 'GET',

--- a/packages/core/test/auth-template/get-auth-template.js
+++ b/packages/core/test/auth-template/get-auth-template.js
@@ -926,6 +926,335 @@ describe('getAuthTemplate', () => {
     });
   });
 
+  describe('two-argument z.request in the test function', () => {
+    const oauth2App = (testFn) => ({
+      authentication: {
+        type: 'oauth2',
+        test: testFn,
+        fields: [{ key: 'access_token' }],
+      },
+      beforeRequest: [
+        (req, z, bundle) => {
+          if (req.withUserToken) {
+            req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+          }
+          return req;
+        },
+      ],
+    });
+
+    it('honours a flag passed on a single object argument', async () => {
+      // createRequestOptions only merges when the first arg is a string; an
+      // object first arg is used as-is, matching the real client.
+      const testFn = async (z) => {
+        const res = await z.request({
+          url: 'https://example.com/api/auth.test',
+          withUserToken: true,
+        });
+        return res.data;
+      };
+      const result = await run(oauth2App(testFn));
+      result.supported.should.be.true();
+      result.source.should.eql('authentication.test');
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+    });
+
+    it('honours a flag passed as the second argument', async () => {
+      const testFn = async (z) => {
+        const res = await z.request('https://example.com/api/auth.test', {
+          withUserToken: true,
+        });
+        return res.data;
+      };
+      const result = await run(oauth2App(testFn));
+      result.supported.should.be.true();
+      result.source.should.eql('authentication.test');
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+    });
+
+    it('merges headers supplied via the second argument', async () => {
+      const testFn = async (z) => {
+        const res = await z.request('https://example.com/me', {
+          headers: { 'X-Api-Key': '{{bundle.authData.api_key}}' },
+        });
+        return res.data;
+      };
+      const result = await run({
+        authentication: {
+          type: 'custom',
+          test: testFn,
+          fields: [{ key: 'api_key' }],
+        },
+      });
+      result.supported.should.be.true();
+      result.template.headers['X-Api-Key'].should.eql(
+        '{{bundle.authData.api_key}}',
+      );
+    });
+  });
+
+  describe('customRequestProperties', () => {
+    // customRequestProperties arrives on the bundle from the request client. It
+    // must reach the app's beforeRequest middleware, but its values are
+    // per-connection and must never appear in the emitted template.
+    const runWithCustom = (compiledApp, customRequestProperties) =>
+      getAuthTemplate(
+        compiledApp,
+        buildInput(compiledApp, { customRequestProperties }),
+      );
+
+    it('exposes custom properties to beforeRequest', async () => {
+      let seen;
+      const beforeRequest = (req, z, bundle) => {
+        seen = req.subdomain;
+        req.headers = req.headers || {};
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        return req;
+      };
+      const result = await runWithCustom(
+        {
+          authentication: {
+            type: 'oauth2',
+            test: STUB_TEST,
+            fields: [{ key: 'access_token' }],
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { subdomain: 'acme' },
+      );
+      seen.should.eql('acme');
+      result.supported.should.be.true();
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+      // The custom property itself is not part of the template
+      should(result.template.subdomain).be.undefined();
+      should(result.template.headers.subdomain).be.undefined();
+    });
+
+    it('does not let custom headers override the request headers', async () => {
+      // The request's own headers take precedence: custom headers neither
+      // replace nor merge into them, so nothing custom reaches the request.
+      let seen;
+      const beforeRequest = (req, z, bundle) => {
+        seen = { ...req.headers };
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        return req;
+      };
+      const result = await runWithCustom(
+        {
+          authentication: {
+            type: 'oauth2',
+            test: STUB_TEST,
+            fields: [{ key: 'access_token' }],
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { headers: { 'X-Tenant': 'acme-corp' } },
+      );
+      should(seen['X-Tenant']).be.undefined();
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+      JSON.stringify(result.template).should.not.match(/acme-corp/);
+    });
+
+    it('keeps a custom-keyed header whose value middleware rewrote', async () => {
+      // The value changed, so it's the middleware's contribution now, not
+      // the raw per-connection value — it belongs in the template.
+      const beforeRequest = (req, z, bundle) => {
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        return req;
+      };
+      const result = await runWithCustom(
+        {
+          authentication: {
+            type: 'oauth2',
+            test: STUB_TEST,
+            fields: [{ key: 'access_token' }],
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { headers: { Authorization: 'Bearer raw-secret' } },
+      );
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+    });
+
+    it("preserves an auth.test object's own headers against custom headers", async () => {
+      // The auth.test request declares Accept; a custom headers object must
+      // not displace it. Defaults win, so Accept survives and X-Tenant
+      // never arrives.
+      let seen;
+      const beforeRequest = (req, z, bundle) => {
+        seen = { ...req.headers };
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        return req;
+      };
+      const result = await runWithCustom(
+        {
+          authentication: {
+            type: 'oauth2',
+            test: {
+              url: 'https://example.com',
+              headers: { Accept: 'application/vnd.v2+json' },
+            },
+            fields: [{ key: 'access_token' }],
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { headers: { 'X-Tenant': 'acme' } },
+      );
+      seen.Accept.should.eql('application/vnd.v2+json');
+      should(seen['X-Tenant']).be.undefined();
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+    });
+
+    it('does not let custom params override the request params', async () => {
+      let seen;
+      const beforeRequest = (req, z, bundle) => {
+        seen = { ...req.params };
+        req.params.api_key = bundle.authData.api_key;
+        return req;
+      };
+      const result = await runWithCustom(
+        {
+          authentication: {
+            type: 'custom',
+            test: STUB_TEST,
+            fields: [{ key: 'api_key' }],
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { params: { region: 'us-east-1' } },
+      );
+      should(seen.region).be.undefined();
+      result.template.params.api_key.should.eql('{{bundle.authData.api_key}}');
+      JSON.stringify(result.template).should.not.match(/us-east-1/);
+    });
+
+    it('does not let custom properties override url or plumbing', async () => {
+      let seenUrl;
+      const beforeRequest = (req, z, bundle) => {
+        seenUrl = req.url;
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        return req;
+      };
+      const result = await runWithCustom(
+        {
+          authentication: {
+            type: 'oauth2',
+            test: { url: 'https://api.example.com/me' },
+            fields: [{ key: 'access_token' }],
+          },
+          beforeRequest: [beforeRequest],
+        },
+        { url: 'https://evil.example.com', merge: false },
+      );
+      seenUrl.should.eql('https://api.example.com/me');
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+    });
+
+    it('exposes custom properties from authentication.test function in beforeRequest', async () => {
+      const testFn = async (z, bundle) => {
+        const res = await z.request({
+          url: 'https://api.example.com/me',
+          headers: { Authorization: `Bearer ${bundle.authData.access_token}` },
+          subdomain: 'acme', // custom request property passed in authentication.test
+        });
+        return res.data;
+      };
+      let seen;
+      const beforeRequest = (req) => {
+        seen = req.subdomain;
+        return req;
+      };
+
+      const compiledApp = {
+        authentication: {
+          type: 'oauth2',
+          test: testFn,
+          fields: [{ key: 'access_token' }],
+        },
+        beforeRequest: [beforeRequest],
+      };
+      const result = await getAuthTemplate(
+        compiledApp,
+        buildInput(compiledApp),
+      );
+
+      seen.should.eql('acme');
+      result.supported.should.be.true();
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+      should(result.template.subdomain).be.undefined();
+    });
+
+    it('keeps custom body, form, and json out of the template', async () => {
+      // sugarBody moves req.form and req.json into req.body, so they reach
+      // the template by the same route a custom body would.
+      for (const custom of [
+        { body: { tenant: 'acme-corp' }, allowGetBody: true },
+        { json: { tenant: 'acme-corp' }, allowGetBody: true },
+        { form: { tenant: 'acme-corp' }, allowGetBody: true },
+      ]) {
+        const result = await runWithCustom(
+          {
+            authentication: {
+              type: 'custom',
+              // A test function that makes no request, so the middleware-path
+              // template is what gets returned.
+              test: async () => ({}),
+              fields: [{ key: 'api_key' }],
+            },
+            beforeRequest: [
+              (req, z, bundle) => {
+                req.headers['X-Api-Key'] = bundle.authData.api_key;
+                return req;
+              },
+            ],
+          },
+          custom,
+        );
+
+        result.supported.should.be.true();
+        result.template.headers['X-Api-Key'].should.eql(
+          '{{bundle.authData.api_key}}',
+        );
+        JSON.stringify(result.template).should.not.match(/acme-corp/);
+      }
+    });
+
+    it('behaves exactly as before when the bundle has no custom properties', async () => {
+      const app = {
+        authentication: {
+          type: 'oauth2',
+          test: STUB_TEST,
+          fields: [{ key: 'access_token' }],
+        },
+        beforeRequest: [
+          (req, z, bundle) => {
+            req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+            return req;
+          },
+        ],
+      };
+      const withEmpty = await runWithCustom(app, {});
+      const withNone = await run(app);
+      withEmpty.should.deepEqual(withNone);
+    });
+  });
+
   describe('fallback when nothing captures auth', () => {
     it('returns supported: true with empty template when there is no path to capture auth', async () => {
       // Auth declared but no beforeRequest, no requestTemplate, and no


### PR DESCRIPTION
<!--

title should be in the format of:

  workType(area): release notes summary

where:

  `workType` is one of (which correspond to semver release levels):
    * fix
    * feat
    * BREAKING CHANGE
  less common (but valid) options:
    * build
    * ci
    * chore
    * docs
    * perf
    * refactor
    * revert
    * style
    * test

  `area` is (probably) one of:
    * cli
    * schema
    * core
    * legacy-scripting-runner
    * schema-to-ts

-->

## Problem

Every request stub in the auth-template handlers declared a single parameter, so `z.request`'s second argument was silently discarded:

```js
stubZ.request = async (reqOrUrl) => { ... }   // options dropped
```

## Changes

### **1. All four stubs accept (reqOrUrl, options)**
Each now normalizes through requestSugar.createRequestOptions — the same helper the real client uses via addUrlOrOptions (create-request-client.js:37), so the stubs accept exactly the shapes production does.

### **2. Pass bundle.customRequestProperties onto synthesized requests**
`runMiddlewareSurvival` drives the app's beforeRequest directly with a request we construct ourselves, so there is no integration code to supply these — we have to.

`runTestFunctionSurvival` deliberately does not inject them. The request client doesn't apply them to every outgoing request, and that path runs the integration's own authentication.test, which passes whatever it needs through its z.request options (that channel is what change 1 restores).

Precedence: the spread sits before the request literal, so anything the request defines wins. Custom values fill in keys the request doesn't set — a per-connection subdomain, say — but never override headers, params, url, or the plumbing.

body, form, and json are dropped in `getCustomRequestProperties`. `extractTemplate` reads exactly headers/params/body; the first two are always defined by the request literal so a custom value is always overridden, but body is not. coerceBody normally discards a GET body, except when allowGetBody is set — and that flag can itself arrive in customRequestProperties, which is the one route by which a custom body reaches the emitted template. sugarBody funnels form and json into body, hence all three. Dropping them where they're read is simpler than guarding each request site.