### PR TITLE
fix(core): decline auth templates built from an empty legacy auth mapping

### DIFF
--- a/packages/core/src/auth-template/get-auth-template.js
+++ b/packages/core/src/auth-template/get-auth-template.js
@@ -78,7 +78,14 @@ const hasAuthPlaceholders = (obj) => {
 // oauth2's access_token, etc.) aren't a strong "I expect this in the
 // request" signal — apps may use process.env exclusively and never
 // reference standard fields, which would be a false positive here.
-const supportedResult = (authType, source, template, auth) => {
+const supportedResult = (authType, source, template, auth, legacyDump) => {
+  // An empty legacy auth mapping dumps the whole credential set. Under capture
+  // those values are placeholders, so the template names credentials the app
+  // may never populate.
+  if (legacyDump) {
+    return { supported: false, reason: 'legacy_authdata_dump', authType };
+  }
+
   if (template && Object.keys(template).length > 0) {
     const s = JSON.stringify(template);
     const hasAuthData = /\{\{\s*bundle\.authData\./.test(s);
@@ -376,7 +383,7 @@ const extractTemplate = (req) => {
 };
 
 // Stub z object used for pipeline capture and test function survival.
-const createStubZ = (compiledApp, cachedZap) => {
+const createStubZ = (compiledApp, cachedZap, onDump) => {
   const Zap = cachedZap !== undefined ? cachedZap : loadLegacyZap(compiledApp);
 
   // Accepts both z.request shapes so a two-arg call isn't silently reduced to
@@ -397,6 +404,7 @@ const createStubZ = (compiledApp, cachedZap) => {
       compiledApp,
       (req, options) => stubZ.request(req, options),
       Zap,
+      onDump,
     ),
     request: stubRequest,
   };
@@ -468,7 +476,10 @@ const runMiddlewareSurvival = async (
     });
   };
 
-  const stubZ = createStubZ(compiledApp, cachedZap);
+  let legacyAuthDump = false;
+  const stubZ = createStubZ(compiledApp, cachedZap, () => {
+    legacyAuthDump = true;
+  });
   const syntheticBundle = {
     authData: placeholderAuthData,
     inputData: {},
@@ -506,7 +517,7 @@ const runMiddlewareSurvival = async (
     return { template: {} };
   }
 
-  return { template: extractTemplate(capturedReq) };
+  return { legacyAuthDump, template: extractTemplate(capturedReq) };
 };
 
 // Run placeholder authData through authentication.test (when it's a function).
@@ -553,7 +564,10 @@ const runTestFunctionSurvival = async (
     });
   };
 
-  const stubZ = createStubZ(compiledApp);
+  let legacyAuthDump = false;
+  const stubZ = createStubZ(compiledApp, undefined, () => {
+    legacyAuthDump = true;
+  });
   const syntheticBundle = {
     authData: placeholderAuthData,
     inputData: {},
@@ -606,7 +620,11 @@ const runTestFunctionSurvival = async (
     // accessing response.data.emails[0]) — that's fine, we already
     // have what we need.
     if (capturedReq) {
-      return { template: extractTemplate(capturedReq), requestMade: true };
+      return {
+        legacyAuthDump,
+        template: extractTemplate(capturedReq),
+        requestMade: true,
+      };
     }
     return { template: {}, requestMade: false, error: err.message };
   }
@@ -615,12 +633,19 @@ const runTestFunctionSurvival = async (
     return { template: {}, requestMade: false };
   }
 
-  return { template: extractTemplate(capturedReq), requestMade: true };
+  return {
+    legacyAuthDump,
+    template: extractTemplate(capturedReq),
+    requestMade: true,
+  };
 };
 
 // --- Main command handler ---
 
 const getAuthTemplate = async (compiledApp, input) => {
+  // Set by the legacy middleware when it writes the whole credential set
+  // because the auth mapping is empty. Any run that dumps taints the result.
+  let sawLegacyDump = false;
   const auth = compiledApp.authentication;
   const authType = auth ? auth.type : null;
 
@@ -691,12 +716,13 @@ const getAuthTemplate = async (compiledApp, input) => {
   // Run placeholder authData through the beforeRequest pipeline directly.
   // This captures auth injected by middleware (most common pattern).
   if (beforeRequest.length > 0) {
-    const { template, error } = await runMiddlewareSurvival(
+    const { template, error, legacyAuthDump } = await runMiddlewareSurvival(
       compiledApp,
       input,
       auth,
       placeholderAuthData,
     );
+    sawLegacyDump = sawLegacyDump || legacyAuthDump;
 
     if (error) {
       if (!auth.test) {
@@ -800,7 +826,7 @@ const getAuthTemplate = async (compiledApp, input) => {
   if (auth.test && typeof auth.test !== 'function') {
     const placeholderAuthData = buildPlaceholderAuthData(auth);
     const testReq = auth.test;
-    const { template, error } = await runMiddlewareSurvival(
+    const { template, error, legacyAuthDump } = await runMiddlewareSurvival(
       compiledApp,
       input,
       auth,
@@ -815,6 +841,7 @@ const getAuthTemplate = async (compiledApp, input) => {
         },
       },
     );
+    sawLegacyDump = sawLegacyDump || legacyAuthDump;
 
     if (error) {
       return {
@@ -893,6 +920,7 @@ const getAuthTemplate = async (compiledApp, input) => {
         'authentication.test',
         cleanTemplate(template),
         auth,
+        sawLegacyDump,
       );
     }
 
@@ -905,12 +933,14 @@ const getAuthTemplate = async (compiledApp, input) => {
 
   // --- Step 4: authentication.test is a function ---
   if (typeof auth.test === 'function') {
-    const { template, requestMade, error } = await runTestFunctionSurvival(
-      auth.test,
-      placeholderAuthData,
-      compiledApp,
-      input,
-    );
+    const { template, requestMade, error, legacyAuthDump } =
+      await runTestFunctionSurvival(
+        auth.test,
+        placeholderAuthData,
+        compiledApp,
+        input,
+      );
+    sawLegacyDump = sawLegacyDump || legacyAuthDump;
 
     if (error && !requestMade) {
       // Function crashed before making a request.
@@ -981,6 +1011,7 @@ const getAuthTemplate = async (compiledApp, input) => {
             'beforeRequest',
             beforeRequestTemplate,
             auth,
+            sawLegacyDump,
           );
         }
 
@@ -989,6 +1020,7 @@ const getAuthTemplate = async (compiledApp, input) => {
           'authentication.test',
           testTemplate,
           auth,
+          sawLegacyDump,
         );
       }
 
@@ -998,6 +1030,7 @@ const getAuthTemplate = async (compiledApp, input) => {
           'beforeRequest',
           beforeRequestTemplate,
           auth,
+          sawLegacyDump,
         );
       }
 
@@ -1017,6 +1050,7 @@ const getAuthTemplate = async (compiledApp, input) => {
       'beforeRequest',
       beforeRequestTemplate,
       auth,
+      sawLegacyDump,
     );
   }
 

--- a/packages/core/src/auth-template/legacy-scripting.js
+++ b/packages/core/src/auth-template/legacy-scripting.js
@@ -29,13 +29,16 @@ const renderAuthMapping = (authMapping, authData) => {
   return result;
 };
 
-const createLegacyBeforeRequest = (app) => {
+const createLegacyBeforeRequest = (app, onDump) => {
   const authType = app.authentication && app.authentication.type;
   const legacy = app.legacy || {};
   const authMapping =
     (legacy.authentication && legacy.authentication.mapping) || {};
   const placement =
     (legacy.authentication && legacy.authentication.placement) || 'header';
+  // An absent mapping is defaulted to {} above, and renderAuthMapping returns
+  // authData wholesale for either. Both shapes dump, so both are reported.
+  const mappingIsEmpty = Object.keys(authMapping).length === 0;
 
   return (req, z, bundle) => {
     const authData = bundle.authData || {};
@@ -57,6 +60,18 @@ const createLegacyBeforeRequest = (app) => {
       }
     } else if (authType === 'session' || authType === 'custom') {
       const rendered = renderAuthMapping(authMapping, authData);
+      // Only session auth is reported. buildPlaceholderAuthData pads session
+      // authData with speculative token names the app may never populate, so
+      // the dump names credentials that do not exist. A custom app's authData
+      // is exactly its declared fields, so its dump is faithful.
+      if (
+        authType === 'session' &&
+        mappingIsEmpty &&
+        onDump &&
+        Object.keys(rendered).length > 0
+      ) {
+        onDump();
+      }
       if (placement === 'header' || placement === 'both') {
         const lowerHeaders = {};
         for (const [k, v] of Object.entries(req.headers)) {
@@ -162,9 +177,9 @@ const getLegacyOperationUrl = (compiledApp, typeOf, key) => {
 //
 // `requestFn` is called as `requestFn(request)` and should return a
 // response-shaped object.
-const buildLegacyScripting = (compiledApp, requestFn, cachedZap) => {
+const buildLegacyScripting = (compiledApp, requestFn, cachedZap, onDump) => {
   const Zap = cachedZap !== undefined ? cachedZap : loadLegacyZap(compiledApp);
-  const legacyBeforeRequest = createLegacyBeforeRequest(compiledApp);
+  const legacyBeforeRequest = createLegacyBeforeRequest(compiledApp, onDump);
 
   return {
     beforeRequest: legacyBeforeRequest,

--- a/packages/core/test/auth-template/get-auth-template.js
+++ b/packages/core/test/auth-template/get-auth-template.js
@@ -1326,4 +1326,81 @@ describe('getAuthTemplate', () => {
       result.template.headers.should.not.have.property('content-length');
     });
   });
+  describe('legacy session auth with an empty auth mapping', () => {
+    // An empty legacy auth mapping makes the scripting middleware write the
+    // whole credential set into the request. Under capture those values are
+    // placeholders, so the template names credentials the app may never
+    // populate. UpkeepCLIAPI@1.3.0 is the production case.
+    const legacyBeforeRequest = (req, z, bundle) =>
+      z.legacyScripting.beforeRequest(req, z, bundle);
+
+    const sessionApp = (legacy) => ({
+      authentication: {
+        type: 'session',
+        test: STUB_TEST,
+        fields: [{ key: 'username' }, { key: 'password' }],
+      },
+      legacy,
+      beforeRequest: [legacyBeforeRequest],
+    });
+
+    it('returns legacy_authdata_dump for header placement', async () => {
+      const result = await run(
+        sessionApp({ authentication: { mapping: {}, placement: 'header' } }),
+      );
+      result.supported.should.be.false();
+      result.reason.should.eql('legacy_authdata_dump');
+    });
+
+    it('returns legacy_authdata_dump for querystring placement', async () => {
+      const result = await run(
+        sessionApp({
+          authentication: { mapping: {}, placement: 'querystring' },
+        }),
+      );
+      result.supported.should.be.false();
+      result.reason.should.eql('legacy_authdata_dump');
+    });
+
+    it('returns legacy_authdata_dump when legacy.authentication is absent', async () => {
+      const result = await run(sessionApp({}));
+      result.supported.should.be.false();
+      result.reason.should.eql('legacy_authdata_dump');
+    });
+
+    it('keeps a legacy session app that declares a real auth mapping', async () => {
+      const result = await run(
+        sessionApp({
+          authentication: {
+            mapping: { 'X-Api-Token': '{{token}}' },
+            placement: 'header',
+          },
+        }),
+      );
+      result.supported.should.be.true();
+      result.template.headers['X-Api-Token'].should.eql(
+        '{{bundle.authData.token}}',
+      );
+      result.template.headers.should.not.have.property('password');
+    });
+
+    it('keeps an app carrying a legacy block whose middleware never runs', async () => {
+      const result = await run({
+        authentication: {
+          type: 'session',
+          test: STUB_TEST,
+          fields: [{ key: 'username' }, { key: 'password' }],
+        },
+        legacy: { authentication: { mapping: {}, placement: 'header' } },
+        requestTemplate: {
+          headers: {
+            username: '{{bundle.authData.username}}',
+            password: '{{bundle.authData.password}}',
+          },
+        },
+      });
+      result.supported.should.be.true();
+      result.source.should.eql('requestTemplate');
+    });
+  });
 });


### PR DESCRIPTION
## What

- `createLegacyBeforeRequest` now reports when an empty legacy auth mapping causes it to write the whole credential set into the request
- `supportedResult` declines a template flagged that way, with a new `legacy_authdata_dump` reason
- Scoped to `session` auth; `requestTemplate` results are unaffected

## Why

When `legacy.authentication.mapping` is empty, `renderAuthMapping` returns `authData` wholesale and the middleware writes every key into the request headers or query string. That matches the real legacy scripting runner (`packages/legacy-scripting-runner/middleware-factory.js`), so the middleware is correct and left alone.

It only misleads during template capture. There `authData` is a synthetic placeholder set, padded for session auth with speculative token names the app may never populate, so the captured template lists credential field names instead of the header the app authenticates with. Once that template is cached and reused, those fields are substituted with real values and sent on every request.

Detecting this from the shape of the captured template does not hold up. Query string placement puts the same dump in `params`, a single unrelated placeholder header defeats a whole-template check, and keying on config alone flags apps that carry a `legacy` block but never run the legacy middleware. Reporting it from the middleware, where the branch is actually taken, avoids all three.

`custom` auth is excluded: its `authData` is exactly the declared fields, so its dump is faithful to what production sends.

## Testing

- 5 new cases in `test/auth-template/get-auth-template.js`: header placement, query string placement, absent `legacy.authentication`, a real auth mapping, and an app carrying a `legacy` block whose middleware never runs
- `pnpm main-tests`: 562 passing, 1 pending, 0 failing

## Notes

- This stops a misleading template being produced; it does not give these apps a working static template. They fall through to `renderAuthTemplate`, which runs the same middleware with real credentials but skips the per-operation pre method, so an app that sets its auth header there still will not get one.