### PR TITLE
fix(core): return undefined for undeclared env vars in auth-template capture

### DIFF
--- a/packages/core/src/auth-template/get-auth-template.js
+++ b/packages/core/src/auth-template/get-auth-template.js
@@ -21,27 +21,22 @@ const errors = require('../errors');
 
 // Opaque sentinels survive core's curly-stripping (normalizeEmptyParamFields)
 // and any stringification middleware does. We embed them into placeholder
-// authData / proxied process.env, then convert back to {{curlies}} on the
+// authData, then convert back to {{curlies}} on the
 // way out (cleanTemplate). Lowercase-underscore markers are URL-safe in
 // hostnames AND querystrings, so a sentinel survives substitution into
 // any URL position without breaking `new URL(...)` parsing — which is
 // what extractTemplate uses to recover params after addQueryParams.
 const AUTH_SENTINEL_OPEN = '__placeholder_auth__';
-const ENV_SENTINEL_OPEN = '__placeholder_env__';
 const SENTINEL_CLOSE = '__end_placeholder__';
 const wrapAuthSentinel = (key) =>
   `${AUTH_SENTINEL_OPEN}${key}${SENTINEL_CLOSE}`;
-const wrapEnvSentinel = (key) => `${ENV_SENTINEL_OPEN}${key}${SENTINEL_CLOSE}`;
 const AUTH_SENTINEL_RE = /__placeholder_auth__(.+?)__end_placeholder__/g;
-const ENV_SENTINEL_RE = /__placeholder_env__(.+?)__end_placeholder__/g;
 
 // Walk a template and replace sentinels with their {{curly}} equivalents.
 // Returns a new object; the input is not mutated.
 const sentinelsToCurlies = (value) => {
   if (typeof value === 'string') {
-    return value
-      .replace(AUTH_SENTINEL_RE, (_, k) => `{{bundle.authData.${k}}}`)
-      .replace(ENV_SENTINEL_RE, (_, k) => `{{process.env.${k}}}`);
+    return value.replace(AUTH_SENTINEL_RE, (_, k) => `{{bundle.authData.${k}}}`);
   }
   if (Array.isArray(value)) {
     return value.map(sentinelsToCurlies);
@@ -60,7 +55,6 @@ const hasAuthPlaceholders = (obj) => {
   const s = JSON.stringify(obj);
   return (
     s.includes(AUTH_SENTINEL_OPEN) ||
-    s.includes(ENV_SENTINEL_OPEN) ||
     /\{\{\s*bundle\.authData\./.test(s) ||
     /\{\{\s*process\.env\./.test(s)
   );
@@ -229,7 +223,9 @@ const buildProxyAuthData = (placeholderAuthData) =>
 const templatesEqual = (a, b) =>
   JSON.stringify(cleanTemplate(a)) === JSON.stringify(cleanTemplate(b));
 
-// Run fn with process.env proxied to return placeholders for unknown vars.
+// Run fn with process.env proxied so an undeclared variable reads as undefined,
+// matching production (the AppVersion env is loaded during capture, so a var
+// absent from it is undefined, not a placeholder).
 // Concurrent withProxiedEnv calls (e.g., parallel URL probe runs) must
 // share the same proxy — naive "save current; restore current" would let
 // the inner call save the outer's Proxy and "restore" to it, leaking the
@@ -244,10 +240,7 @@ const withProxiedEnv = async (fn) => {
         if (prop in target) {
           return target[prop];
         }
-        if (typeof prop === 'symbol') {
-          return undefined;
-        }
-        return wrapEnvSentinel(prop);
+        return undefined;
       },
     });
   }
@@ -352,7 +345,6 @@ const extractTemplate = (req) => {
         // literals like trigger-specific filter params.
         if (
           (typeof v === 'string' && v.includes(AUTH_SENTINEL_OPEN)) ||
-          (typeof v === 'string' && v.includes(ENV_SENTINEL_OPEN)) ||
           /\{\{bundle\.authData\./.test(v) ||
           /\{\{process\.env\./.test(v)
         ) {

--- a/packages/core/test/auth-template/get-auth-template.js
+++ b/packages/core/test/auth-template/get-auth-template.js
@@ -21,6 +21,32 @@ const run = (compiledApp) =>
 
 const STUB_TEST = { url: 'https://example.com' };
 
+// Set variables on process.env for fn, then restore. Simulates the AppVersion
+// env being loaded during production capture (local invoke doesn't load it).
+const withStubbedEnv = async (vars, fn) => {
+  const saved = new Map();
+  for (const [key, value] of Object.entries(vars)) {
+    saved.set(
+      key,
+      Object.prototype.hasOwnProperty.call(process.env, key)
+        ? process.env[key]
+        : undefined,
+    );
+    process.env[key] = value;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [key, prior] of saved) {
+      if (prior === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prior;
+      }
+    }
+  }
+};
+
 describe('getAuthTemplate', () => {
   describe('early returns', () => {
     it('returns supported with empty template when no authentication', async () => {
@@ -317,30 +343,83 @@ describe('getAuthTemplate', () => {
       result.reason.should.eql('auth_fields_consumed');
     });
 
-    it('does not flag auth_fields_consumed when no fields are declared', async () => {
-      // App uses only process.env (server-side secret), no declared fields.
-      // Placeholders survive (the env var) — should be supported.
+    it('resolves an undeclared process.env var to undefined so a || falls through to authData', async () => {
+      // Procore shape: `process.env.ACCESS_TOKEN || bundle.authData.access_token`.
+      // ACCESS_TOKEN is undeclared, so the || must reach the authData placeholder.
       const beforeRequest = (req, z, bundle) => {
         req.headers = req.headers || {};
-        if (bundle.authData.access_token) {
-          req.headers.Authorization = `Bot ${process.env.BOT_TOKEN}`;
-        }
+        req.headers.Authorization = `Bearer ${
+          process.env.ACCESS_TOKEN || bundle.authData.access_token
+        }`;
         return req;
       };
       const result = await run({
-        authentication: { type: 'oauth2', test: STUB_TEST },
+        authentication: {
+          type: 'oauth2',
+          test: STUB_TEST,
+          fields: [{ key: 'access_token' }],
+        },
         beforeRequest: [beforeRequest],
       });
       result.supported.should.be.true();
-      result.source.should.eql('authentication.test');
       result.template.headers.Authorization.should.eql(
-        'Bot {{process.env.BOT_TOKEN}}',
+        'Bearer {{bundle.authData.access_token}}',
       );
     });
 
-    it('flags auth_fields_consumed when declared fields are gone but process.env survives', async () => {
-      // Declared auth fields are consumed by base64 encoding, but a
-      // server-side env var still survives in another header.
+    it('omits a header whose value is an undeclared process.env var', async () => {
+      // PushPress shape: an undeclared process.env value on the company-id header
+      // resolves to undefined and drops out of the serialized template.
+      const beforeRequest = (req, z, bundle) => {
+        req.headers = req.headers || {};
+        req.headers['api-key'] = bundle.authData.apiKey;
+        req.headers['company-id'] = process.env.PUSHPRESS_COMPANY_ID;
+        return req;
+      };
+      const result = await run({
+        authentication: {
+          type: 'custom',
+          test: STUB_TEST,
+          fields: [{ key: 'apiKey' }],
+        },
+        beforeRequest: [beforeRequest],
+      });
+      result.supported.should.be.true();
+      result.template.headers['api-key'].should.eql('{{bundle.authData.apiKey}}');
+      // undefined-valued headers drop when the template is serialized to JSON.
+      const serialized = JSON.parse(JSON.stringify(result.template));
+      serialized.headers.should.not.have.property('company-id');
+    });
+
+    it('keeps a declared server-side env var and stays supported', async () => {
+      // A declared value is present in process.env during capture, so the proxy
+      // returns it unchanged; the fix only affects undeclared vars.
+      const beforeRequest = (req, z, bundle) => {
+        req.headers = req.headers || {};
+        req.headers.Authorization = `Bearer ${bundle.authData.access_token}`;
+        req.headers['X-Region'] = process.env.SERVER_REGION;
+        return req;
+      };
+      const result = await withStubbedEnv({ SERVER_REGION: 'us-east-1' }, () =>
+        run({
+          authentication: {
+            type: 'oauth2',
+            test: STUB_TEST,
+            fields: [{ key: 'access_token' }],
+          },
+          beforeRequest: [beforeRequest],
+        }),
+      );
+      result.supported.should.be.true();
+      result.template.headers.Authorization.should.eql(
+        'Bearer {{bundle.authData.access_token}}',
+      );
+      result.template.headers['X-Region'].should.eql('us-east-1');
+    });
+
+    it('flags auth_fields_consumed when declared fields are gone but a declared process.env value survives', async () => {
+      // Declared auth fields are consumed by base64 encoding, but a declared
+      // server-side env value survives in another header (not an auth placeholder).
       const beforeRequest = (req, z, bundle) => {
         req.headers = req.headers || {};
         const encoded = Buffer.from(
@@ -350,14 +429,16 @@ describe('getAuthTemplate', () => {
         req.headers['X-App'] = `${process.env.APP_ID}`;
         return req;
       };
-      const result = await run({
-        authentication: {
-          type: 'custom',
-          test: STUB_TEST,
-          fields: [{ key: 'api_key' }, { key: 'api_secret' }],
-        },
-        beforeRequest: [beforeRequest],
-      });
+      const result = await withStubbedEnv({ APP_ID: 'app-123' }, () =>
+        run({
+          authentication: {
+            type: 'custom',
+            test: STUB_TEST,
+            fields: [{ key: 'api_key' }, { key: 'api_secret' }],
+          },
+          beforeRequest: [beforeRequest],
+        }),
+      );
       result.supported.should.be.false();
       result.reason.should.eql('auth_fields_consumed');
     });


### PR DESCRIPTION
## What

During auth-template capture, `process.env` is temporarily swapped for a proxy. The proxy previously returned a placeholder sentinel string for any variable not present in the environment. This branch changes the proxy to return `undefined`, so a read of an undeclared variable behaves teh same during a capture as it does at normal runtime.

## Why

Auth-template capture runs an integration's `beforeRequest` code with placeholder credentials and records the result. The credentials are then stripped from the result and replaced with fillable `{{ ... }}` placeholders for the static template.

The env proxy (used during this `beforeRequest` run) introduced a second, unintended difference. If the `beforeRequest` code looks like this:

```js
const token = process.env.TOKEN || bundle.authData.access_token;
req.headers.Authorization = `Bearer ${token}`;
```

Here the `TOKEN` env variable is meant to be a dev-only override that is undeclared in production. At runtime, `process.env.TOKEN` is `undefined` and the real credential is used. Before this code change, the proxy would return a truthy sentinel string for that missing env variable, so during capture the `||` took the wrong logic branch and baked in a `{{ process.env.TOKEN }}` placeholder into the static template.

When the template is later rendered, placeholders are substituted from the available credentials and environment variables. An undeclared env variable has no value to substitute, and the literal placeholder text is sent as the credential.

Some comparison stages to make this more clear:


> **stage**: real runtime read of process.env.ACCESS_TOKEN
> **OLD CODE**: undefined
> **NEW CODE**: undefined (unchanged; this was always right at runtime)
> ────────────────────────────────────────
> **stage**: capture read via the Proxy
> **OLD CODE**: truthy sentinel string
> **NEW CODE**: undefined
> ────────────────────────────────────────
> **stage**: ... || bundle.authData.access_token during capture
> **OLD CODE**: short-circuits to the left (the env sentinel)
> **NEW CODE**: falls through to the right (the authData sentinel)
> ────────────────────────────────────────
> **stage**: header captured into the template
> **OLD CODE**: Bearer {{process.env.ACCESS_TOKEN}}
> **NEW CODE**: Bearer {{bundle.authData.access_token}}

## Testing

- Full `packages/core` suite passes
- Added regression tests:
  - an undeclared `||` fallback now reaches the `authData` placeholder
  - a header whose value is an undeclared env var drops from the serialized template
  - an app that reads a declared server-side variable is unchanged
- The two undeclared-variable tests fail on the previous code and pass on this branch